### PR TITLE
Refine checks

### DIFF
--- a/qa/check-charset.py
+++ b/qa/check-charset.py
@@ -56,7 +56,7 @@ excluded_check_ids = (
     fonts have the expected glyph order.
     """,
 )
-def com_google_fonts_check_googlesans_glyphs_glyphset_contents(ttFont):
+def com_google_fonts_check_googlesans_glyphs_glyphset_contents(font, ttFont):
     """Confirm that fonts have all expected Unicode encoded and non-Unicoded
     encoded glyph definitions.This test also confirms that the glyph order
     is defined as expected."""
@@ -65,7 +65,7 @@ def com_google_fonts_check_googlesans_glyphs_glyphset_contents(ttFont):
 
     tests_passed = True
     glyph_list_raw = ""
-    base_file_path = os.path.basename(ttFont.reader.file.name) + ".glyphsetdef"
+    base_file_path = os.path.basename(font) + ".glyphsetdef"
     expected_glyph_definition_path = os.path.join(
         glyph_definition_basedir, base_file_path
     )
@@ -79,9 +79,8 @@ def com_google_fonts_check_googlesans_glyphs_glyphset_contents(ttFont):
     if not (ttFont.getGlyphOrder() == glyph_list):
         tests_passed = False
         yield FAIL, (
-            "{} failed expected glyph set check. Diffs:\n\n```diff\n{}\n```"
+            "Font failed expected glyph set check. Diffs:\n\n```diff\n{}\n```"
         ).format(
-            ttFont.reader.file.name,
             "\n".join(
                 unified_diff(
                     list(ttFont.getGlyphOrder()),

--- a/qa/check-fea.py
+++ b/qa/check-fea.py
@@ -103,11 +103,11 @@ def com_google_fonts_check_googlesans_features_variable_uprights(ttFont):
         fea_tags.add(gsub_record.FeatureTag)
 
     if sorted(fea_tags) == VAR_UPRIGHT_FEA:
-        yield PASS, f"{tt.reader.file.name} contains the expected feature tags"
+        yield PASS, f"Font contains the expected feature tags"
     else:
         yield (
             FAIL,
-            f"{tt.reader.file.name} does not contain the expected feature tags.\n"
+            f"Font does not contain the expected feature tags.\n"
             f"Found:{sorted(fea_tags)}\nExpected:{VAR_UPRIGHT_FEA}",
         )
 

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -18,22 +18,19 @@ from fontbakery.checkrunner import FAIL, PASS, WARN, Section
 from fontbakery.constants import UNICODERANGE_DATA
 from fontbakery.fonts_profile import profile_factory
 from fontbakery.message import Message
-from fontbakery.profiles.universal import UNIVERSAL_PROFILE_CHECKS
 from fontbakery.profiles.googlefonts import GOOGLEFONTS_PROFILE_CHECKS
+from fontbakery.profiles.outline import OUTLINE_PROFILE_CHECKS
+from fontbakery.profiles.shared_conditions import is_italic
 from fontbakery.utils import (
     chars_in_range,
     compute_unicoderange_bits,
     unicoderange_bit_name,
 )
-from fontbakery.profiles.shared_conditions import is_italic
 
 profile_imports = ("fontbakery.profiles.googlefonts",)
 profile = profile_factory(default_section=Section("Google Sans Flex Custom Checks"))
 
 GOOGLESANSFLEX_PROFILE_CHECKS = GOOGLEFONTS_PROFILE_CHECKS + [
-    "com.google.fonts/check/googlesansflex/opentype/os2/fsselectionbit7",
-    "com.google.fonts/check/googlesansflex/opentype/os2/winascent",
-    "com.google.fonts/check/googlesansflex/opentype/os2/windescent",
     "com.google.fonts/check/googlesansflex/opentype/os2/unicode_range_bits",
     "com.google.fonts/check/googlesansflex/vf/fvaraxes",
     "com.google.fonts/check/googlesansflex/vf/fvardefault",
@@ -43,12 +40,11 @@ GOOGLESANSFLEX_PROFILE_CHECKS = GOOGLEFONTS_PROFILE_CHECKS + [
 # define check ID's in the upstream `universal` profile
 # that should be excluded here
 excluded_check_ids = (
+    *OUTLINE_PROFILE_CHECKS,  # Separate.
     "com.google.fonts/check/ftxvalidator_is_available",
     "com.google.fonts/check/dsig",
-    "com.google.fonts/check/family/win_ascent_and_descent",  # replaced by custom checks
+    "com.google.fonts/check/family/win_ascent_and_descent",  # replaced by value checks
     "com.google.fonts/check/unwanted_tables",
-    "com.google.fonts/check/outline_jaggy_segments",  # too many unactionable warnings
-    "com.google.fonts/check/outline_semi_vertical",  # design rather than QA problem
     "com.google.fonts/check/contour_count",  # design rather than QA problem
     "com.adobe.fonts/check/varfont/valid_default_instance_nameids",  # Bogus
     "com.google.fonts/check/varfont/regular_wght_coord",  # Buggy in 0.8.9
@@ -64,6 +60,7 @@ ATTRIBUTES = {
     "wght_axis_default": 400.0,
 }
 
+# Global Google Sans attributes, in 1000 upM font units.
 GS_FONTUNIT_ATTRIBUTES_UPRIGHT = {
     "head.yMax": 1263,
     "head.yMin": -989,
@@ -107,88 +104,6 @@ GS_FONTUNIT_ATTRIBUTES_ITALIC = {
 # OpenType table attribute checks
 # ================================================
 
-# ::::::::::::::::::::::::::::::::::::::::::::::::
-# Vertical metrics
-# ::::::::::::::::::::::::::::::::::::::::::::::::
-
-# OS/2.fsSelection bit 7 (USE_TYPO_METRICS) is set in all fonts
-@check(
-    id="com.google.fonts/check/googlesansflex/opentype/os2/fsselectionbit7",
-    rationale="""
-    Confirms that fonts have OS/2.fsSelection bit 7 (USE_TYPO_METRICS) set \
-    for typo vertical metrics (instead of win vertical metrics)
-    """,
-)
-def com_google_fonts_check_googlesansflex_opentype_os2_fsselectionbit7(ttFonts):
-    """OS/2.fsSelection bit 7 (USE_TYPO_METRICS) is set in all fonts"""
-    os2_fsselection_bit7_isset = ATTRIBUTES["os2_fsselection_bit7"] == 1
-
-    found_fail = False
-    fail_list = []
-    for tt in ttFonts:
-        fsselection_int = tt["OS/2"].fsSelection
-        fsselection_bit_is_set_test = (fsselection_int & (1 << 7)) != 0
-        if fsselection_bit_is_set_test is os2_fsselection_bit7_isset:
-            pass
-        else:
-            found_fail = True
-            fail_list.append(tt.reader.file.name)
-
-    if found_fail:
-        yield (
-            FAIL,
-            f"The OS/2.fsSelection bit 7 (USE_TYPO_METRICS) was NOT set "
-            f"in the following fonts: {fail_list}.",
-        )
-    else:
-        yield PASS, "The OS/2.fsSelection bit 7 (USE_TYPO_METRICS) was set in all fonts."
-
-
-# Note: winAscent and winDescent bounds are defined above yMin and below yMax values
-# OS/2.winAscent check
-@check(
-    id="com.google.fonts/check/googlesansflex/opentype/os2/winascent",
-    rationale="""
-    Confirms that the OS/2.winAscent value is defined above the yMax
-    value across the full glyph repertoire.
-    """,
-)
-def com_google_fonts_check_googlesansflex_opentype_os2_winascent(ttFont):
-    """OS/2.winAscent is defined above yMax value across the glyph repertoire"""
-    if ttFont["head"].yMax >= ttFont["OS/2"].usWinAscent:
-        yield (
-            FAIL,
-            f"The OS/2.usWinAscent value must be larger "
-            f"than the head.yMax value.  Received: OS/2.usWinAscent = "
-            f"{ttFont['OS/2'].usWinAscent} head.yMax = {ttFont['head'].yMax}",
-        )
-    else:
-        yield PASS, "The OS/2.winAscent definition is appropriate."
-
-
-# OS/2.winDescent check
-@check(
-    id="com.google.fonts/check/googlesansflex/opentype/os2/windescent",
-    rationale="""
-    Confirms that the OS/2.winDescent value is defined below the yMin
-    value across the full glyph repertoire.
-    """,
-)
-def com_google_fonts_check_googlesansflex_opentype_os2_windescent(ttFont):
-    """OS/2.winDescent is defined below yMin value across the glyph repertoire"""
-    # note: WinDescent is expressed as a positive value even though the metric
-    # extends below the baseline.  We must use unary neg operation for the
-    # comparison here
-    if ttFont["head"].yMin <= -ttFont["OS/2"].usWinDescent:
-        yield (
-            FAIL,
-            f"The OS/2.usWinDescent value must be less "
-            f"than the head.yMin value.  Received: OS/2.usWinDescent = "
-            f"{ttFont['OS/2'].usWinDescent} head.yMin = {ttFont['head'].yMin}",
-        )
-    else:
-        yield PASS, "The OS/2.winDescent value is appropriate."
-
 
 @check(id="com.google.fonts/check/googlesansflex/opentype/global_fu_attributes")
 def com_google_fonts_check_googlesansflex_opentype_global_fu_attributes(ttFont):
@@ -216,11 +131,6 @@ def com_google_fonts_check_googlesansflex_opentype_global_fu_attributes(ttFont):
 
     if matches:
         yield PASS, "All global attributes match."
-
-
-# ::::::::::::::::::::::::::::::::::::::::::::::::
-# Other metrics
-# ::::::::::::::::::::::::::::::::::::::::::::::::
 
 
 @check(

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -51,13 +51,11 @@ excluded_check_ids = (
     "com.google.fonts/check/varfont/bold_wght_coord",  # Buggy in 0.8.9
 )
 
-ATTRIBUTES = {
-    "expected_fvar_axes": ["opsz", "wdth", "wght", "ROND"],
-    "opsz_axis_default": 18.0,
-    "os2_fsselection_bit7": 1,
-    "rond_axis_default": 0.0,
-    "wdth_axis_default": 100.0,
-    "wght_axis_default": 400.0,
+AXIS_DEFAULTS = {
+    "opsz": 18,
+    "wdth": 100,
+    "wght": 400,
+    "ROND": 0,
 }
 
 # Global Google Sans attributes, in 1000 upM font units.
@@ -192,29 +190,17 @@ def com_google_fonts_check_googlesansflex_unicode_range_bits(ttFont, unicoderang
 )
 def com_google_fonts_check_googlesansflex_variable_fvar_axes(ttFont):
     """Confirms that the variable font builds include expected axes."""
-    tt = ttFont
-    observed_axis_list = []
-    for axis in tt["fvar"].axes:
-        observed_axis_list.append(axis.axisTag)
+    expected_fvar_axes = AXIS_DEFAULTS.keys()
+    observed_axis_list = {axis.axisTag for axis in ttFont["fvar"].axes}
 
-    if len(observed_axis_list) != len(ATTRIBUTES["expected_fvar_axes"]):
-        yield (
-            FAIL,
-            f"{tt.reader.file.name} does not include the correct axis tags. \n"
+    if observed_axis_list != expected_fvar_axes:
+        yield FAIL, (
+            f"Font does not include the correct axis tags. \n"
             f"Observed: {observed_axis_list}\n"
-            f"Expected: {ATTRIBUTES['expected_fvar_axes']}",
+            f"Expected: {expected_fvar_axes}"
         )
-
-    has_all_tags = True
-    for axis_tag in ATTRIBUTES["expected_fvar_axes"]:
-        if axis_tag in observed_axis_list:
-            pass
-        else:
-            has_all_tags = False
-            yield (FAIL, f"{tt.reader.file.name} does not include axis tag {axis_tag}")
-
-    if has_all_tags:
-        yield (PASS, f"{tt.reader.file.name} includes all expected axis tags")
+    else:
+        yield PASS, f"Font includes all expected axis tags"
 
 
 @check(
@@ -227,29 +213,17 @@ def com_google_fonts_check_googlesansflex_variable_fvar_axes(ttFont):
 )
 def com_google_fonts_check_googlesansflex_variable_fvar_default(ttFont):
     """Confirms that the variable font builds include correct fvar default."""
-    tt = ttFont
-    expectations = {
-        "opsz": ATTRIBUTES["opsz_axis_default"],
-        "wdth": ATTRIBUTES["wdth_axis_default"],
-        "wght": ATTRIBUTES["wght_axis_default"],
-        "ROND": ATTRIBUTES["rond_axis_default"],
-    }
-
-    for axis in tt["fvar"].axes:
+    for axis in ttFont["fvar"].axes:
         tag = axis.axisTag
-        if tag in expectations:
-            if axis.defaultValue != expectations[tag]:
-                yield (
-                    FAIL,
-                    f"{tt.reader.file.name} does not include the correct "
-                    f"fvar {tag} axis default.\n"
-                    f"Found: `{axis.defaultValue}` and expected `{expectations[tag]}`",
-                )
-            else:
-                yield (
-                    PASS,
-                    f"{tt.reader.file.name} contains the expected fvar {tag} default.",
-                )
+        expected = AXIS_DEFAULTS[tag]
+        if axis.defaultValue != expected:
+            yield FAIL, (
+                f"Font does not include the correct "
+                f"fvar {tag} axis default.\n"
+                f"Found: `{axis.defaultValue}` and expected `{expected}`"
+            )
+        else:
+            yield PASS, f"Font contains the expected fvar {tag} default."
 
 
 # ================================================

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -25,6 +25,7 @@ from fontbakery.utils import (
     compute_unicoderange_bits,
     unicoderange_bit_name,
 )
+from fontbakery.profiles.shared_conditions import is_italic
 
 profile_imports = ("fontbakery.profiles.googlefonts",)
 profile = profile_factory(default_section=Section("Google Sans Flex Custom Checks"))
@@ -33,18 +34,10 @@ GOOGLESANSFLEX_PROFILE_CHECKS = GOOGLEFONTS_PROFILE_CHECKS + [
     "com.google.fonts/check/googlesansflex/opentype/os2/fsselectionbit7",
     "com.google.fonts/check/googlesansflex/opentype/os2/winascent",
     "com.google.fonts/check/googlesansflex/opentype/os2/windescent",
-    "com.google.fonts/check/googlesansflex/opentype/hhea/ascent",
-    "com.google.fonts/check/googlesansflex/opentype/hhea/descent",
-    "com.google.fonts/check/googlesansflex/opentype/hhea/linegap",
-    "com.google.fonts/check/googlesansflex/opentype/os2/strikeout",
-    "com.google.fonts/check/googlesansflex/opentype/os2/typodescender",
-    "com.google.fonts/check/googlesansflex/opentype/os2/typoascender",
-    "com.google.fonts/check/googlesansflex/opentype/os2/typolinegap",
     "com.google.fonts/check/googlesansflex/opentype/os2/unicode_range_bits",
-    "com.google.fonts/check/googlesansflex/opentype/post/underline",
     "com.google.fonts/check/googlesansflex/vf/fvaraxes",
     "com.google.fonts/check/googlesansflex/vf/fvardefault",
-    "com.google.fonts/check/googlesansflex/head/yminmax",
+    "com.google.fonts/check/googlesansflex/opentype/global_fu_attributes",
 ]
 
 # define check ID's in the upstream `universal` profile
@@ -64,27 +57,44 @@ excluded_check_ids = (
 
 ATTRIBUTES = {
     "expected_fvar_axes": ["opsz", "wdth", "wght", "ROND"],
-    "hhea_ascent": 966,  # set to match typo metrics values
-    "hhea_descent": -286,
-    "hhea_linegap": 0,
-    "italic_ymax": 1263,
-    "italic_ymin": -955,
     "opsz_axis_default": 18.0,
     "os2_fsselection_bit7": 1,
-    "os2_strikeout_position": 306,
-    "os2_strikeout_size": 84,
-    "os2_typoascender": 966,  # set to match hhea metrics values
-    "os2_typodescender": -286,
-    "os2_typolinegap": 0,
-    "post_underline_position": -160,
-    "post_underline_thickness": 84,
     "rond_axis_default": 0.0,
-    "upright_ymax": 1263,
-    "upright_ymin": -989,
     "wdth_axis_default": 100.0,
     "wght_axis_default": 400.0,
 }
 
+GS_FONTUNIT_ATTRIBUTES_UPRIGHT = {
+    "head.yMax": 1263,
+    "head.yMin": -989,
+    "hhea.ascender": 966,
+    "hhea.descender": -286,
+    "hhea.lineGap": 0,
+    "OS/2.sTypoAscender": 966,  # set to match hhea metrics values
+    "OS/2.sTypoDescender": -286,
+    "OS/2.sTypoLineGap": 0,
+    "OS/2.usWinAscent": 1323,
+    "OS/2.usWinDescent": 1079,
+    "OS/2.yStrikeoutPosition": 306,
+    "OS/2.yStrikeoutSize": 84,
+    "OS/2.ySubscriptXOffset": 0,
+    "OS/2.ySubscriptXSize": 650,
+    "OS/2.ySubscriptYOffset": 75,
+    "OS/2.ySubscriptYSize": 600,
+    "OS/2.ySuperscriptXOffset": 0,
+    "OS/2.ySuperscriptXSize": 650,
+    "OS/2.ySuperscriptYOffset": 350,
+    "OS/2.ySuperscriptYSize": 600,
+    "post.underlinePosition": -160,
+    "post.underlineThickness": 84,
+}
+
+GS_FONTUNIT_ATTRIBUTES_ITALIC = {
+    **GS_FONTUNIT_ATTRIBUTES_UPRIGHT,
+    "head.yMin": -955,
+    "OS/2.ySubscriptXOffset": -13,
+    "OS/2.ySuperscriptXOffset": 62,
+}
 
 # ================================================
 #
@@ -134,31 +144,6 @@ def com_google_fonts_check_googlesansflex_opentype_os2_fsselectionbit7(ttFonts):
         yield PASS, "The OS/2.fsSelection bit 7 (USE_TYPO_METRICS) was set in all fonts."
 
 
-@check(
-    id="com.google.fonts/check/googlesansflex/head/yminmax",
-    rationale="""Confirms that the head.yMin and head.yMax values are like in Google Sans v10.001.""",
-)
-def com_google_fonts_check_googlesansflex_head_yminmax(ttFont):
-    """head.yMin and .yMax matches Google Sans 10.001."""
-    if (expected := ATTRIBUTES["upright_ymax"]) != (actual := ttFont["head"].yMax):
-        yield (
-            FAIL,
-            f"The head.yMax value does not match Google Sans. "
-            f"Should be {expected} but is {actual}",
-        )
-    else:
-        yield PASS, "The head.yMax definition matches Google Sans."
-
-    if (expected := ATTRIBUTES["upright_ymin"]) != (actual := ttFont["head"].yMin):
-        yield (
-            FAIL,
-            f"The head.yMin value does not match Google Sans. "
-            f"Should be {expected} but is {actual}",
-        )
-    else:
-        yield PASS, "The head.yMin definition matches Google Sans."
-
-
 # Note: winAscent and winDescent bounds are defined above yMin and below yMax values
 # OS/2.winAscent check
 @check(
@@ -205,185 +190,37 @@ def com_google_fonts_check_googlesansflex_opentype_os2_windescent(ttFont):
         yield PASS, "The OS/2.winDescent value is appropriate."
 
 
-# hhea.Ascent check
-@check(
-    id="com.google.fonts/check/googlesansflex/opentype/hhea/ascent",
-    rationale="""
-    Confirms that the hhea.ascent value is defined as expected
-    """,
-)
-def com_google_fonts_check_googlesansflex_opentype_hhea_ascent(ttFont):
-    """hhea.ascent is defined as expected"""
-    if ttFont["hhea"].ascent != ATTRIBUTES["hhea_ascent"]:
-        yield (
-            FAIL,
-            f"The hhea.ascent value {ttFont['hhea'].ascent} does not "
-            f"match the required value {ATTRIBUTES['hhea_ascent']}",
-        )
+@check(id="com.google.fonts/check/googlesansflex/opentype/global_fu_attributes")
+def com_google_fonts_check_googlesansflex_opentype_global_fu_attributes(ttFont):
+    """Check that global font unit attributes match GS v10.001 (taking upM into
+    consideration)."""
+
+    if is_italic(ttFont):
+        attrs = GS_FONTUNIT_ATTRIBUTES_ITALIC
     else:
-        yield PASS, "The hhea.ascent value matches the required value."
+        attrs = GS_FONTUNIT_ATTRIBUTES_UPRIGHT
 
+    # GS is using 1000 upM, GSF may use something else.
+    upm_scale = ttFont["head"].unitsPerEm / 1000
 
-# hhea.Descent check
-@check(
-    id="com.google.fonts/check/googlesansflex/opentype/hhea/descent",
-    rationale="""
-    Confirms that the hhea.descent value is defined as expected
-    """,
-)
-def com_google_fonts_check_googlesansflex_opentype_hhea_descent(ttFont):
-    """hhea.descent is defined as expected"""
-    if ttFont["hhea"].descent != ATTRIBUTES["hhea_descent"]:
-        yield (
-            FAIL,
-            f"The hhea.descent value {ttFont['hhea'].descent} does not "
-            f"match the required value {ATTRIBUTES['hhea_descent']}",
-        )
-    else:
-        yield PASS, "The hhea.descent value matches the required value."
+    matches = True
+    for attr, expected in attrs.items():
+        table_name, attr = attr.split(".")
+        table = ttFont[table_name]
+        scaled_expected = expected * upm_scale
+        if scaled_expected.is_integer():
+            scaled_expected = int(scaled_expected)
+        if (actual := getattr(table, attr)) != scaled_expected:
+            matches = False
+            yield FAIL, f"{table_name}.{attr} should be {scaled_expected} but is {actual}"
 
-
-# hhea.lineGap check
-@check(
-    id="com.google.fonts/check/googlesansflex/opentype/hhea/linegap",
-    rationale="""
-    Confirms that the hhea.lineGap value is defined as expected
-    """,
-)
-def com_google_fonts_check_googlesansflex_opentype_hhea_linegap(ttFont):
-    """hhea.linegap is defined as expected"""
-    if ttFont["hhea"].lineGap != ATTRIBUTES["hhea_linegap"]:
-        yield (
-            FAIL,
-            f"The hhea.lineGap value {ttFont['hhea'].lineGap} does not "
-            f"match the required value {ATTRIBUTES['hhea_linegap']}",
-        )
-    else:
-        yield PASS, "The hhea.lineGap value matches the required value."
-
-
-# OS/2.typoDescender check
-@check(
-    id="com.google.fonts/check/googlesansflex/opentype/os2/typodescender",
-    rationale="""
-    Confirms that the OS/2.typoDescender value is defined as expected
-    """,
-)
-def com_google_fonts_check_googlesansflex_opentype_os2_typodescender(ttFont):
-    """OS/2.typoDescender is defined as expected"""
-    if ttFont["OS/2"].sTypoDescender != ATTRIBUTES["os2_typodescender"]:
-        yield (
-            FAIL,
-            f"The OS/2.typoDescender value {ttFont['OS/2'].sTypoDescender} does not "
-            f"match the required value {ATTRIBUTES['os2_typodescender']}",
-        )
-    else:
-        yield PASS, "The OS/2.typoDescender value matches the required value."
-
-
-# OS/2.typoAscender check
-@check(
-    id="com.google.fonts/check/googlesansflex/opentype/os2/typoascender",
-    rationale="""
-    Confirms that the OS/2.typoAscender value is defined as expected
-    """,
-)
-def com_google_fonts_check_googlesansflex_opentype_os2_typoascender(ttFont):
-    """OS/2.typoAscender is defined as expected"""
-    if ttFont["OS/2"].sTypoAscender != ATTRIBUTES["os2_typoascender"]:
-        yield (
-            FAIL,
-            f"The OS/2.typoAscender value {ttFont['OS/2'].sTypoAscender} does not "
-            f"match the required value {ATTRIBUTES['os2_typoascender']}",
-        )
-    else:
-        yield PASS, "The OS/2.typoAscender value matches the required value."
-
-
-# OS/2.typoLineGap check
-@check(
-    id="com.google.fonts/check/googlesansflex/opentype/os2/typolinegap",
-    rationale="""
-    Confirms that the OS/2.typoLineGap value is defined as expected
-    """,
-)
-def com_google_fonts_check_googlesansflex_opentype_os2_typolinegap(ttFont):
-    """OS/2.typoLineGap is defined as expected"""
-    if ttFont["OS/2"].sTypoLineGap != ATTRIBUTES["os2_typolinegap"]:
-        yield (
-            FAIL,
-            f"The OS/2.typoLineGap value {ttFont['OS/2'].sTypoLineGap} does not "
-            f"match the required value {ATTRIBUTES['os2_typolinegap']}",
-        )
-    else:
-        yield PASS, "The OS/2.typoLineGap value matches the required value."
+    if matches:
+        yield PASS, "All global attributes match."
 
 
 # ::::::::::::::::::::::::::::::::::::::::::::::::
 # Other metrics
 # ::::::::::::::::::::::::::::::::::::::::::::::::
-
-# post underline checks
-@check(
-    id="com.google.fonts/check/googlesansflex/opentype/post/underline",
-    rationale="""
-    Confirms that the post table underline thickness and position are
-    set to the correct values
-    """,
-)
-def com_google_fonts_check_googlesansflex_opentype_post_underline(ttFont):
-    """Post table underline thickness and position are set to correct values"""
-
-    # underline position
-    if ttFont["post"].underlinePosition != ATTRIBUTES["post_underline_position"]:
-        yield (
-            FAIL,
-            f"The post underline position value {ttFont['post'].underlinePosition} "
-            f"does not match the required value {ATTRIBUTES['post_underline_position']}",
-        )
-    else:
-        yield PASS, "The post underline position value matches the required value."
-
-    # underline thickness
-    if ttFont["post"].underlineThickness != ATTRIBUTES["post_underline_thickness"]:
-        yield (
-            FAIL,
-            f"The post underline thickness value {ttFont['post'].underlineThickness} "
-            f"does not match the required value {ATTRIBUTES['post_underline_thickness']}",
-        )
-    else:
-        yield PASS, "The post underline thickness value matches the required value."
-
-
-@check(
-    id="com.google.fonts/check/googlesansflex/opentype/os2/strikeout",
-    rationale="""
-    Confirms that the OS/2 table strikeout size and position are
-    set to the correct values
-    """,
-)
-def com_google_fonts_check_googlesansflex_opentype_os2_strikeout(ttFont):
-    """OS/2 table strikeout size and position are set to correct values"""
-
-    # strikeout position
-    if ttFont["OS/2"].yStrikeoutPosition != ATTRIBUTES["os2_strikeout_position"]:
-        yield (
-            FAIL,
-            f"The OS/2 strikeout position value {ttFont['OS/2'].yStrikeoutPosition} "
-            f"does not match the required value {ATTRIBUTES['os2_strikeout_position']}",
-        )
-    else:
-        yield PASS, "The OS/2 strikeout position value matches the required value."
-
-    # strikeout thickness
-    if ttFont["OS/2"].yStrikeoutSize != ATTRIBUTES["os2_strikeout_size"]:
-        yield (
-            FAIL,
-            f"The OS/2 strikeout size value {ttFont['OS/2'].yStrikeoutSize} "
-            f"does not match the required value {ATTRIBUTES['os2_strikeout_size']}",
-        )
-    else:
-        yield PASS, "The OS/2 strikeout size value matches the required value."
 
 
 @check(

--- a/qa/check-shaping.py
+++ b/qa/check-shaping.py
@@ -46,10 +46,9 @@ def hb_font(font):
 
 
 @check(id="com.google.fonts/check/googlesans/features/regression")
-def com_google_fonts_check_googlesans_features_regression(ttFont, hb_font):
+def com_google_fonts_check_googlesans_features_regression(font, ttFont, hb_font):
     """But does it shape?"""
-    tt = ttFont
-    filename = Path(tt.reader.file.name)
+    filename = Path(font)
 
     shaping_file_found = False
     shaping_basedir = Path("qa", "shaping")
@@ -86,7 +85,7 @@ def com_google_fonts_check_googlesans_features_regression(ttFont, hb_font):
             return
 
         shaped_texts = shape_texts(
-            tt,
+            ttFont,
             hb_font,
             shaping_texts,
             shaping_script,
@@ -99,7 +98,7 @@ def com_google_fonts_check_googlesans_features_regression(ttFont, hb_font):
         if shaped_texts == shaped_texts_expected:
             yield PASS, f"{shaping_file}: No regression detected"
         else:
-            if "fvar" in tt:
+            if "fvar" in ttFont:
                 assert isinstance(shaped_texts, dict)
                 assert isinstance(shaped_texts_expected, dict)
 


### PR DESCRIPTION
* Use `font` variable instead of reaching into `ttFont` to get filename.
* Many checks don't need to print the filename in the results string because the check already says which files it ran on.
* Consolidate many custom global font attribute checks into a single one that works for uprights and italics and is easier to extend:
    * `com.google.fonts/check/googlesansflex/opentype/os2/winascent`
    * `com.google.fonts/check/googlesansflex/opentype/os2/windescent`
    * `com.google.fonts/check/googlesansflex/opentype/hhea/ascent`
    * `com.google.fonts/check/googlesansflex/opentype/hhea/descent`
    * `com.google.fonts/check/googlesansflex/opentype/hhea/linegap`
    * `com.google.fonts/check/googlesansflex/opentype/os2/strikeout`
    * `com.google.fonts/check/googlesansflex/opentype/os2/typodescender`
    * `com.google.fonts/check/googlesansflex/opentype/os2/typoascender`
    * `com.google.fonts/check/googlesansflex/opentype/os2/typolinegap`
    * `com.google.fonts/check/googlesansflex/opentype/post/underline`
    * `com.google.fonts/check/googlesansflex/head/yminmax`
* Minor cleanup in the way the `fvar` checks work.
* Use some upstream checks instead of custom ones:
    * `com.google.fonts/check/googlesansflex/opentype/os2/fsselectionbit7`
* Remove outline checks because we test for them in a different profile.

@chrissimpkins @MariannaPaszkowska ready for review.