### PR TITLE
Simplify workflow trigger

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,12 +1,6 @@
 name: Build font and specimen
 
-on:
-  push:
-    paths-ignore:
-      - .github
-      - documentation
-      - '**/README.md'
-  release:
+on: [push, release]
 
 jobs:
   build:

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -11,8 +11,6 @@ on:
   push:
     branches-ignore:
       - main
-    paths:
-      - sources/**
 
 jobs:
   ufodiff:


### PR DESCRIPTION
Hopefully this will get the workflow to run on #78 

The `paths-ignore` shouldn't be stopping the build workflow from triggered, but we have no idea what else it could be so this is our debugging step

@MariannaPaszkowska sorry to bother you with this one