### PR TITLE
Don't build GitHub pages in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,14 +54,6 @@ jobs:
       continue-on-error: true
     - name: proof
       run: make proof
-    - name: setup site
-      run: cp scripts/index.html out/index.html
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
-      if: ${{ github.ref == 'refs/heads/main' }}
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./out
     - name: Archive artifacts
       uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Will close #9 

This, in combination with deleting the `gh-pages` branch, should stop them being generated and get rid of the existing ones