### PR TITLE
Don't enforce a specific Python 3 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build.stamp: venv .init.stamp sources/config.yaml $(SOURCES)
 	. venv/bin/activate; python3 scripts/first-run.py
 
 venv/touchfile: requirements.txt
-	test -d venv || python3.8 -m venv venv
+	test -d venv || python3 -m venv venv
 	. venv/bin/activate; pip install -U setuptools wheel pip
 	. venv/bin/activate; pip install -Ur requirements.txt
 	touch venv/touchfile


### PR DESCRIPTION
Follow up to #15, will close #10 