### PR TITLE
Import automation fix: update glyphsLib to latest

### DIFF
--- a/.github/actions/import/requirements.txt
+++ b/.github/actions/import/requirements.txt
@@ -1,4 +1,4 @@
 fonttools==4.37.3
-glyphsLib==6.0.7
+glyphsLib==6.1.0
 ufo2ft==2.28.0
 ufoLib2==0.13.1


### PR DESCRIPTION
Following #68, the [latest error](https://github.com/googlefonts/googlesans-flex/actions/runs/3628450865/jobs/6119483529#step:4:119) in the workflow appears to be because the script relies on a feature only added in the latest version of `glyphsLib`. I've updated the dependency pulled in so that this should work going forwards