### PR TITLE
ufodiff on CI

### DIFF
--- a/.github/actions/ufodiff/Dockerfile
+++ b/.github/actions/ufodiff/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.8.15-alpine
+
+RUN apk add git
+
+RUN pip install ufodiff
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/ufodiff/README.md
+++ b/.github/actions/ufodiff/README.md
@@ -1,0 +1,5 @@
+# ufodiff GitHub action
+
+Runs [ufodiff](https://github.com/source-foundry/ufodiff) in a Docker container so you can make it a GitHub action
+
+Currently only supports the `delta*` subcommands

--- a/.github/actions/ufodiff/action.yml
+++ b/.github/actions/ufodiff/action.yml
@@ -1,0 +1,18 @@
+name: 'ufodiff'
+description: 'A UFO source file diff tool for collaborative typeface development projects'
+inputs:
+  subcommand:
+    description: 'ufodiff delta subcommand'
+    required: true
+    default: 'delta'
+  compare-against:
+    description: 'the branch to compare to'
+    required: true
+    default: 'main'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.subcommand }}
+    - all
+    - ${{ format('branch:{0}', inputs.compare-against) }}

--- a/.github/actions/ufodiff/entrypoint.sh
+++ b/.github/actions/ufodiff/entrypoint.sh
@@ -10,8 +10,10 @@ git config --global --add safe.directory /github/workspace
 # Change to repo location as otherwise ufodiff dies
 cd /github/workspace
 
-git fetch origin main &> /dev/null
-git branch main origin/main &> /dev/null
+# Re-parse branch from 3rd arg, which will be branch:name (see action.yml)
+branch=$(echo $3 | cut -d : -f 2)
+git fetch origin "$branch" &> /dev/null
+git branch "$branch" "origin/$branch" &> /dev/null
 
 # Call ufodiff with the supplied args
 ufodiff $*

--- a/.github/actions/ufodiff/entrypoint.sh
+++ b/.github/actions/ufodiff/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Check repo is mounted
+[[ -d /github/workspace/.git ]] || echo "ERROR: repository not found at /github/workspace"
+[[ -d /github/workspace/.git ]] || exit 1
+
+# An error is thrown about using the repo as configured by actions/checkout otherwise
+git config --global --add safe.directory /github/workspace
+
+# Change to repo location as otherwise ufodiff dies
+cd /github/workspace
+
+git fetch origin main
+git branch main origin/main
+
+# Call ufodiff with the supplied args
+ufodiff $*

--- a/.github/actions/ufodiff/entrypoint.sh
+++ b/.github/actions/ufodiff/entrypoint.sh
@@ -10,8 +10,8 @@ git config --global --add safe.directory /github/workspace
 # Change to repo location as otherwise ufodiff dies
 cd /github/workspace
 
-git fetch origin main
-git branch main origin/main
+git fetch origin main &> /dev/null
+git branch main origin/main &> /dev/null
 
 # Call ufodiff with the supplied args
 ufodiff $*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,3 +81,12 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           body: "Production ready fonts"
+  diff:
+    if: startsWith(github.ref_name, 'import-')
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ufodiff
+        uses: ./.github/actions/ufodiff

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,12 +81,3 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           body: "Production ready fonts"
-  diff:
-    if: startsWith(github.ref_name, 'import-')
-    needs:
-      - build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run ufodiff
-        uses: ./.github/actions/ufodiff

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -1,0 +1,26 @@
+name: Regression checks
+# We want to run regression checks on pushes that aren't to main, and that
+# build successfully. There isn't a great way to do this as
+# on.workflow_run.types doesn't actually distinguish whether the workflow
+# failed or not. However, now that we've checked that it's been run we can use
+# conditionals to check it was successful before starting regressions, it just
+# means in each job there must be the following conditional:
+# `github.event.workflow_run.conclusion == 'success'`
+# https://github.com/orgs/community/discussions/26238#discussioncomment-3250901
+on:
+  workflow_run:
+    workflows:
+      - Build font and specimen
+    branches-ignore:
+      - main
+    types:
+      - completed
+
+jobs:
+  diff:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ufodiff
+        uses: ./.github/actions/ufodiff


### PR DESCRIPTION
Uses a docker-based GitHub action to run ufodiff on the repo.

~~Currently configured to compare against master on branches called `import-*` (* being anything)~~ Runs on all pushes to branches except `main`

Keeping as draft until I know it works as intended