### PR TITLE
Tune checks

### DIFF
--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -49,6 +49,10 @@ excluded_check_ids = (
     "com.adobe.fonts/check/varfont/valid_default_instance_nameids",  # Bogus
     "com.google.fonts/check/varfont/regular_wght_coord",  # Buggy in 0.8.9
     "com.google.fonts/check/varfont/bold_wght_coord",  # Buggy in 0.8.9
+    "com.google.fonts/check/vertical_metrics",  # GS is our reference.
+    "com.google.fonts/check/varfont/regular_opsz_coord",  # No, opsz=18
+    "com.google.fonts/check/glyph_coverage",  # We have our own target
+    "com.google.fonts/check/file_size",  # We're going bigger
 )
 
 AXIS_DEFAULTS = {

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -60,8 +60,6 @@ AXIS_DEFAULTS = {
 
 # Global Google Sans attributes, in 1000 upM font units.
 GS_FONTUNIT_ATTRIBUTES_UPRIGHT = {
-    "head.yMax": 1263,
-    "head.yMin": -989,
     "hhea.ascender": 966,
     "hhea.descender": -286,
     "hhea.lineGap": 0,
@@ -86,7 +84,6 @@ GS_FONTUNIT_ATTRIBUTES_UPRIGHT = {
 
 GS_FONTUNIT_ATTRIBUTES_ITALIC = {
     **GS_FONTUNIT_ATTRIBUTES_UPRIGHT,
-    "head.yMin": -955,
     "OS/2.ySubscriptXOffset": -13,
     "OS/2.ySuperscriptXOffset": 62,
 }

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -37,7 +37,7 @@ GOOGLESANSFLEX_PROFILE_CHECKS = GOOGLEFONTS_PROFILE_CHECKS + [
     "com.google.fonts/check/googlesansflex/opentype/global_fu_attributes",
 ]
 
-# define check ID's in the upstream `universal` profile
+# define check ID's in the upstream `googlefonts` profile
 # that should be excluded here
 excluded_check_ids = (
     *OUTLINE_PROFILE_CHECKS,  # Separate.

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -43,7 +43,6 @@ excluded_check_ids = (
     *OUTLINE_PROFILE_CHECKS,  # Separate.
     "com.google.fonts/check/ftxvalidator_is_available",
     "com.google.fonts/check/dsig",
-    "com.google.fonts/check/family/win_ascent_and_descent",  # replaced by value checks
     "com.google.fonts/check/unwanted_tables",
     "com.google.fonts/check/contour_count",  # design rather than QA problem
     "com.adobe.fonts/check/varfont/valid_default_instance_nameids",  # Bogus
@@ -72,8 +71,6 @@ GS_FONTUNIT_ATTRIBUTES_UPRIGHT = {
     "OS/2.sTypoAscender": 966,  # set to match hhea metrics values
     "OS/2.sTypoDescender": -286,
     "OS/2.sTypoLineGap": 0,
-    "OS/2.usWinAscent": 1323,
-    "OS/2.usWinDescent": 1079,
     "OS/2.yStrikeoutPosition": 306,
     "OS/2.yStrikeoutSize": 84,
     "OS/2.ySubscriptXOffset": 0,

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -60,6 +60,7 @@ AXIS_DEFAULTS = {
     "wdth": 100,
     "wght": 400,
     "ROND": 0,
+    "GRAD": 0,
 }
 
 # Global Google Sans attributes, in 1000 upM font units.

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -53,6 +53,7 @@ excluded_check_ids = (
     "com.google.fonts/check/varfont/regular_opsz_coord",  # No, opsz=18
     "com.google.fonts/check/glyph_coverage",  # We have our own target
     "com.google.fonts/check/file_size",  # We're going bigger
+    "com.google.fonts/check/font_names",  # We have our own naming ideas
 )
 
 AXIS_DEFAULTS = {

--- a/sources/config.yaml
+++ b/sources/config.yaml
@@ -5,6 +5,7 @@ axisOrder:
   - wdth
   - wght
   - ROND
+  - GRAD
 familyName: Google Sans Flex
 # The existing UFO sources are quadratics, so it probably does not make sense
 # to build OTFs. Also, Google Sans doesn't build OTFs, so it makes sense to do

--- a/sources/config.yaml
+++ b/sources/config.yaml
@@ -77,7 +77,7 @@ stat:
     value: 125.0
   - flags: 0
     name: ExtraExpanded
-    value: 151.0
+    value: 150.0
 - name: Optical size
   tag: opsz
   values:

--- a/sources/config.yaml
+++ b/sources/config.yaml
@@ -148,8 +148,11 @@ stat:
   tag: ROND
   values:
   - flags: 2
-    name: Square
+    name: Default
     value: 0.0
-  - flags: 0
-    name: Round
-    value: 100.0
+- name: Grade
+  tag: GRAD
+  values:
+  - flags: 2
+    name: Normal
+    value: 0.0


### PR DESCRIPTION
This changes the tests as discussed with @MariannaPaszkowska.

* Exclude `com.google.fonts/check/vertical_metrics` and `com.google.fonts/check/varfont/regular_opsz_coord` because we use GS as the reference.
* Exclude `com.google.fonts/check/glyph_coverage` because we have our own target
* Exclude `com.google.fonts/check/file_size` because we're past the 1MB anyway and know it.
* Exclude `com.google.fonts/check/font_names` because we want our own naming.
* Make wdth=150 ExtraExpanded instead of 151
* Add dummy STAT entries for GRAD and ROND, as expected by the axis registry
* Use Google Fonts' `com.google.fonts/check/family/win_ascent_and_descent` to check win metrics.