### PR TITLE
Fix ufodiff not running / Better CI triggers

### DIFF
--- a/.github/actions/ufodiff/Dockerfile
+++ b/.github/actions/ufodiff/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.8.15-alpine
+FROM python:3.8.15-slim
 
-RUN apk add git
+RUN apt update && apt install git -y --no-install-recommends
 
 RUN pip install ufodiff
 

--- a/.github/actions/ufodiff/entrypoint.sh
+++ b/.github/actions/ufodiff/entrypoint.sh
@@ -1,19 +1,22 @@
 #!/bin/sh
 
 # Check repo is mounted
-[[ -d /github/workspace/.git ]] || echo "ERROR: repository not found at /github/workspace"
-[[ -d /github/workspace/.git ]] || exit 1
+if [ ! -e /github/workspace/.git ] ; then
+    echo "ERROR: repository not found at /github/workspace"
+    exit 1
+fi
 
 # An error is thrown about using the repo as configured by actions/checkout otherwise
 git config --global --add safe.directory /github/workspace
 
 # Change to repo location as otherwise ufodiff dies
+# shellcheck disable=SC2164
 cd /github/workspace
 
 # Re-parse branch from 3rd arg, which will be branch:name (see action.yml)
-branch=$(echo $3 | cut -d : -f 2)
-git fetch origin "$branch" &> /dev/null
-git branch "$branch" "origin/$branch" &> /dev/null
+branch=$(echo "$3" | cut -d : -f 2)
+git fetch origin "$branch" >/dev/null 2>&1
+git branch "$branch" "origin/$branch" >/dev/null 2>&1
 
 # Call ufodiff with the supplied args
-ufodiff $*
+ufodiff "$*"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,12 @@
 name: Build font and specimen
 
-on: [push, release]
+on:
+  push:
+    paths-ignore:
+      - .github
+      - documentation
+      - '**/README.md'
+  release:
 
 jobs:
   build:

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -8,17 +8,14 @@ name: Regression checks
 # `github.event.workflow_run.conclusion == 'success'`
 # https://github.com/orgs/community/discussions/26238#discussioncomment-3250901
 on:
-  workflow_run:
-    workflows:
-      - Build font and specimen
+  push:
     branches-ignore:
       - main
-    types:
-      - completed
+    paths:
+      - sources/**
 
 jobs:
-  diff:
-    if: github.event.workflow_run.conclusion == 'success'
+  ufodiff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This change will ensure ufodiff runs. Conditional workflows seem to temperamental, so I've fallen back on running every push (not to `main`)

The regression pipeline is skipped when nothing font-related has changed. I've also made the main build be skipped when READMEs or GitHub actions/workflows are changed. Might as well save costs where we can