### PR TITLE
2022-12-13 Import from fb-wip

### DIFF
--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/N_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/N_.glif
@@ -35,7 +35,7 @@
       <point x="246" y="1429" type="qcurve"/>
       <point x="1200" y="4" type="line"/>
       <point x="1200" y="4" type="line"/>
-      <point x="1200" y="10" type="line"/>
+      <point x="1200" y="4" type="line"/>
       <point x="1200" y="1430" type="line"/>
       <point x="1200" y="1432" name="inserted"/>
       <point x="1200" y="1432"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/W_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/W_.glif
@@ -35,8 +35,8 @@
       <point x="60" y="1432" name="inserted"/>
       <point x="61" y="1428" type="qcurve"/>
       <point x="403" y="140" type="line"/>
-      <point x="440" y="1" type="line"/>
-      <point x="440" y="1" type="line"/>
+      <point x="440" y="0" type="line"/>
+      <point x="440" y="0" type="line"/>
       <point x="481" y="140" type="line"/>
       <point x="871" y="1434" type="line"/>
       <point x="872" y="1438" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/caroncomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/caroncomb.glif
@@ -14,21 +14,21 @@
       <point x="-250" y="1432" type="line"/>
       <point x="-247" y="1432"/>
       <point x="-247" y="1432" name="inserted"/>
-      <point x="-245" y="1430" type="qcurve"/>
+      <point x="0" y="1173" type="qcurve"/>
       <point x="0" y="1173" type="line"/>
-      <point x="1" y="1173" type="line"/>
-      <point x="244" y="1430" type="line"/>
-      <point x="246" y="1432"/>
-      <point x="246" y="1432"/>
-      <point x="249" y="1432" type="qcurve"/>
-      <point x="249" y="1432" type="line"/>
-      <point x="252" y="1432"/>
-      <point x="252" y="1432" name="inserted"/>
-      <point x="248" y="1428" type="qcurve"/>
-      <point x="248" y="1428" type="line"/>
-      <point x="5" y="1171" type="line"/>
-      <point x="3" y="1169"/>
-      <point x="3" y="1169"/>
+      <point x="0" y="1173" type="line"/>
+      <point x="0" y="1173" type="line"/>
+      <point x="245" y="1432"/>
+      <point x="245" y="1432"/>
+      <point x="248" y="1432" type="qcurve"/>
+      <point x="248" y="1432" type="line"/>
+      <point x="251" y="1432"/>
+      <point x="251" y="1432" name="inserted"/>
+      <point x="247" y="1428" type="qcurve"/>
+      <point x="247" y="1428" type="line"/>
+      <point x="4" y="1171" type="line"/>
+      <point x="2" y="1169"/>
+      <point x="2" y="1169"/>
       <point x="0" y="1169" type="qcurve"/>
       <point x="0" y="1169" type="line"/>
       <point x="-2" y="1169"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/circumflexcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/circumflexcomb.glif
@@ -5,13 +5,13 @@
   <anchor x="0" y="1432" name="top"/>
   <outline>
     <contour>
-      <point x="-248" y="1173" type="qcurve"/>
-      <point x="-248" y="1173" type="line"/>
-      <point x="-5" y="1430" type="line"/>
-      <point x="-3" y="1432"/>
-      <point x="-3" y="1432"/>
-      <point x="-1" y="1432" type="qcurve"/>
-      <point x="-1" y="1432" type="line"/>
+      <point x="-247" y="1173" type="qcurve"/>
+      <point x="-247" y="1173" type="line"/>
+      <point x="-4" y="1430" type="line"/>
+      <point x="-2" y="1432"/>
+      <point x="-2" y="1432"/>
+      <point x="0" y="1432" type="qcurve"/>
+      <point x="0" y="1432" type="line"/>
       <point x="2" y="1432"/>
       <point x="2" y="1432" name="inserted"/>
       <point x="4" y="1430" type="qcurve"/>
@@ -23,16 +23,16 @@
       <point x="250" y="1169" type="line"/>
       <point x="247" y="1169"/>
       <point x="247" y="1169" name="inserted"/>
-      <point x="245" y="1171" type="qcurve"/>
+      <point x="0" y="1427" type="qcurve"/>
       <point x="0" y="1427" type="line"/>
-      <point x="-1" y="1427" type="line"/>
-      <point x="-244" y="1171" type="line"/>
-      <point x="-246" y="1169"/>
-      <point x="-246" y="1169"/>
-      <point x="-249" y="1169" type="qcurve"/>
-      <point x="-249" y="1169" type="line"/>
-      <point x="-252" y="1169"/>
-      <point x="-252" y="1169" name="inserted"/>
+      <point x="0" y="1427" type="line"/>
+      <point x="0" y="1427" type="line"/>
+      <point x="-245" y="1169"/>
+      <point x="-245" y="1169"/>
+      <point x="-248" y="1169" type="qcurve"/>
+      <point x="-248" y="1169" type="line"/>
+      <point x="-251" y="1169"/>
+      <point x="-251" y="1169" name="inserted"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/five.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/five.glif
@@ -20,7 +20,7 @@
       <point x="264" y="1428" type="line"/>
       <point x="166" y="662" type="line"/>
       <point x="166" y="662" type="line"/>
-      <point x="236" y="764" name="inserted"/>
+      <point x="235" y="764" name="inserted"/>
       <point x="428" y="882"/>
       <point x="560" y="882" type="qcurve" smooth="yes"/>
       <point x="580" y="882" type="line" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/germandbls.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/germandbls.glif
@@ -17,8 +17,8 @@
       <point x="960" y="1123" type="line"/>
       <point x="960" y="953"/>
       <point x="783" y="770"/>
-      <point x="619" y="770" type="qcurve"/>
-      <point x="619" y="774" type="line"/>
+      <point x="635" y="772" type="qcurve"/>
+      <point x="635" y="772" type="line"/>
       <point x="823" y="774"/>
       <point x="1042" y="582"/>
       <point x="1042" y="403" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/less.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/less.glif
@@ -13,23 +13,23 @@
       <point x="113" y="543"/>
       <point x="113" y="543" name="inserted"/>
       <point x="115" y="544" type="qcurve"/>
-      <point x="871" y="899" type="line"/>
-      <point x="874" y="900"/>
-      <point x="874" y="900"/>
-      <point x="875" y="899" type="qcurve"/>
-      <point x="875" y="899" type="line"/>
+      <point x="871" y="899" type="line" smooth="yes"/>
+      <point x="875" y="901"/>
+      <point x="875" y="901"/>
+      <point x="876" y="899" type="qcurve"/>
+      <point x="876" y="899" type="line"/>
       <point x="877" y="897"/>
       <point x="877" y="897" name="inserted"/>
       <point x="873" y="895" type="qcurve" smooth="yes"/>
       <point x="118" y="542" type="line"/>
       <point x="118" y="542" type="line"/>
       <point x="873" y="191" type="line"/>
-      <point x="876" y="189" name="inserted"/>
-      <point x="876" y="189"/>
-      <point x="875" y="187" type="qcurve"/>
-      <point x="875" y="187" type="line"/>
-      <point x="874" y="185"/>
-      <point x="874" y="185"/>
+      <point x="877" y="189" name="inserted"/>
+      <point x="877" y="189"/>
+      <point x="876" y="187" type="qcurve"/>
+      <point x="876" y="187" type="line"/>
+      <point x="875" y="185"/>
+      <point x="875" y="185"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/r.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/r.glif
@@ -24,7 +24,7 @@
       <point x="214" y="1018" type="qcurve"/>
       <point x="214" y="674" type="line"/>
       <point x="214" y="674" type="line"/>
-      <point x="228" y="837"/>
+      <point x="227" y="836"/>
       <point x="418" y="1048"/>
       <point x="560" y="1048" type="qcurve" smooth="yes"/>
       <point x="594" y="1048" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/semicolon.glif
@@ -18,21 +18,21 @@
       <point x="188" y="962"/>
     </contour>
     <contour>
-      <point x="106" y="-111" type="line" smooth="yes"/>
+      <point x="108" y="-108" type="line" smooth="yes"/>
       <point x="105" y="-113" name="inserted"/>
       <point x="105" y="-113"/>
-      <point x="98" y="-113" type="qcurve"/>
-      <point x="98" y="-112" type="line"/>
+      <point x="100" y="-110" type="qcurve"/>
+      <point x="100" y="-109" type="line"/>
       <point x="178" y="12" type="line"/>
       <point x="169" y="12"/>
-      <point x="158" y="23"/>
+      <point x="158" y="22"/>
       <point x="158" y="30" type="qcurve" smooth="yes"/>
       <point x="158" y="37"/>
       <point x="167" y="48"/>
-      <point x="175" y="48" type="qcurve"/>
-      <point x="184" y="48"/>
-      <point x="192" y="37"/>
-      <point x="192" y="31" type="qcurve" smooth="yes"/>
+      <point x="175" y="48" type="qcurve" smooth="yes"/>
+      <point x="183" y="48"/>
+      <point x="192" y="38"/>
+      <point x="192" y="30" type="qcurve" smooth="yes"/>
       <point x="192" y="25" name="inserted"/>
       <point x="186" y="14"/>
       <point x="182" y="8" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/sterling.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/sterling.glif
@@ -48,8 +48,8 @@
       <point x="246" y="463" type="line"/>
       <point x="247" y="308"/>
       <point x="156" y="70"/>
-      <point x="71" y="5" type="qcurve"/>
-      <point x="71" y="4" type="line"/>
+      <point x="70" y="4" type="qcurve"/>
+      <point x="70" y="4" type="line"/>
       <point x="594" y="4" type="line"/>
       <point x="695" y="4"/>
       <point x="820" y="115"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/y.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/glyphs/y.glif
@@ -16,8 +16,8 @@
       <point x="25" y="1020"/>
       <point x="25" y="1020" name="inserted"/>
       <point x="26" y="1017" type="qcurve"/>
-      <point x="430" y="36" type="line"/>
-      <point x="430" y="36" type="line"/>
+      <point x="431" y="36" type="line"/>
+      <point x="431" y="36" type="line"/>
       <point x="431" y="36" type="line"/>
       <point x="431" y="36" type="line"/>
       <point x="838" y="1017" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/fontinfo.plist
@@ -64,9 +64,9 @@
         <key>name</key>
         <string>numerator-osb</string>
         <key>x</key>
-        <integer>563</integer>
+        <integer>555</integer>
         <key>y</key>
-        <integer>672</integer>
+        <integer>675</integer>
       </dict>
       <dict>
         <key>angle</key>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/A_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/A_.glif
@@ -16,8 +16,8 @@
       <point x="953" y="0" name="inserted"/>
       <point x="898" y="154" type="qcurve" smooth="yes"/>
       <point x="746" y="581" type="line"/>
-      <point x="726" y="666" type="line"/>
-      <point x="720" y="666" type="line"/>
+      <point x="723" y="666" type="line"/>
+      <point x="723" y="666" type="line"/>
       <point x="704" y="580" type="line"/>
       <point x="568" y="164" type="line" smooth="yes"/>
       <point x="514" y="0" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/G_ermandbls.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/G_ermandbls.glif
@@ -28,8 +28,8 @@
       <point x="1004" y="820" type="qcurve"/>
       <point x="1157" y="820"/>
       <point x="1427" y="596"/>
-      <point x="1427" y="407" type="qcurve"/>
-      <point x="1427" y="399" type="line"/>
+      <point x="1427" y="404" type="qcurve"/>
+      <point x="1427" y="404" type="line"/>
       <point x="1425" y="195"/>
       <point x="1164" y="-27"/>
       <point x="968" y="-27" type="qcurve"/>
@@ -50,8 +50,8 @@
       <point x="798" y="403" type="qcurve"/>
       <point x="841" y="403"/>
       <point x="889" y="440"/>
-      <point x="889" y="476" type="qcurve"/>
-      <point x="889" y="481" type="line"/>
+      <point x="889" y="479" type="qcurve"/>
+      <point x="889" y="479" type="line"/>
       <point x="889" y="518"/>
       <point x="825" y="558"/>
       <point x="768" y="558" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/M_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/M_.glif
@@ -19,14 +19,14 @@
       <point x="92" y="1432"/>
       <point x="437" y="1432" type="qcurve"/>
       <point x="437" y="1432" type="line"/>
-      <point x="765" y="1432"/>
-      <point x="765" y="1432" name="inserted"/>
+      <point x="778" y="1432"/>
+      <point x="778" y="1432" name="inserted"/>
       <point x="889" y="1178" type="qcurve" smooth="yes"/>
-      <point x="1075" y="753" type="line"/>
-      <point x="1077" y="753" type="line"/>
+      <point x="1076" y="751" type="line"/>
+      <point x="1076" y="751" type="line"/>
       <point x="1252" y="1178" type="line" smooth="yes"/>
-      <point x="1367" y="1432" name="inserted"/>
-      <point x="1367" y="1432"/>
+      <point x="1357" y="1432" name="inserted"/>
+      <point x="1357" y="1432"/>
       <point x="1696" y="1432" type="qcurve"/>
       <point x="1696" y="1432" type="line"/>
       <point x="2050" y="1432"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/N_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/N_.glif
@@ -16,7 +16,7 @@
       <point x="855" y="213" type="qcurve" smooth="yes"/>
       <point x="640" y="545" type="line"/>
       <point x="640" y="545" type="line"/>
-      <point x="640" y="547" type="line"/>
+      <point x="640" y="545" type="line"/>
       <point x="640" y="266" type="line"/>
       <point x="640" y="0" name="inserted"/>
       <point x="640" y="0"/>
@@ -31,10 +31,10 @@
       <point x="398" y="1432" type="qcurve"/>
       <point x="398" y="1432" type="line"/>
       <point x="638" y="1432"/>
-      <point x="638" y="1432" name="inserted"/>
+      <point x="637" y="1432" name="inserted"/>
       <point x="750" y="1234" type="qcurve" smooth="yes"/>
-      <point x="921" y="932" type="line"/>
-      <point x="923" y="932" type="line"/>
+      <point x="922" y="932" type="line"/>
+      <point x="922" y="932" type="line"/>
       <point x="922" y="932" type="line"/>
       <point x="922" y="1160" type="line"/>
       <point x="922" y="1432" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/V_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/V_.glif
@@ -23,8 +23,8 @@
       <point x="504" y="1432" name="inserted"/>
       <point x="557" y="1278" type="qcurve" smooth="yes"/>
       <point x="714" y="820" type="line"/>
-      <point x="744" y="735" type="line"/>
-      <point x="750" y="735" type="line"/>
+      <point x="747" y="726" type="line"/>
+      <point x="747" y="726" type="line"/>
       <point x="776" y="821" type="line"/>
       <point x="919" y="1293" type="line" smooth="yes"/>
       <point x="961" y="1432" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/W_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/W_.glif
@@ -15,8 +15,8 @@
       <point x="1256" y="0" name="inserted"/>
       <point x="1190" y="222" type="qcurve" smooth="yes"/>
       <point x="1082" y="588" type="line"/>
-      <point x="1067" y="660" type="line"/>
-      <point x="1065" y="660" type="line"/>
+      <point x="1066" y="662" type="line"/>
+      <point x="1066" y="662" type="line"/>
       <point x="1048" y="588" type="line"/>
       <point x="942" y="222" type="line" smooth="yes"/>
       <point x="878" y="0" name="inserted"/>
@@ -29,14 +29,14 @@
       <point x="48" y="1113" type="line" smooth="yes"/>
       <point x="-39" y="1432"/>
       <point x="-39" y="1432"/>
-      <point x="227" y="1432" type="qcurve"/>
-      <point x="227" y="1432" type="line"/>
+      <point x="245" y="1432" type="qcurve"/>
+      <point x="245" y="1432" type="line"/>
       <point x="529" y="1432"/>
       <point x="529" y="1432" name="inserted"/>
       <point x="574" y="1266" type="qcurve" smooth="yes"/>
       <point x="677" y="888" type="line"/>
-      <point x="691" y="822" type="line"/>
-      <point x="693" y="822" type="line"/>
+      <point x="692" y="818" type="line"/>
+      <point x="692" y="818" type="line"/>
       <point x="705" y="888" type="line"/>
       <point x="816" y="1251" type="line" smooth="yes"/>
       <point x="871" y="1432"/>
@@ -47,14 +47,14 @@
       <point x="1324" y="1432" name="inserted"/>
       <point x="1372" y="1251" type="qcurve" smooth="yes"/>
       <point x="1468" y="890" type="line"/>
-      <point x="1483" y="828" type="line"/>
-      <point x="1485" y="828" type="line"/>
+      <point x="1484" y="825" type="line"/>
+      <point x="1484" y="825" type="line"/>
       <point x="1498" y="890" type="line"/>
       <point x="1586" y="1270" type="line" smooth="yes"/>
       <point x="1623" y="1432" name="inserted"/>
       <point x="1623" y="1432"/>
-      <point x="1910" y="1432" type="qcurve"/>
-      <point x="1910" y="1432" type="line"/>
+      <point x="1895" y="1432" type="qcurve"/>
+      <point x="1895" y="1432" type="line"/>
       <point x="2168" y="1432"/>
       <point x="2168" y="1432"/>
       <point x="2087" y="1130" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/b.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/b.glif
@@ -10,9 +10,9 @@
       <point x="813" y="-16" type="qcurve" smooth="yes"/>
       <point x="726" y="-16"/>
       <point x="590" y="27"/>
-      <point x="545" y="74" type="qcurve"/>
-      <point x="543" y="75" type="line"/>
-      <point x="542" y="74" type="line"/>
+      <point x="542" y="75" type="qcurve"/>
+      <point x="542" y="75" type="line"/>
+      <point x="542" y="75" type="line"/>
       <point x="542" y="0" name="inserted"/>
       <point x="542" y="0"/>
       <point x="322" y="0" type="qcurve"/>
@@ -30,7 +30,7 @@
       <point x="576" y="1221" type="qcurve" smooth="yes"/>
       <point x="576" y="1038" type="line"/>
       <point x="576" y="1006" type="line"/>
-      <point x="582" y="1006" type="line"/>
+      <point x="576" y="1006" type="line"/>
       <point x="622" y="1034"/>
       <point x="728" y="1060"/>
       <point x="790" y="1060" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/braceleft.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/braceleft.glif
@@ -39,8 +39,8 @@
       <point x="678" y="853" type="line" smooth="yes"/>
       <point x="678" y="745"/>
       <point x="574" y="649"/>
-      <point x="468" y="621" type="qcurve"/>
-      <point x="468" y="611" type="line"/>
+      <point x="458" y="616" type="qcurve"/>
+      <point x="458" y="616" type="line"/>
       <point x="574" y="589"/>
       <point x="678" y="497"/>
       <point x="678" y="387" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/braceright.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/braceright.glif
@@ -25,8 +25,8 @@
       <point x="242" y="344" type="line" smooth="yes"/>
       <point x="242" y="452"/>
       <point x="346" y="548"/>
-      <point x="452" y="576" type="qcurve"/>
-      <point x="452" y="586" type="line"/>
+      <point x="462" y="581" type="qcurve"/>
+      <point x="462" y="581" type="line"/>
       <point x="346" y="608"/>
       <point x="242" y="700"/>
       <point x="242" y="810" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/caroncomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/caroncomb.glif
@@ -15,22 +15,22 @@
       <point x="-94" y="1484"/>
       <point x="-94" y="1484"/>
       <point x="0" y="1367" type="qcurve"/>
-      <point x="2" y="1367" type="line"/>
-      <point x="2" y="1367" type="line"/>
-      <point x="4" y="1367" type="line"/>
-      <point x="96" y="1484"/>
-      <point x="96" y="1484"/>
-      <point x="269" y="1484" type="qcurve"/>
-      <point x="269" y="1484" type="line"/>
-      <point x="432" y="1484"/>
-      <point x="432" y="1484"/>
-      <point x="432" y="1464" type="qcurve"/>
-      <point x="432" y="1464" type="line"/>
-      <point x="272" y="1259" type="line" smooth="yes"/>
-      <point x="183" y="1145"/>
-      <point x="183" y="1145"/>
-      <point x="2" y="1145" type="qcurve"/>
-      <point x="2" y="1145" type="line"/>
+      <point x="0" y="1367" type="line"/>
+      <point x="0" y="1367" type="line"/>
+      <point x="0" y="1367" type="line"/>
+      <point x="92" y="1484"/>
+      <point x="92" y="1484"/>
+      <point x="260" y="1484" type="qcurve"/>
+      <point x="260" y="1484" type="line"/>
+      <point x="428" y="1484"/>
+      <point x="428" y="1484"/>
+      <point x="428" y="1464" type="qcurve"/>
+      <point x="428" y="1464" type="line"/>
+      <point x="268" y="1259" type="line" smooth="yes"/>
+      <point x="179" y="1145"/>
+      <point x="179" y="1145"/>
+      <point x="0" y="1145" type="qcurve"/>
+      <point x="0" y="1145" type="line"/>
       <point x="-178" y="1145"/>
       <point x="-178" y="1145"/>
     </contour>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/circumflexcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/circumflexcomb.glif
@@ -5,34 +5,34 @@
   <anchor x="0" y="1484" name="top"/>
   <outline>
     <contour>
-      <point x="-430" y="1165" type="qcurve"/>
-      <point x="-430" y="1165" type="line"/>
-      <point x="-270" y="1370" type="line" smooth="yes"/>
-      <point x="-181" y="1484"/>
-      <point x="-181" y="1484"/>
+      <point x="-428" y="1165" type="qcurve"/>
+      <point x="-428" y="1165" type="line"/>
+      <point x="-268" y="1370" type="line" smooth="yes"/>
+      <point x="-179" y="1484"/>
+      <point x="-179" y="1484"/>
       <point x="0" y="1484" type="qcurve"/>
       <point x="0" y="1484" type="line"/>
-      <point x="180" y="1484"/>
-      <point x="180" y="1484"/>
-      <point x="270" y="1370" type="qcurve" smooth="yes"/>
-      <point x="432" y="1165" type="line"/>
-      <point x="432" y="1165" type="line"/>
-      <point x="432" y="1145"/>
-      <point x="432" y="1145"/>
-      <point x="264" y="1145" type="qcurve"/>
-      <point x="264" y="1145" type="line"/>
-      <point x="96" y="1145"/>
-      <point x="96" y="1145"/>
-      <point x="2" y="1262" type="qcurve"/>
+      <point x="178" y="1484"/>
+      <point x="178" y="1484"/>
+      <point x="268" y="1370" type="qcurve" smooth="yes"/>
+      <point x="430" y="1165" type="line"/>
+      <point x="430" y="1165" type="line"/>
+      <point x="430" y="1145"/>
+      <point x="430" y="1145"/>
+      <point x="262" y="1145" type="qcurve"/>
+      <point x="262" y="1145" type="line"/>
+      <point x="94" y="1145"/>
+      <point x="94" y="1145"/>
+      <point x="0" y="1262" type="qcurve"/>
       <point x="0" y="1262" type="line"/>
       <point x="0" y="1262" type="line"/>
-      <point x="-2" y="1262" type="line"/>
-      <point x="-94" y="1145"/>
-      <point x="-94" y="1145"/>
-      <point x="-267" y="1145" type="qcurve"/>
-      <point x="-267" y="1145" type="line"/>
-      <point x="-430" y="1145"/>
-      <point x="-430" y="1145"/>
+      <point x="0" y="1262" type="line"/>
+      <point x="-92" y="1145"/>
+      <point x="-92" y="1145"/>
+      <point x="-265" y="1145" type="qcurve"/>
+      <point x="-265" y="1145" type="line"/>
+      <point x="-428" y="1145"/>
+      <point x="-428" y="1145"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/comma.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/comma.glif
@@ -4,11 +4,11 @@
   <unicode hex="002C"/>
   <outline>
     <contour>
-      <point x="359" y="-171" type="line"/>
-      <point x="268" y="-305" name="inserted"/>
-      <point x="268" y="-305"/>
-      <point x="50" y="-158" type="qcurve"/>
-      <point x="50" y="-123" type="line"/>
+      <point x="405" y="-103" type="line" smooth="yes"/>
+      <point x="269" y="-305" name="inserted"/>
+      <point x="269" y="-305"/>
+      <point x="59" y="-164" type="qcurve"/>
+      <point x="59" y="-111" type="line"/>
       <point x="158" y="24" type="line"/>
       <point x="120" y="48"/>
       <point x="42" y="161"/>
@@ -19,9 +19,9 @@
       <point x="402" y="494"/>
       <point x="552" y="355"/>
       <point x="552" y="242" type="qcurve" smooth="yes"/>
-      <point x="552" y="160"/>
-      <point x="494" y="25"/>
-      <point x="439" y="-52" type="qcurve"/>
+      <point x="552" y="175"/>
+      <point x="512" y="55"/>
+      <point x="457" y="-26" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -4,24 +4,24 @@
   <anchor x="0" y="0" name="_bottom"/>
   <outline>
     <contour>
-      <point x="82" y="-505" type="line" smooth="yes"/>
-      <point x="-18" y="-654" name="inserted"/>
-      <point x="-18" y="-654"/>
-      <point x="-192" y="-535" type="qcurve"/>
-      <point x="-192" y="-523" type="line"/>
-      <point x="-106" y="-393" type="line"/>
-      <point x="-144" y="-373"/>
-      <point x="-198" y="-307"/>
-      <point x="-198" y="-241" type="qcurve" smooth="yes"/>
-      <point x="-198" y="-159"/>
-      <point x="-79" y="-49"/>
-      <point x="0" y="-49" type="qcurve" smooth="yes"/>
+      <point x="84" y="-501" type="line" smooth="yes"/>
+      <point x="-19" y="-654" name="inserted"/>
+      <point x="-19" y="-654"/>
+      <point x="-179" y="-547" type="qcurve"/>
+      <point x="-179" y="-507" type="line"/>
+      <point x="-107" y="-394" type="line"/>
+      <point x="-156" y="-363"/>
+      <point x="-197" y="-292"/>
+      <point x="-197" y="-239" type="qcurve" smooth="yes"/>
+      <point x="-197" y="-161"/>
+      <point x="-87" y="-49"/>
+      <point x="1" y="-49" type="qcurve" smooth="yes"/>
       <point x="82" y="-49"/>
-      <point x="199" y="-159"/>
-      <point x="199" y="-241" type="qcurve" smooth="yes"/>
-      <point x="199" y="-281"/>
-      <point x="172" y="-372"/>
-      <point x="142" y="-416" type="qcurve" smooth="yes"/>
+      <point x="198" y="-154"/>
+      <point x="198" y="-239" type="qcurve" smooth="yes"/>
+      <point x="198" y="-291"/>
+      <point x="165" y="-380"/>
+      <point x="123" y="-443" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/commaturnedabovecomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/commaturnedabovecomb.glif
@@ -5,24 +5,24 @@
   <anchor x="0" y="1702" name="top"/>
   <outline>
     <contour>
-      <point x="-82" y="1553" type="line" smooth="yes"/>
-      <point x="18" y="1702" name="inserted"/>
-      <point x="18" y="1702"/>
-      <point x="193" y="1583" type="qcurve"/>
-      <point x="193" y="1571" type="line"/>
-      <point x="107" y="1441" type="line"/>
-      <point x="145" y="1421"/>
-      <point x="198" y="1355"/>
-      <point x="198" y="1289" type="qcurve" smooth="yes"/>
-      <point x="198" y="1207"/>
-      <point x="80" y="1097"/>
-      <point x="1" y="1097" type="qcurve" smooth="yes"/>
-      <point x="-82" y="1097"/>
-      <point x="-198" y="1207"/>
-      <point x="-198" y="1289" type="qcurve" smooth="yes"/>
-      <point x="-198" y="1329"/>
-      <point x="-171" y="1420"/>
-      <point x="-142" y="1464" type="qcurve" smooth="yes"/>
+      <point x="-83" y="1549" type="line" smooth="yes"/>
+      <point x="20" y="1702" name="inserted"/>
+      <point x="20" y="1702"/>
+      <point x="180" y="1595" type="qcurve"/>
+      <point x="180" y="1555" type="line"/>
+      <point x="108" y="1442" type="line"/>
+      <point x="157" y="1411"/>
+      <point x="198" y="1340"/>
+      <point x="198" y="1287" type="qcurve" smooth="yes"/>
+      <point x="198" y="1209"/>
+      <point x="88" y="1097"/>
+      <point x="0" y="1097" type="qcurve" smooth="yes"/>
+      <point x="-81" y="1097"/>
+      <point x="-197" y="1202"/>
+      <point x="-197" y="1287" type="qcurve" smooth="yes"/>
+      <point x="-197" y="1339"/>
+      <point x="-164" y="1428"/>
+      <point x="-122" y="1491" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/d.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/d.glif
@@ -15,10 +15,10 @@
       <point x="1007" y="0" type="line"/>
       <point x="817" y="0"/>
       <point x="817" y="0" name="inserted"/>
-      <point x="817" y="112" type="qcurve"/>
-      <point x="812" y="112" type="line"/>
-      <point x="812" y="112" type="line"/>
-      <point x="779" y="67"/>
+      <point x="817" y="122" type="qcurve"/>
+      <point x="817" y="122" type="line"/>
+      <point x="817" y="122" type="line"/>
+      <point x="781" y="67"/>
       <point x="631" y="-14"/>
       <point x="508" y="-14" type="qcurve" smooth="yes"/>
       <point x="310" y="-14" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/f.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/f.glif
@@ -6,9 +6,9 @@
   <anchor x="472" y="1432" name="top"/>
   <outline>
     <contour>
-      <point x="608" y="241" type="line"/>
-      <point x="608" y="0" name="inserted"/>
-      <point x="608" y="0"/>
+      <point x="602" y="241" type="line"/>
+      <point x="602" y="0" name="inserted"/>
+      <point x="602" y="0"/>
       <point x="351" y="0" type="qcurve"/>
       <point x="351" y="0" type="line"/>
       <point x="98" y="0"/>
@@ -33,11 +33,11 @@
       <point x="677" y="1107" name="inserted"/>
       <point x="648" y="1120"/>
       <point x="634" y="1120" type="qcurve" smooth="yes"/>
-      <point x="617" y="1120"/>
-      <point x="597" y="1098"/>
-      <point x="597" y="1080" type="qcurve"/>
-      <point x="597" y="965" type="line"/>
-      <point x="608" y="935" type="line"/>
+      <point x="619.2972972972973" y="1120"/>
+      <point x="602" y="1098"/>
+      <point x="602" y="1080" type="qcurve"/>
+      <point x="602" y="965" type="line"/>
+      <point x="602" y="935" type="line"/>
     </contour>
     <contour>
       <point x="591" y="606" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/five.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/five.glif
@@ -18,8 +18,8 @@
       <point x="1010" y="986" name="inserted"/>
       <point x="821" y="986" type="qcurve"/>
       <point x="462" y="986" type="line"/>
-      <point x="444" y="873" type="line"/>
-      <point x="448" y="869" type="line"/>
+      <point x="446" y="871" type="line"/>
+      <point x="446" y="871" type="line"/>
       <point x="483" y="892" name="inserted"/>
       <point x="600" y="925"/>
       <point x="684" y="925" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/five.numerator.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/five.numerator.glif
@@ -17,9 +17,9 @@
       <point x="588" y="1200" name="inserted"/>
       <point x="468" y="1200" type="qcurve"/>
       <point x="274" y="1200" type="line"/>
-      <point x="267" y="1151" type="line"/>
-      <point x="269" y="1148" type="line"/>
-      <point x="289" y="1158" name="inserted"/>
+      <point x="266" y="1146" type="line"/>
+      <point x="266" y="1146" type="line"/>
+      <point x="288" y="1158" name="inserted"/>
       <point x="350" y="1170"/>
       <point x="395" y="1170" type="qcurve"/>
       <point x="395" y="1170" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/five.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/five.tf.glif
@@ -17,9 +17,9 @@
       <point x="1045" y="985" name="inserted"/>
       <point x="821" y="985" type="qcurve"/>
       <point x="462" y="985" type="line"/>
-      <point x="444" y="858" type="line"/>
-      <point x="448" y="854" type="line"/>
-      <point x="484" y="878" name="inserted"/>
+      <point x="443" y="850" type="line"/>
+      <point x="443" y="850" type="line"/>
+      <point x="484" y="879" name="inserted"/>
       <point x="600" y="910"/>
       <point x="684" y="910" type="qcurve"/>
       <point x="684" y="910" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/four.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/four.glif
@@ -4,8 +4,8 @@
   <unicode hex="0034"/>
   <outline>
     <contour>
-      <point x="581" y="217" type="qcurve"/>
-      <point x="584" y="420" type="line"/>
+      <point x="605" y="217" type="qcurve"/>
+      <point x="605" y="420" type="line"/>
       <point x="605" y="490" type="line"/>
       <point x="605" y="1347" type="line" smooth="yes"/>
       <point x="605" y="1447" name="inserted"/>
@@ -20,8 +20,8 @@
       <point x="1049" y="0"/>
       <point x="812" y="0" type="qcurve"/>
       <point x="812" y="0" type="line"/>
-      <point x="581" y="0"/>
-      <point x="581" y="0"/>
+      <point x="605" y="0"/>
+      <point x="605" y="0"/>
     </contour>
     <contour>
       <point x="217" y="194" type="line" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/four.numerator.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/four.numerator.glif
@@ -3,8 +3,8 @@
   <advance width="674"/>
   <outline>
     <contour>
-      <point x="325" y="800" type="qcurve"/>
-      <point x="325" y="906" type="line"/>
+      <point x="339" y="800" type="qcurve"/>
+      <point x="339" y="906" type="line"/>
       <point x="339" y="942" type="line"/>
       <point x="339" y="1440" type="line"/>
       <point x="350" y="1440" name="inserted"/>
@@ -19,8 +19,8 @@
       <point x="578" y="680"/>
       <point x="450" y="680" type="qcurve"/>
       <point x="450" y="680" type="line"/>
-      <point x="325" y="680"/>
-      <point x="325" y="680"/>
+      <point x="339" y="680"/>
+      <point x="339" y="680"/>
     </contour>
     <contour>
       <point x="129" y="788" type="line" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/four.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/four.tf.glif
@@ -3,8 +3,8 @@
   <advance width="1152"/>
   <outline>
     <contour>
-      <point x="581" y="217" type="qcurve"/>
-      <point x="584" y="420" type="line"/>
+      <point x="605" y="217" type="qcurve"/>
+      <point x="605" y="420" type="line"/>
       <point x="605" y="490" type="line"/>
       <point x="605" y="1347" type="line" smooth="yes"/>
       <point x="605" y="1447" name="inserted"/>
@@ -19,8 +19,8 @@
       <point x="1049" y="0"/>
       <point x="812" y="0" type="qcurve"/>
       <point x="812" y="0" type="line"/>
-      <point x="581" y="0"/>
-      <point x="581" y="0"/>
+      <point x="605" y="0"/>
+      <point x="605" y="0"/>
     </contour>
     <contour>
       <point x="217" y="194" type="line" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/germandbls.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/germandbls.glif
@@ -16,10 +16,10 @@
       <point x="1258" y="1099" type="qcurve"/>
       <point x="1258" y="1099" type="line"/>
       <point x="1258" y="971"/>
-      <point x="1069" y="800"/>
-      <point x="949" y="777" type="qcurve"/>
-      <point x="949" y="766" type="line"/>
-      <point x="1129" y="762"/>
+      <point x="1070" y="798"/>
+      <point x="919" y="770" type="qcurve"/>
+      <point x="919" y="770" type="line"/>
+      <point x="1130" y="763"/>
       <point x="1351" y="545"/>
       <point x="1351" y="401" type="qcurve"/>
       <point x="1351" y="401" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/h.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/h.glif
@@ -39,8 +39,8 @@
       <point x="558" y="1432" name="inserted"/>
       <point x="558" y="1213" type="qcurve" smooth="yes"/>
       <point x="558" y="1013" type="line"/>
-      <point x="558" y="902" type="line"/>
-      <point x="566" y="902" type="line"/>
+      <point x="558" y="891" type="line"/>
+      <point x="558" y="891" type="line"/>
       <point x="602" y="976"/>
       <point x="768" y="1060"/>
       <point x="882" y="1060" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/less.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/less.glif
@@ -16,8 +16,8 @@
       <point x="651" y="1002" type="line" smooth="yes"/>
       <point x="891" y="1117"/>
       <point x="891" y="1117"/>
-      <point x="891" y="908" type="qcurve"/>
-      <point x="891" y="908" type="line"/>
+      <point x="891" y="904" type="qcurve"/>
+      <point x="891" y="904" type="line"/>
       <point x="891" y="690"/>
       <point x="891" y="690" name="inserted"/>
       <point x="821" y="658" type="qcurve" smooth="yes"/>
@@ -26,8 +26,8 @@
       <point x="819" y="430" type="line" smooth="yes"/>
       <point x="892" y="399" name="inserted"/>
       <point x="892" y="399"/>
-      <point x="892" y="171" type="qcurve"/>
-      <point x="892" y="171" type="line"/>
+      <point x="892" y="192" type="qcurve"/>
+      <point x="892" y="192" type="line"/>
       <point x="892" y="-15"/>
       <point x="892" y="-15"/>
     </contour>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/m.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/m.glif
@@ -51,9 +51,9 @@
       <point x="322" y="1020" type="line"/>
       <point x="557" y="1020"/>
       <point x="557" y="1020" name="inserted"/>
-      <point x="557" y="902" type="qcurve"/>
-      <point x="557" y="902" type="line"/>
-      <point x="565" y="902" type="line"/>
+      <point x="557" y="892" type="qcurve"/>
+      <point x="557" y="892" type="line"/>
+      <point x="557" y="892" type="line"/>
       <point x="603" y="976"/>
       <point x="768" y="1060"/>
       <point x="882" y="1060" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/mu.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/mu.glif
@@ -47,15 +47,15 @@
       <point x="1038" y="-18" type="qcurve"/>
       <point x="958" y="-18"/>
       <point x="786" y="41" name="inserted"/>
-      <point x="752" y="118" type="qcurve"/>
-      <point x="744" y="118" type="line"/>
+      <point x="748" y="124" type="qcurve"/>
+      <point x="748" y="124" type="line"/>
       <point x="732" y="57"/>
       <point x="682" y="0"/>
       <point x="644" y="0" type="qcurve"/>
-      <point x="592" y="0"/>
-      <point x="556" y="57"/>
-      <point x="532" y="120" type="qcurve"/>
-      <point x="520" y="120" type="line"/>
+      <point x="599" y="0"/>
+      <point x="552" y="48"/>
+      <point x="526" y="124" type="qcurve"/>
+      <point x="526" y="124" type="line"/>
       <point x="576" y="-42" type="line"/>
       <point x="576" y="-199" type="line"/>
       <point x="576" y="-432" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/n.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/n.glif
@@ -36,9 +36,9 @@
       <point x="322" y="1020" type="line"/>
       <point x="558" y="1020"/>
       <point x="558" y="1020" name="inserted"/>
-      <point x="558" y="902" type="qcurve"/>
-      <point x="558" y="902" type="line"/>
-      <point x="565" y="902" type="line"/>
+      <point x="558" y="892" type="qcurve"/>
+      <point x="558" y="892" type="line"/>
+      <point x="558" y="892" type="line"/>
       <point x="601" y="976"/>
       <point x="768" y="1060"/>
       <point x="882" y="1060" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/one.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/one.tf.glif
@@ -6,8 +6,8 @@
       <point x="818" y="236" type="line" smooth="yes"/>
       <point x="818" y="0" name="inserted"/>
       <point x="818" y="0"/>
-      <point x="547" y="0" type="qcurve"/>
-      <point x="547" y="0" type="line"/>
+      <point x="557" y="0" type="qcurve"/>
+      <point x="557" y="0" type="line"/>
       <point x="294" y="0"/>
       <point x="294" y="0"/>
       <point x="294" y="236" type="qcurve"/>
@@ -23,8 +23,8 @@
       <point x="389" y="1369" type="line" smooth="yes"/>
       <point x="499" y="1447"/>
       <point x="499" y="1447"/>
-      <point x="580" y="1447" type="qcurve"/>
-      <point x="580" y="1447" type="line"/>
+      <point x="658" y="1447" type="qcurve"/>
+      <point x="658" y="1447" type="line"/>
       <point x="818" y="1447"/>
       <point x="818" y="1447" name="inserted"/>
       <point x="818" y="1214" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/p.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/p.glif
@@ -38,7 +38,7 @@
       <point x="601" y="19"/>
       <point x="576" y="35" type="qcurve"/>
       <point x="576" y="35" type="line"/>
-      <point x="576" y="4" type="line"/>
+      <point x="576" y="35" type="line"/>
     </contour>
     <contour>
       <point x="696" y="380" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/q.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/q.glif
@@ -14,9 +14,9 @@
       <point x="722" y="-432"/>
       <point x="722" y="-432" name="inserted"/>
       <point x="722" y="-197" type="qcurve" smooth="yes"/>
-      <point x="722" y="47" type="line"/>
-      <point x="722" y="47" type="line"/>
-      <point x="721" y="47" type="line"/>
+      <point x="722" y="48" type="line"/>
+      <point x="722" y="48" type="line"/>
+      <point x="722" y="48" type="line"/>
       <point x="697" y="26"/>
       <point x="588" y="-14"/>
       <point x="496" y="-14" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/r.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/r.glif
@@ -21,9 +21,9 @@
       <point x="322" y="1020" type="line"/>
       <point x="517" y="1020"/>
       <point x="517" y="1020" name="inserted"/>
-      <point x="517" y="904" type="qcurve"/>
-      <point x="517" y="904" type="line"/>
-      <point x="518" y="905" type="line"/>
+      <point x="517" y="903" type="qcurve"/>
+      <point x="517" y="903" type="line"/>
+      <point x="517" y="903" type="line"/>
       <point x="560" y="981"/>
       <point x="659" y="1037"/>
       <point x="719" y="1037" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/registered.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/registered.glif
@@ -58,17 +58,17 @@
       <point x="760" y="1074" type="qcurve"/>
       <point x="760" y="1026"/>
       <point x="717" y="963"/>
-      <point x="689" y="949" type="qcurve"/>
-      <point x="689" y="946" type="line"/>
-      <point x="729" y="896" type="line"/>
-      <point x="736" y="887" type="line" smooth="yes"/>
+      <point x="687" y="948" type="qcurve"/>
+      <point x="687" y="948" type="line"/>
+      <point x="751" y="868" type="line"/>
+      <point x="751" y="868" type="line"/>
       <point x="817" y="783"/>
       <point x="817" y="783"/>
       <point x="693" y="783" type="qcurve"/>
       <point x="693" y="783" type="line"/>
       <point x="586" y="783"/>
       <point x="586" y="783"/>
-      <point x="567" y="820" type="qcurve" smooth="yes"/>
+      <point x="549" y="854" type="qcurve" smooth="yes"/>
       <point x="529" y="894" type="line"/>
       <point x="523" y="894" type="line"/>
       <point x="523" y="873" type="line" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/semicolon.glif
@@ -18,12 +18,12 @@
       <point x="522" y="924"/>
     </contour>
     <contour>
-      <point x="399" y="-119" type="line" smooth="yes"/>
-      <point x="287" y="-299" name="inserted"/>
-      <point x="287" y="-299"/>
-      <point x="60" y="-143" type="qcurve"/>
-      <point x="60" y="-143" type="line"/>
-      <point x="187" y="35" type="line"/>
+      <point x="405" y="-109" type="line" smooth="yes"/>
+      <point x="277" y="-297" name="inserted"/>
+      <point x="277" y="-297"/>
+      <point x="84" y="-167" type="qcurve"/>
+      <point x="84" y="-117" type="line"/>
+      <point x="192" y="32" type="line"/>
       <point x="150" y="61"/>
       <point x="80" y="153"/>
       <point x="80" y="222" type="qcurve" smooth="yes"/>
@@ -33,9 +33,9 @@
       <point x="410" y="451"/>
       <point x="549" y="319"/>
       <point x="549" y="222" type="qcurve" smooth="yes"/>
-      <point x="549" y="174"/>
-      <point x="515" y="68"/>
-      <point x="481" y="13" type="qcurve" smooth="yes"/>
+      <point x="549" y="160"/>
+      <point x="513" y="50"/>
+      <point x="480" y="1" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/sterling.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/sterling.glif
@@ -48,8 +48,8 @@
       <point x="699" y="627" type="line"/>
       <point x="699" y="572"/>
       <point x="633" y="485"/>
-      <point x="587" y="450" type="qcurve"/>
-      <point x="593" y="442" type="line"/>
+      <point x="574" y="440" type="qcurve"/>
+      <point x="574" y="440" type="line"/>
       <point x="794" y="440" type="line"/>
       <point x="893" y="440"/>
       <point x="1018" y="474"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/three.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/three.glif
@@ -44,8 +44,8 @@
       <point x="1030" y="1108" type="line"/>
       <point x="1030" y="1000" name="inserted"/>
       <point x="930" y="840"/>
-      <point x="830" y="804" type="qcurve"/>
-      <point x="830" y="796" type="line"/>
+      <point x="823" y="800" type="qcurve"/>
+      <point x="823" y="800" type="line"/>
       <point x="948" y="772"/>
       <point x="1094" y="584"/>
       <point x="1094" y="456" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/three.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/three.tf.glif
@@ -43,8 +43,8 @@
       <point x="1030" y="1108" type="line"/>
       <point x="1030" y="1000" name="inserted"/>
       <point x="930" y="840"/>
-      <point x="830" y="804" type="qcurve"/>
-      <point x="830" y="796" type="line"/>
+      <point x="822" y="800" type="qcurve"/>
+      <point x="822" y="800" type="line"/>
       <point x="948" y="772"/>
       <point x="1094" y="584"/>
       <point x="1094" y="456" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/u.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/u.glif
@@ -42,10 +42,10 @@
       <point x="980" y="0" type="line"/>
       <point x="744" y="0"/>
       <point x="744" y="0" name="inserted"/>
-      <point x="744" y="118" type="qcurve"/>
-      <point x="744" y="118" type="line"/>
-      <point x="736" y="118" type="line"/>
-      <point x="700" y="44"/>
+      <point x="744" y="131" type="qcurve"/>
+      <point x="744" y="131" type="line"/>
+      <point x="744" y="131" type="line"/>
+      <point x="701" y="43"/>
       <point x="534" y="-40"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/v.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/v.glif
@@ -23,8 +23,8 @@
       <point x="438" y="1020" name="inserted"/>
       <point x="483" y="890" type="qcurve" smooth="yes"/>
       <point x="548" y="702" type="line"/>
-      <point x="604" y="516" type="line"/>
-      <point x="610" y="516" type="line"/>
+      <point x="607" y="509" type="line"/>
+      <point x="607" y="509" type="line"/>
       <point x="664" y="702" type="line"/>
       <point x="733" y="896" type="line" smooth="yes"/>
       <point x="777" y="1020" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/w.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/w.glif
@@ -15,8 +15,8 @@
       <point x="962" y="0"/>
       <point x="900" y="202" type="qcurve" smooth="yes"/>
       <point x="866" y="315" type="line"/>
-      <point x="848" y="384" type="line"/>
-      <point x="841" y="384" type="line"/>
+      <point x="844" y="390" type="line"/>
+      <point x="844" y="390" type="line"/>
       <point x="824" y="315" type="line"/>
       <point x="791" y="204" type="line" smooth="yes"/>
       <point x="729" y="0" name="inserted"/>
@@ -35,8 +35,8 @@
       <point x="445" y="1020" name="inserted"/>
       <point x="481" y="873" type="qcurve" smooth="yes"/>
       <point x="535" y="651" type="line"/>
-      <point x="554" y="566" type="line"/>
-      <point x="556" y="566" type="line"/>
+      <point x="555" y="562" type="line"/>
+      <point x="555" y="562" type="line"/>
       <point x="575" y="650" type="line"/>
       <point x="618" y="856" type="line" smooth="yes"/>
       <point x="652" y="1020" name="inserted"/>
@@ -47,8 +47,8 @@
       <point x="1085" y="1020"/>
       <point x="1123" y="858" type="qcurve" smooth="yes"/>
       <point x="1170" y="650" type="line"/>
-      <point x="1190" y="566" type="line"/>
-      <point x="1197" y="566" type="line"/>
+      <point x="1194" y="562" type="line"/>
+      <point x="1194" y="562" type="line"/>
       <point x="1215" y="649" type="line"/>
       <point x="1267" y="892" type="line" smooth="yes"/>
       <point x="1294" y="1020" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/y.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/y.glif
@@ -11,20 +11,20 @@
       <point x="45" y="727" type="line" smooth="yes"/>
       <point x="-88" y="1020"/>
       <point x="-88" y="1020"/>
-      <point x="168" y="1020" type="qcurve"/>
-      <point x="168" y="1020" type="line"/>
+      <point x="177" y="1020" type="qcurve"/>
+      <point x="177" y="1020" type="line"/>
       <point x="442" y="1020"/>
       <point x="442" y="1020" name="inserted"/>
       <point x="486" y="890" type="qcurve" smooth="yes"/>
       <point x="602" y="544" type="line"/>
-      <point x="606" y="534" type="line"/>
-      <point x="607" y="534" type="line"/>
+      <point x="606" y="531" type="line"/>
+      <point x="606" y="531" type="line"/>
       <point x="610" y="544" type="line"/>
       <point x="736" y="896" type="line" smooth="yes"/>
       <point x="780" y="1020" name="inserted"/>
       <point x="780" y="1020"/>
-      <point x="1042" y="1020" type="qcurve"/>
-      <point x="1042" y="1020" type="line"/>
+      <point x="1034" y="1020" type="qcurve"/>
+      <point x="1034" y="1020" type="line"/>
       <point x="1287" y="1020"/>
       <point x="1287" y="1020"/>
       <point x="1161" y="739" type="qcurve" smooth="yes"/>
@@ -33,8 +33,8 @@
       <point x="681" y="-356" type="line"/>
       <point x="647" y="-432"/>
       <point x="647" y="-432"/>
-      <point x="365" y="-432" type="qcurve"/>
-      <point x="365" y="-432" type="line"/>
+      <point x="386" y="-432" type="qcurve"/>
+      <point x="386" y="-432" type="line"/>
       <point x="129" y="-432"/>
       <point x="129" y="-432" name="inserted"/>
       <point x="304" y="-94" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/yen.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/yen.glif
@@ -15,8 +15,8 @@
       <point x="597" y="1432"/>
       <point x="664" y="1278" type="qcurve" smooth="yes"/>
       <point x="762" y="1054" type="line"/>
-      <point x="792" y="984" type="line"/>
-      <point x="807" y="984" type="line"/>
+      <point x="800" y="969" type="line"/>
+      <point x="800" y="969" type="line"/>
       <point x="846" y="1058" type="line"/>
       <point x="971" y="1293" type="line" smooth="yes"/>
       <point x="1045" y="1432"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/G_ermandbls.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/G_ermandbls.glif
@@ -28,8 +28,8 @@
       <point x="789" y="810" type="qcurve"/>
       <point x="1012" y="810"/>
       <point x="1252" y="601"/>
-      <point x="1252" y="407" type="qcurve"/>
-      <point x="1252" y="399" type="line"/>
+      <point x="1252" y="403" type="qcurve"/>
+      <point x="1252" y="403" type="line"/>
       <point x="1250" y="195"/>
       <point x="1006" y="-27"/>
       <point x="823" y="-27" type="qcurve"/>
@@ -50,8 +50,8 @@
       <point x="833" y="111" type="qcurve"/>
       <point x="962" y="111"/>
       <point x="1104" y="250"/>
-      <point x="1104" y="391" type="qcurve"/>
-      <point x="1104" y="396" type="line"/>
+      <point x="1104" y="394" type="qcurve"/>
+      <point x="1104" y="394" type="line"/>
       <point x="1103" y="534"/>
       <point x="936" y="683"/>
       <point x="783" y="683" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/Y_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/Y_.glif
@@ -28,8 +28,8 @@
       <point x="118" y="1432" name="inserted"/>
       <point x="157" y="1367" type="qcurve"/>
       <point x="449" y="890" type="line"/>
-      <point x="502" y="801" type="line"/>
-      <point x="504" y="801" type="line"/>
+      <point x="503" y="801" type="line"/>
+      <point x="503" y="801" type="line"/>
       <point x="555" y="887" type="line"/>
       <point x="846" y="1367" type="line"/>
       <point x="886" y="1432" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/a.alt.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/a.alt.glif
@@ -27,8 +27,8 @@
       <point x="934" y="0"/>
       <point x="934" y="0" name="inserted"/>
       <point x="934" y="70" type="qcurve"/>
-      <point x="934" y="150" type="line"/>
-      <point x="930" y="150" type="line"/>
+      <point x="934" y="156" type="line"/>
+      <point x="934" y="156" type="line"/>
       <point x="884" y="68"/>
       <point x="690" y="-32"/>
       <point x="574" y="-32" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/a.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/a.glif
@@ -14,9 +14,9 @@
       <point x="856" y="0" type="line"/>
       <point x="790" y="0"/>
       <point x="790" y="0"/>
-      <point x="790" y="71" type="qcurve"/>
+      <point x="790" y="136" type="qcurve"/>
       <point x="790" y="136" type="line"/>
-      <point x="786" y="136" type="line"/>
+      <point x="790" y="136" type="line"/>
       <point x="736" y="70"/>
       <point x="552" y="-14"/>
       <point x="454" y="-14" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/braceleft.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/braceleft.glif
@@ -39,8 +39,8 @@
       <point x="363" y="842" type="line"/>
       <point x="363" y="748"/>
       <point x="299" y="636"/>
-      <point x="229" y="612" type="qcurve"/>
-      <point x="229" y="604" type="line"/>
+      <point x="219" y="608" type="qcurve"/>
+      <point x="219" y="608" type="line"/>
       <point x="296" y="578"/>
       <point x="359" y="468"/>
       <point x="359" y="374" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/braceright.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/braceright.glif
@@ -25,8 +25,8 @@
       <point x="295" y="374" type="line" smooth="yes"/>
       <point x="295" y="468"/>
       <point x="358" y="578"/>
-      <point x="425" y="604" type="qcurve"/>
-      <point x="425" y="612" type="line"/>
+      <point x="435" y="608" type="qcurve"/>
+      <point x="435" y="608" type="line"/>
       <point x="355" y="636"/>
       <point x="291" y="748"/>
       <point x="291" y="842" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/caroncomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/caroncomb.glif
@@ -1,39 +1,38 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="caroncomb" format="2">
   <unicode hex="030C"/>
-  <guideline x="0" y="0" angle="90" identifier="3jB8PUTLga"/>
   <anchor x="0" y="1020" name="_top"/>
   <anchor x="0" y="1432" name="top"/>
   <outline>
     <contour>
-      <point x="-118" y="1240" type="qcurve" smooth="yes"/>
-      <point x="-248" y="1408" type="line"/>
-      <point x="-258" y="1421" type="line"/>
-      <point x="-258" y="1432"/>
-      <point x="-258" y="1432"/>
-      <point x="-184" y="1432" type="qcurve"/>
-      <point x="-184" y="1432" type="line"/>
-      <point x="-129" y="1432"/>
-      <point x="-129" y="1432" name="inserted"/>
-      <point x="-88" y="1379" type="qcurve" smooth="yes"/>
-      <point x="-4" y="1269" type="line"/>
-      <point x="7" y="1269" type="line"/>
-      <point x="83" y="1371" type="line" smooth="yes"/>
-      <point x="129" y="1432" name="inserted"/>
-      <point x="129" y="1432"/>
-      <point x="176" y="1432" type="qcurve"/>
-      <point x="176" y="1432" type="line"/>
-      <point x="259" y="1432"/>
-      <point x="259" y="1432"/>
-      <point x="259" y="1421" type="qcurve"/>
-      <point x="249" y="1408" type="line"/>
-      <point x="120" y="1240" type="line" smooth="yes"/>
-      <point x="65" y="1169" name="inserted"/>
-      <point x="65" y="1169"/>
-      <point x="1" y="1169" type="qcurve"/>
-      <point x="1" y="1169" type="line"/>
-      <point x="-63" y="1169"/>
-      <point x="-63" y="1169"/>
+      <point x="-114" y="1240" type="qcurve" smooth="yes"/>
+      <point x="-244" y="1408" type="line"/>
+      <point x="-254" y="1421" type="line"/>
+      <point x="-254" y="1432"/>
+      <point x="-254" y="1432"/>
+      <point x="-191" y="1432" type="qcurve"/>
+      <point x="-191" y="1432" type="line"/>
+      <point x="-124" y="1432"/>
+      <point x="-124" y="1432" name="inserted"/>
+      <point x="0" y="1269" type="qcurve"/>
+      <point x="0" y="1269" type="line"/>
+      <point x="0" y="1269" type="line"/>
+      <point x="0" y="1269" type="line"/>
+      <point x="122" y="1432" name="inserted"/>
+      <point x="122" y="1432"/>
+      <point x="187" y="1432" type="qcurve"/>
+      <point x="187" y="1432" type="line"/>
+      <point x="252" y="1432"/>
+      <point x="252" y="1432"/>
+      <point x="252" y="1421" type="qcurve"/>
+      <point x="242" y="1408" type="line"/>
+      <point x="113" y="1240" type="line" smooth="yes"/>
+      <point x="58" y="1169" name="inserted"/>
+      <point x="58" y="1169"/>
+      <point x="0" y="1169" type="qcurve"/>
+      <point x="0" y="1169" type="line"/>
+      <point x="-59" y="1169"/>
+      <point x="-59" y="1169"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/circumflexcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/circumflexcomb.glif
@@ -5,34 +5,34 @@
   <anchor x="0" y="1432" name="top"/>
   <outline>
     <contour>
-      <point x="-258" y="1180" type="qcurve"/>
-      <point x="-248" y="1193" type="line"/>
-      <point x="-119" y="1361" type="line" smooth="yes"/>
-      <point x="-64" y="1432" name="inserted"/>
-      <point x="-64" y="1432"/>
+      <point x="-252" y="1180" type="qcurve"/>
+      <point x="-242" y="1193" type="line"/>
+      <point x="-113" y="1361" type="line" smooth="yes"/>
+      <point x="-58" y="1432" name="inserted"/>
+      <point x="-58" y="1432"/>
       <point x="0" y="1432" type="qcurve"/>
       <point x="0" y="1432" type="line"/>
-      <point x="64" y="1432"/>
-      <point x="64" y="1432"/>
-      <point x="119" y="1361" type="qcurve" smooth="yes"/>
-      <point x="249" y="1193" type="line"/>
-      <point x="259" y="1180" type="line"/>
-      <point x="259" y="1169"/>
-      <point x="259" y="1169"/>
-      <point x="185" y="1169" type="qcurve"/>
-      <point x="185" y="1169" type="line"/>
-      <point x="130" y="1169"/>
-      <point x="130" y="1169" name="inserted"/>
-      <point x="89" y="1222" type="qcurve" smooth="yes"/>
-      <point x="5" y="1332" type="line"/>
-      <point x="-6" y="1332" type="line"/>
-      <point x="-82" y="1230" type="line" smooth="yes"/>
-      <point x="-128" y="1169" name="inserted"/>
-      <point x="-128" y="1169"/>
-      <point x="-175" y="1169" type="qcurve"/>
-      <point x="-175" y="1169" type="line"/>
-      <point x="-258" y="1169"/>
-      <point x="-258" y="1169"/>
+      <point x="59" y="1432"/>
+      <point x="59" y="1432"/>
+      <point x="114" y="1361" type="qcurve" smooth="yes"/>
+      <point x="244" y="1193" type="line"/>
+      <point x="254" y="1180" type="line"/>
+      <point x="254" y="1169"/>
+      <point x="254" y="1169"/>
+      <point x="189" y="1169" type="qcurve"/>
+      <point x="189" y="1169" type="line"/>
+      <point x="124" y="1169"/>
+      <point x="124" y="1169" name="inserted"/>
+      <point x="0" y="1332" type="qcurve"/>
+      <point x="0" y="1332" type="line"/>
+      <point x="0" y="1332" type="line"/>
+      <point x="0" y="1332" type="line"/>
+      <point x="-122" y="1169" name="inserted"/>
+      <point x="-122" y="1169"/>
+      <point x="-187" y="1169" type="qcurve"/>
+      <point x="-187" y="1169" type="line"/>
+      <point x="-252" y="1169"/>
+      <point x="-252" y="1169"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/d.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/d.glif
@@ -16,8 +16,8 @@
       <point x="934" y="0"/>
       <point x="934" y="0" name="inserted"/>
       <point x="934" y="70" type="qcurve"/>
-      <point x="934" y="150" type="line"/>
-      <point x="930" y="150" type="line"/>
+      <point x="934" y="157" type="line"/>
+      <point x="934" y="157" type="line"/>
       <point x="884" y="68"/>
       <point x="690" y="-32"/>
       <point x="574" y="-32" type="qcurve" smooth="yes"/>
@@ -30,9 +30,9 @@
       <point x="572" y="1044" type="qcurve" smooth="yes"/>
       <point x="688" y="1044"/>
       <point x="892" y="942"/>
-      <point x="930" y="870" type="qcurve"/>
-      <point x="930" y="870" type="line"/>
-      <point x="930" y="870" type="line"/>
+      <point x="932" y="865" type="qcurve"/>
+      <point x="932" y="865" type="line"/>
+      <point x="932" y="865" type="line"/>
       <point x="932" y="1365" type="line"/>
       <point x="932" y="1432" name="inserted"/>
       <point x="932" y="1432"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/five.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/five.glif
@@ -19,7 +19,7 @@
       <point x="816" y="1293" type="qcurve"/>
       <point x="300" y="1293" type="line"/>
       <point x="234" y="778" type="line"/>
-      <point x="240" y="776" type="line"/>
+      <point x="234" y="778" type="line"/>
       <point x="280" y="834"/>
       <point x="438" y="904"/>
       <point x="538" y="904" type="qcurve"/>
@@ -38,8 +38,8 @@
       <point x="54" y="305" type="line"/>
       <point x="38" y="371" name="inserted"/>
       <point x="38" y="371"/>
-      <point x="103" y="394" type="qcurve"/>
-      <point x="103" y="394" type="line"/>
+      <point x="108" y="393" type="qcurve"/>
+      <point x="108" y="393" type="line"/>
       <point x="177" y="416"/>
       <point x="177" y="416"/>
       <point x="192" y="344" type="qcurve"/>
@@ -57,11 +57,11 @@
       <point x="502" y="764" type="qcurve"/>
       <point x="502" y="764" type="line"/>
       <point x="417" y="764"/>
-      <point x="306" y="718"/>
-      <point x="277" y="686" type="qcurve"/>
-      <point x="277" y="686" type="line"/>
-      <point x="221" y="622"/>
-      <point x="221" y="622"/>
+      <point x="309" y="722"/>
+      <point x="265" y="672" type="qcurve"/>
+      <point x="265" y="672" type="line"/>
+      <point x="222" y="621"/>
+      <point x="222" y="621"/>
       <point x="161" y="648" type="qcurve"/>
       <point x="161" y="648" type="line"/>
       <point x="98" y="674"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/five.numerator.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/five.numerator.glif
@@ -17,8 +17,8 @@
       <point x="535" y="1322" name="inserted"/>
       <point x="486" y="1322" type="qcurve"/>
       <point x="256" y="1322" type="line"/>
-      <point x="227" y="1126" type="line"/>
-      <point x="230" y="1125" type="line"/>
+      <point x="226" y="1121" type="line"/>
+      <point x="226" y="1121" type="line"/>
       <point x="247" y="1145"/>
       <point x="319" y="1169"/>
       <point x="361" y="1169" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/five.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/five.tf.glif
@@ -17,8 +17,8 @@
       <point x="955" y="1293" name="inserted"/>
       <point x="886" y="1293" type="qcurve"/>
       <point x="370" y="1293" type="line"/>
-      <point x="304" y="778" type="line"/>
-      <point x="310" y="776" type="line"/>
+      <point x="304" y="769" type="line"/>
+      <point x="304" y="769" type="line"/>
       <point x="350" y="834"/>
       <point x="508" y="904"/>
       <point x="608" y="904" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/four.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/four.glif
@@ -27,10 +27,10 @@
       <point x="137" y="328" type="line"/>
       <point x="46" y="328" name="inserted"/>
       <point x="46" y="328"/>
-      <point x="46" y="410" type="qcurve"/>
-      <point x="46" y="410" type="line"/>
-      <point x="46" y="434"/>
-      <point x="47" y="434"/>
+      <point x="46" y="380" type="qcurve"/>
+      <point x="46" y="380" type="line"/>
+      <point x="46" y="433"/>
+      <point x="46" y="433"/>
       <point x="114" y="536" type="qcurve" smooth="yes"/>
       <point x="683" y="1403" type="line" smooth="yes"/>
       <point x="702" y="1432" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/four.numerator.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/four.numerator.glif
@@ -3,8 +3,8 @@
   <advance width="620"/>
   <outline>
     <contour>
-      <point x="330" y="738" type="qcurve"/>
-      <point x="330" y="886" type="line"/>
+      <point x="331" y="738" type="qcurve"/>
+      <point x="331" y="886" type="line"/>
       <point x="331" y="895" type="line"/>
       <point x="331" y="1399" type="line"/>
       <point x="337" y="1407" name="inserted"/>
@@ -19,8 +19,8 @@
       <point x="446" y="685"/>
       <point x="390" y="685" type="qcurve"/>
       <point x="390" y="685" type="line"/>
-      <point x="330" y="685"/>
-      <point x="330" y="685" name="inserted"/>
+      <point x="331" y="685"/>
+      <point x="331" y="685" name="inserted"/>
     </contour>
     <contour>
       <point x="63" y="856" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/germandbls.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/germandbls.glif
@@ -17,9 +17,9 @@
       <point x="1033" y="1101" type="line"/>
       <point x="1033" y="967"/>
       <point x="826" y="789"/>
-      <point x="665" y="780" type="qcurve"/>
-      <point x="665" y="778" type="line"/>
-      <point x="888" y="765.9674796747968"/>
+      <point x="658" y="779" type="qcurve"/>
+      <point x="658" y="779" type="line"/>
+      <point x="888" y="766"/>
       <point x="1128" y="570.439024390244"/>
       <point x="1128" y="408" type="qcurve"/>
       <point x="1128" y="408" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/greater.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/greater.glif
@@ -4,32 +4,32 @@
   <unicode hex="003E"/>
   <outline>
     <contour>
-      <point x="158" y="174" type="line" smooth="yes"/>
-      <point x="80" y="138"/>
-      <point x="80" y="138"/>
-      <point x="80" y="206" type="qcurve"/>
-      <point x="80" y="206" type="line"/>
-      <point x="80" y="280"/>
-      <point x="80" y="280" name="inserted"/>
-      <point x="138" y="306" type="qcurve" smooth="yes"/>
-      <point x="675" y="544" type="line"/>
-      <point x="675" y="547" type="line"/>
-      <point x="134" y="788" type="line" smooth="yes"/>
-      <point x="80" y="812" name="inserted"/>
-      <point x="80" y="812"/>
-      <point x="80" y="888" type="qcurve"/>
-      <point x="80" y="888" type="line"/>
-      <point x="80" y="954"/>
-      <point x="80" y="954"/>
-      <point x="157" y="917" type="qcurve" smooth="yes"/>
-      <point x="792" y="616" type="line" smooth="yes"/>
-      <point x="842" y="592" name="inserted"/>
-      <point x="842" y="592"/>
+      <point x="158" y="176" type="line" smooth="yes"/>
+      <point x="80" y="140"/>
+      <point x="80" y="140"/>
+      <point x="80" y="211" type="qcurve"/>
+      <point x="80" y="211" type="line"/>
+      <point x="80" y="282"/>
+      <point x="80" y="282" name="inserted"/>
+      <point x="138" y="308" type="qcurve" smooth="yes"/>
+      <point x="675" y="546" type="line"/>
+      <point x="675" y="546" type="line"/>
+      <point x="134" y="787" type="line" smooth="yes"/>
+      <point x="80" y="811" name="inserted"/>
+      <point x="80" y="811"/>
+      <point x="80" y="882" type="qcurve"/>
+      <point x="80" y="882" type="line"/>
+      <point x="80" y="953"/>
+      <point x="80" y="953"/>
+      <point x="157" y="916" type="qcurve" smooth="yes"/>
+      <point x="792" y="615" type="line" smooth="yes"/>
+      <point x="842" y="591" name="inserted"/>
+      <point x="842" y="591"/>
       <point x="842" y="540" type="qcurve"/>
       <point x="842" y="540" type="line"/>
-      <point x="842" y="492"/>
-      <point x="842" y="492"/>
-      <point x="791" y="468" type="qcurve" smooth="yes"/>
+      <point x="842" y="494"/>
+      <point x="842" y="494"/>
+      <point x="791" y="470" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/less.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/less.glif
@@ -4,32 +4,32 @@
   <unicode hex="003C"/>
   <outline>
     <contour>
-      <point x="764" y="174" type="qcurve" smooth="yes"/>
-      <point x="131" y="468" type="line" smooth="yes"/>
-      <point x="80" y="492"/>
-      <point x="80" y="492"/>
+      <point x="764" y="176" type="qcurve" smooth="yes"/>
+      <point x="131" y="470" type="line" smooth="yes"/>
+      <point x="80" y="494"/>
+      <point x="80" y="494"/>
       <point x="80" y="540" type="qcurve"/>
       <point x="80" y="540" type="line"/>
-      <point x="80" y="592"/>
-      <point x="80" y="592" name="inserted"/>
-      <point x="130" y="616" type="qcurve" smooth="yes"/>
-      <point x="765" y="917" type="line" smooth="yes"/>
-      <point x="842" y="954"/>
-      <point x="842" y="954"/>
-      <point x="842" y="888" type="qcurve"/>
-      <point x="842" y="888" type="line"/>
-      <point x="842" y="812"/>
-      <point x="842" y="812" name="inserted"/>
-      <point x="788" y="788" type="qcurve" smooth="yes"/>
-      <point x="247" y="547" type="line"/>
-      <point x="247" y="544" type="line"/>
-      <point x="782" y="307" type="line" smooth="yes"/>
-      <point x="842" y="281" name="inserted"/>
-      <point x="842" y="281"/>
-      <point x="842" y="206" type="qcurve"/>
-      <point x="842" y="206" type="line"/>
-      <point x="842" y="138"/>
-      <point x="842" y="138"/>
+      <point x="80" y="591"/>
+      <point x="80" y="591" name="inserted"/>
+      <point x="130" y="615" type="qcurve" smooth="yes"/>
+      <point x="765" y="916" type="line" smooth="yes"/>
+      <point x="842" y="953"/>
+      <point x="842" y="953"/>
+      <point x="842" y="887" type="qcurve"/>
+      <point x="842" y="887" type="line"/>
+      <point x="842" y="811"/>
+      <point x="842" y="811" name="inserted"/>
+      <point x="788" y="787" type="qcurve" smooth="yes"/>
+      <point x="247" y="546" type="line"/>
+      <point x="247" y="546" type="line"/>
+      <point x="782" y="309" type="line" smooth="yes"/>
+      <point x="842" y="283" name="inserted"/>
+      <point x="842" y="283"/>
+      <point x="842" y="208" type="qcurve"/>
+      <point x="842" y="208" type="line"/>
+      <point x="842" y="140"/>
+      <point x="842" y="140"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/mu.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/mu.glif
@@ -47,15 +47,15 @@
       <point x="1076" y="-22" type="qcurve"/>
       <point x="1000" y="-22"/>
       <point x="885" y="79"/>
-      <point x="878" y="241" type="qcurve"/>
-      <point x="875" y="241" type="line"/>
+      <point x="877" y="247" type="qcurve"/>
+      <point x="877" y="247" type="line"/>
       <point x="859" y="156"/>
       <point x="700" y="-22"/>
       <point x="555" y="-22" type="qcurve"/>
       <point x="440" y="-22"/>
       <point x="289" y="88"/>
-      <point x="276" y="174" type="qcurve"/>
-      <point x="273" y="174" type="line"/>
+      <point x="274" y="180" type="qcurve"/>
+      <point x="274" y="180" type="line"/>
       <point x="278" y="10" type="line"/>
       <point x="278" y="-365" type="line"/>
       <point x="278" y="-432" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/nine.glif
@@ -35,9 +35,9 @@
       <point x="611" y="482"/>
       <point x="637" y="520" type="qcurve"/>
       <point x="652" y="542" type="line"/>
-      <point x="646" y="549" type="line"/>
-      <point x="632" y="541"/>
-      <point x="597" y="520"/>
+      <point x="652" y="542" type="line"/>
+      <point x="619" y="529"/>
+      <point x="567" y="520"/>
       <point x="506" y="520" type="qcurve"/>
       <point x="506" y="520" type="line"/>
       <point x="308" y="520"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/nine.tf.glif
@@ -33,10 +33,10 @@
       <point x="524" y="355"/>
       <point x="611" y="482"/>
       <point x="637" y="520" type="qcurve"/>
-      <point x="652" y="542" type="line"/>
-      <point x="646" y="549" type="line"/>
-      <point x="632" y="541"/>
-      <point x="597" y="520"/>
+      <point x="661" y="556" type="line"/>
+      <point x="661" y="556" type="line"/>
+      <point x="633" y="537"/>
+      <point x="558" y="520"/>
       <point x="506" y="520" type="qcurve"/>
       <point x="506" y="520" type="line"/>
       <point x="308" y="520"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/one.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/one.tf.glif
@@ -14,17 +14,17 @@
       <point x="618" y="1258" type="line"/>
       <point x="237" y="1011" type="line" smooth="yes"/>
       <point x="190" y="981" name="inserted"/>
-      <point x="190" y="982"/>
-      <point x="155" y="1039" type="qcurve"/>
-      <point x="155" y="1039" type="line"/>
-      <point x="117" y="1097"/>
+      <point x="190" y="981"/>
+      <point x="154" y="1039" type="qcurve"/>
+      <point x="154" y="1039" type="line"/>
+      <point x="119" y="1096"/>
       <point x="119" y="1096"/>
       <point x="169" y="1128" type="qcurve" smooth="yes"/>
       <point x="568" y="1381" type="line" smooth="yes"/>
       <point x="654" y="1436"/>
       <point x="654" y="1436"/>
-      <point x="694" y="1436" type="qcurve"/>
-      <point x="694" y="1436" type="line"/>
+      <point x="705" y="1436" type="qcurve"/>
+      <point x="705" y="1436" type="line"/>
       <point x="758" y="1436"/>
       <point x="758" y="1436" name="inserted"/>
       <point x="758" y="1368" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/ordfeminine.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/ordfeminine.glif
@@ -60,8 +60,8 @@
       <point x="714" y="560"/>
       <point x="714" y="560"/>
       <point x="714" y="613" type="qcurve"/>
-      <point x="714" y="769" type="line"/>
-      <point x="708" y="769" type="line"/>
+      <point x="714" y="779" type="line"/>
+      <point x="714" y="779" type="line"/>
       <point x="695" y="685"/>
       <point x="537" y="548"/>
     </contour>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/q.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/q.glif
@@ -28,9 +28,9 @@
       <point x="348" y="1044"/>
       <point x="570" y="1044" type="qcurve" smooth="yes"/>
       <point x="684" y="1044"/>
-      <point x="890" y="940"/>
-      <point x="928" y="872" type="qcurve"/>
-      <point x="932" y="872" type="line"/>
+      <point x="891" y="940"/>
+      <point x="932" y="865" type="qcurve"/>
+      <point x="932" y="865" type="line"/>
       <point x="932" y="950" type="line" smooth="yes"/>
       <point x="932" y="1020" name="inserted"/>
       <point x="932" y="1020"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/registered.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/registered.glif
@@ -58,17 +58,17 @@
       <point x="714" y="1086" type="qcurve"/>
       <point x="714" y="1040"/>
       <point x="656" y="968"/>
-      <point x="614" y="956" type="qcurve"/>
+      <point x="608" y="955" type="qcurve"/>
       <point x="608" y="955" type="line"/>
-      <point x="687" y="843" type="line"/>
-      <point x="689" y="840" type="line" smooth="yes"/>
+      <point x="689" y="840" type="line"/>
+      <point x="689" y="840" type="line"/>
       <point x="729" y="781" name="inserted"/>
       <point x="729" y="781"/>
-      <point x="680" y="781" type="qcurve"/>
-      <point x="680" y="781" type="line"/>
+      <point x="678" y="781" type="qcurve"/>
+      <point x="678" y="781" type="line"/>
       <point x="628" y="781"/>
       <point x="628" y="781"/>
-      <point x="604" y="818" type="qcurve"/>
+      <point x="600" y="823" type="qcurve" smooth="yes"/>
       <point x="518" y="948" type="line"/>
       <point x="466" y="948" type="line"/>
       <point x="466" y="816" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/semicolon.glif
@@ -18,11 +18,11 @@
       <point x="350" y="966"/>
     </contour>
     <contour>
-      <point x="226" y="-135" type="line"/>
-      <point x="196" y="-178" name="inserted"/>
-      <point x="196" y="-178"/>
-      <point x="82" y="-178" type="qcurve"/>
-      <point x="82" y="-165" type="line"/>
+      <point x="238" y="-118" type="line" smooth="yes"/>
+      <point x="197" y="-178" name="inserted"/>
+      <point x="197" y="-178"/>
+      <point x="123" y="-126" type="qcurve"/>
+      <point x="123" y="-108" type="line"/>
       <point x="201" y="0" type="line"/>
       <point x="163" y="8"/>
       <point x="111" y="69"/>
@@ -34,8 +34,8 @@
       <point x="357" y="162"/>
       <point x="357" y="112" type="qcurve" smooth="yes"/>
       <point x="357" y="85"/>
-      <point x="338" y="28"/>
-      <point x="306" y="-20" type="qcurve"/>
+      <point x="339" y="27"/>
+      <point x="306" y="-20" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/six.glif
@@ -33,10 +33,10 @@
       <point x="612" y="1409" type="line"/>
       <point x="652" y="1463"/>
       <point x="652" y="1463"/>
-      <point x="707" y="1429" type="qcurve"/>
-      <point x="707" y="1429" type="line"/>
-      <point x="767" y="1390"/>
-      <point x="767" y="1390" name="inserted"/>
+      <point x="711" y="1425" type="qcurve"/>
+      <point x="711" y="1425" type="line"/>
+      <point x="771" y="1387"/>
+      <point x="771" y="1387" name="inserted"/>
       <point x="729" y="1332" type="qcurve"/>
       <point x="561" y="1112" type="line"/>
       <point x="526" y="1061"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/sterling.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/sterling.glif
@@ -48,8 +48,8 @@
       <point x="406" y="521" type="line"/>
       <point x="407" y="393"/>
       <point x="327" y="206"/>
-      <point x="252" y="147" type="qcurve"/>
-      <point x="255" y="144" type="line"/>
+      <point x="248" y="144" type="qcurve"/>
+      <point x="248" y="144" type="line"/>
       <point x="647" y="144" type="line"/>
       <point x="722" y="144"/>
       <point x="805" y="227"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/three.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/three.glif
@@ -44,8 +44,8 @@
       <point x="858" y="1094" type="line"/>
       <point x="858" y="972"/>
       <point x="736" y="792"/>
-      <point x="632" y="762" type="qcurve"/>
-      <point x="632" y="760" type="line"/>
+      <point x="629" y="761" type="qcurve"/>
+      <point x="629" y="761" type="line"/>
       <point x="756" y="738"/>
       <point x="914" y="536"/>
       <point x="914" y="402" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/three.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/three.tf.glif
@@ -43,8 +43,8 @@
       <point x="948" y="1094" type="line"/>
       <point x="948" y="972"/>
       <point x="826" y="792"/>
-      <point x="722" y="762" type="qcurve"/>
-      <point x="722" y="760" type="line"/>
+      <point x="719" y="761" type="qcurve"/>
+      <point x="719" y="761" type="line"/>
       <point x="846" y="738"/>
       <point x="1004" y="536"/>
       <point x="1004" y="402" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/w.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/w.glif
@@ -15,8 +15,8 @@
       <point x="965" y="-11" name="inserted"/>
       <point x="946" y="49" type="qcurve" smooth="yes"/>
       <point x="723" y="760" type="line"/>
-      <point x="704" y="830" type="line"/>
-      <point x="702" y="830" type="line"/>
+      <point x="703" y="833" type="line"/>
+      <point x="703" y="833" type="line"/>
       <point x="682" y="760" type="line"/>
       <point x="460" y="45" type="line" smooth="yes"/>
       <point x="443" y="-11"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/yen.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/glyphs/yen.glif
@@ -15,8 +15,8 @@
       <point x="150" y="1432"/>
       <point x="181" y="1378" type="qcurve"/>
       <point x="519" y="790" type="line"/>
-      <point x="570" y="706" type="line"/>
-      <point x="572" y="706" type="line"/>
+      <point x="571" y="704" type="line"/>
+      <point x="571" y="704" type="line"/>
       <point x="621" y="787" type="line"/>
       <point x="959" y="1378" type="line"/>
       <point x="991" y="1432"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/S_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/S_.glif
@@ -6,66 +6,66 @@
   <anchor x="1060" y="1432" name="top"/>
   <outline>
     <contour>
-      <point x="1108" y="-41" type="qcurve" smooth="yes"/>
-      <point x="784" y="-41"/>
-      <point x="364" y="121"/>
-      <point x="220" y="302" type="qcurve"/>
-      <point x="220" y="302" type="line"/>
-      <point x="210" y="317" name="inserted"/>
-      <point x="210" y="317"/>
-      <point x="214" y="320" type="qcurve"/>
-      <point x="214" y="320" type="line"/>
-      <point x="219" y="323"/>
-      <point x="219" y="323"/>
-      <point x="229" y="308" type="qcurve"/>
-      <point x="229" y="308" type="line"/>
-      <point x="370" y="129"/>
-      <point x="786" y="-31"/>
-      <point x="1108" y="-31" type="qcurve" smooth="yes"/>
+      <point x="1123" y="-41" type="qcurve" smooth="yes"/>
+      <point x="776" y="-41"/>
+      <point x="317" y="125"/>
+      <point x="168" y="302" type="qcurve"/>
+      <point x="168" y="302" type="line"/>
+      <point x="158" y="317" name="inserted"/>
+      <point x="158" y="317"/>
+      <point x="161" y="320" type="qcurve"/>
+      <point x="161" y="320" type="line"/>
+      <point x="166" y="323"/>
+      <point x="166" y="323"/>
+      <point x="177" y="308" type="qcurve"/>
+      <point x="177" y="308" type="line"/>
+      <point x="323" y="133"/>
+      <point x="778" y="-31"/>
+      <point x="1123" y="-31" type="qcurve" smooth="yes"/>
       <point x="1458" y="-31"/>
-      <point x="1910" y="194"/>
-      <point x="1910" y="369" type="qcurve"/>
-      <point x="1910" y="372" type="line"/>
-      <point x="1910" y="535"/>
-      <point x="1526" y="721"/>
-      <point x="1097" y="765" type="qcurve" smooth="yes"/>
+      <point x="1910" y="189"/>
+      <point x="1910" y="376" type="qcurve"/>
+      <point x="1910" y="379" type="line"/>
+      <point x="1910" y="552"/>
+      <point x="1527" y="729"/>
+      <point x="1097" y="766" type="qcurve" smooth="yes"/>
       <point x="1028" y="772" type="line" smooth="yes"/>
-      <point x="623" y="813"/>
-      <point x="260" y="983"/>
+      <point x="622" y="807"/>
+      <point x="260" y="973"/>
       <point x="260" y="1130" type="qcurve"/>
       <point x="260" y="1136" type="line"/>
-      <point x="260" y="1281"/>
-      <point x="708" y="1476"/>
-      <point x="1056" y="1476" type="qcurve" smooth="yes"/>
-      <point x="1335" y="1476"/>
-      <point x="1735" y="1329"/>
-      <point x="1856" y="1205" type="qcurve"/>
-      <point x="1856" y="1205" type="line"/>
-      <point x="1864" y="1197" name="inserted"/>
-      <point x="1864" y="1197"/>
-      <point x="1861" y="1194" type="qcurve"/>
-      <point x="1861" y="1194" type="line"/>
-      <point x="1856" y="1190"/>
-      <point x="1856" y="1190"/>
-      <point x="1849" y="1197" type="qcurve"/>
-      <point x="1849" y="1197" type="line"/>
-      <point x="1730" y="1322"/>
-      <point x="1333" y="1466"/>
-      <point x="1056" y="1466" type="qcurve" smooth="yes"/>
-      <point x="713" y="1466"/>
-      <point x="270" y="1277"/>
+      <point x="260" y="1291"/>
+      <point x="715" y="1476"/>
+      <point x="1040" y="1476" type="qcurve"/>
+      <point x="1342" y="1476"/>
+      <point x="1742" y="1329"/>
+      <point x="1863" y="1205" type="qcurve"/>
+      <point x="1863" y="1205" type="line"/>
+      <point x="1871" y="1197" name="inserted"/>
+      <point x="1871" y="1197"/>
+      <point x="1868" y="1194" type="qcurve"/>
+      <point x="1868" y="1194" type="line"/>
+      <point x="1863" y="1190"/>
+      <point x="1863" y="1190"/>
+      <point x="1856" y="1197" type="qcurve"/>
+      <point x="1856" y="1197" type="line"/>
+      <point x="1737" y="1322"/>
+      <point x="1340" y="1466"/>
+      <point x="1040" y="1466" type="qcurve"/>
+      <point x="720" y="1466"/>
+      <point x="270" y="1287"/>
       <point x="270" y="1136" type="qcurve"/>
       <point x="270" y="1131" type="line"/>
-      <point x="270" y="987"/>
-      <point x="630" y="822"/>
+      <point x="270" y="977"/>
+      <point x="630" y="817"/>
       <point x="1031" y="782" type="qcurve" smooth="yes"/>
-      <point x="1100" y="775" type="line" smooth="yes"/>
-      <point x="1532" y="731"/>
-      <point x="1920" y="542"/>
-      <point x="1920" y="374" type="qcurve"/>
-      <point x="1920" y="368" type="line"/>
-      <point x="1920" y="190"/>
-      <point x="1462" y="-41"/>
+      <point x="1100" y="776" type="line" smooth="yes"/>
+      <point x="1533" y="738"/>
+      <point x="1920" y="559"/>
+      <point x="1920" y="381" type="qcurve"/>
+      <point x="1920" y="375" type="line"/>
+      <point x="1920" y="185"/>
+      <point x="1465" y="-41"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/a.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/a.glif
@@ -15,58 +15,58 @@
       <point x="1786" y="0"/>
       <point x="1786" y="0"/>
       <point x="1786" y="6" type="qcurve"/>
-      <point x="1786" y="405" type="line"/>
-      <point x="1786" y="405" type="line"/>
-      <point x="1690" y="182"/>
-      <point x="1280" y="-28"/>
-      <point x="928" y="-28" type="qcurve" smooth="yes"/>
-      <point x="489" y="-28"/>
-      <point x="96" y="131"/>
+      <point x="1786" y="277" type="line"/>
+      <point x="1786" y="277" type="line"/>
+      <point x="1666" y="136"/>
+      <point x="1251" y="-28"/>
+      <point x="895" y="-28" type="qcurve" smooth="yes"/>
+      <point x="509" y="-28"/>
+      <point x="96" y="138"/>
       <point x="96" y="309" type="qcurve"/>
       <point x="96" y="312" type="line"/>
       <point x="96" y="480"/>
-      <point x="499" y="630"/>
-      <point x="949" y="630" type="qcurve" smooth="yes"/>
+      <point x="519" y="630"/>
+      <point x="894" y="630" type="qcurve" smooth="yes"/>
       <point x="1232" y="630"/>
-      <point x="1628" y="535"/>
-      <point x="1786" y="429" type="qcurve"/>
-      <point x="1786" y="618" type="line" smooth="yes"/>
-      <point x="1786" y="847"/>
-      <point x="1408" y="1052"/>
-      <point x="986" y="1052" type="qcurve" smooth="yes"/>
-      <point x="703" y="1052"/>
-      <point x="234" y="935"/>
-      <point x="154" y="844" type="qcurve"/>
-      <point x="154" y="844" type="line"/>
-      <point x="150" y="839"/>
-      <point x="150" y="839"/>
-      <point x="146" y="843" type="qcurve"/>
-      <point x="146" y="843" type="line"/>
-      <point x="143" y="846"/>
-      <point x="143" y="846" name="inserted"/>
-      <point x="147" y="851" type="qcurve"/>
-      <point x="147" y="851" type="line"/>
-      <point x="230" y="943"/>
-      <point x="704" y="1062"/>
-      <point x="987" y="1062" type="qcurve" smooth="yes"/>
-      <point x="1414" y="1062"/>
-      <point x="1796" y="849"/>
-      <point x="1796" y="612" type="qcurve"/>
+      <point x="1628" y="536"/>
+      <point x="1786" y="430" type="qcurve"/>
+      <point x="1786" y="589" type="line"/>
+      <point x="1786" y="858"/>
+      <point x="1356" y="1052"/>
+      <point x="1017" y="1052" type="qcurve" smooth="yes"/>
+      <point x="713" y="1052"/>
+      <point x="303" y="928"/>
+      <point x="207" y="854" type="qcurve"/>
+      <point x="207" y="854" type="line"/>
+      <point x="202" y="850"/>
+      <point x="202" y="850"/>
+      <point x="199" y="855" type="qcurve"/>
+      <point x="199" y="855" type="line"/>
+      <point x="197" y="858"/>
+      <point x="197" y="858" name="inserted"/>
+      <point x="202" y="862" type="qcurve"/>
+      <point x="202" y="862" type="line"/>
+      <point x="301" y="937"/>
+      <point x="714" y="1062"/>
+      <point x="1018" y="1062" type="qcurve" smooth="yes"/>
+      <point x="1364" y="1062"/>
+      <point x="1796" y="861"/>
+      <point x="1796" y="592" type="qcurve"/>
     </contour>
     <contour>
-      <point x="949" y="620" type="qcurve" smooth="yes"/>
-      <point x="502" y="620"/>
+      <point x="894" y="620" type="qcurve" smooth="yes"/>
+      <point x="522" y="620"/>
       <point x="106" y="475"/>
-      <point x="106" y="313" type="qcurve"/>
-      <point x="106" y="307" type="line"/>
-      <point x="106" y="136"/>
-      <point x="495" y="-18"/>
-      <point x="928" y="-18" type="qcurve" smooth="yes"/>
-      <point x="1280" y="-18"/>
-      <point x="1688" y="189"/>
-      <point x="1786" y="419" type="qcurve"/>
+      <point x="106" y="312" type="qcurve"/>
+      <point x="106" y="309" type="line"/>
+      <point x="106" y="143"/>
+      <point x="515" y="-18"/>
+      <point x="895" y="-18" type="qcurve" smooth="yes"/>
+      <point x="1251" y="-18"/>
+      <point x="1664" y="142"/>
+      <point x="1786" y="290" type="qcurve"/>
       <point x="1786" y="419" type="line"/>
-      <point x="1628" y="525"/>
+      <point x="1628" y="528"/>
       <point x="1232" y="620"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/c.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/c.glif
@@ -15,20 +15,20 @@
       <point x="82" y="757"/>
       <point x="557" y="1062"/>
       <point x="925" y="1062" type="qcurve" smooth="yes"/>
-      <point x="1142" y="1062"/>
-      <point x="1535" y="970"/>
-      <point x="1622" y="899" type="qcurve"/>
-      <point x="1622" y="899" type="line"/>
-      <point x="1630" y="892" name="inserted"/>
-      <point x="1630" y="892"/>
-      <point x="1626" y="889" type="qcurve"/>
-      <point x="1626" y="889" type="line"/>
-      <point x="1622" y="886"/>
-      <point x="1622" y="886"/>
-      <point x="1614" y="893" type="qcurve"/>
-      <point x="1614" y="893" type="line"/>
-      <point x="1527" y="962"/>
-      <point x="1138" y="1053"/>
+      <point x="1212" y="1062"/>
+      <point x="1595" y="938"/>
+      <point x="1702" y="867" type="qcurve"/>
+      <point x="1702" y="867" type="line"/>
+      <point x="1710" y="860" name="inserted"/>
+      <point x="1710" y="860"/>
+      <point x="1706" y="857" type="qcurve"/>
+      <point x="1706" y="857" type="line"/>
+      <point x="1702" y="854"/>
+      <point x="1702" y="854"/>
+      <point x="1694" y="861" type="qcurve"/>
+      <point x="1694" y="861" type="line"/>
+      <point x="1587" y="930"/>
+      <point x="1208" y="1053"/>
       <point x="925" y="1053" type="qcurve" smooth="yes"/>
       <point x="562" y="1053"/>
       <point x="93" y="753"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/dollar.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/dollar.glif
@@ -5,7 +5,7 @@
   <outline>
     <contour>
       <point x="1040" y="-11" type="qcurve" smooth="yes"/>
-      <point x="702" y="-11"/>
+      <point x="732" y="-11"/>
       <point x="262" y="152"/>
       <point x="110" y="333" type="qcurve"/>
       <point x="110" y="333" type="line"/>
@@ -18,25 +18,25 @@
       <point x="118" y="340" type="qcurve"/>
       <point x="118" y="340" type="line"/>
       <point x="269" y="160"/>
-      <point x="705" y="-1"/>
+      <point x="735" y="-1"/>
       <point x="1040" y="-1" type="qcurve" smooth="yes"/>
       <point x="1383" y="-1"/>
-      <point x="1803" y="206"/>
-      <point x="1803" y="380" type="qcurve"/>
-      <point x="1803" y="383" type="line"/>
-      <point x="1803" y="538"/>
-      <point x="1430" y="723"/>
-      <point x="1013" y="773" type="qcurve" smooth="yes"/>
-      <point x="963" y="779" type="line" smooth="yes"/>
-      <point x="565" y="826"/>
-      <point x="208" y="983"/>
+      <point x="1803" y="207"/>
+      <point x="1803" y="381" type="qcurve"/>
+      <point x="1803" y="384" type="line"/>
+      <point x="1803" y="559"/>
+      <point x="1460" y="702"/>
+      <point x="1111" y="744" type="qcurve" smooth="yes"/>
+      <point x="887" y="771" type="line" smooth="yes"/>
+      <point x="517" y="816"/>
+      <point x="208" y="963"/>
       <point x="208" y="1111" type="qcurve"/>
       <point x="208" y="1119" type="line"/>
-      <point x="208" y="1257"/>
+      <point x="208" y="1267"/>
       <point x="644" y="1436"/>
-      <point x="981" y="1436" type="qcurve" smooth="yes"/>
-      <point x="1267" y="1436"/>
-      <point x="1640" y="1307"/>
+      <point x="950" y="1436" type="qcurve" smooth="yes"/>
+      <point x="1247" y="1436"/>
+      <point x="1630" y="1307"/>
       <point x="1771" y="1163" type="qcurve"/>
       <point x="1771" y="1163" type="line"/>
       <point x="1777" y="1156" name="inserted"/>
@@ -47,28 +47,28 @@
       <point x="1770" y="1150"/>
       <point x="1762" y="1158" type="qcurve"/>
       <point x="1762" y="1158" type="line"/>
-      <point x="1634" y="1299"/>
-      <point x="1264" y="1426"/>
-      <point x="980" y="1426" type="qcurve" smooth="yes"/>
+      <point x="1624" y="1299"/>
+      <point x="1244" y="1426"/>
+      <point x="949" y="1426" type="qcurve" smooth="yes"/>
       <point x="648" y="1426"/>
-      <point x="219" y="1252"/>
+      <point x="219" y="1262"/>
       <point x="219" y="1118" type="qcurve"/>
       <point x="219" y="1113" type="line"/>
-      <point x="219" y="993"/>
-      <point x="550" y="841"/>
-      <point x="965" y="789" type="qcurve"/>
-      <point x="1014" y="783" type="line"/>
-      <point x="1437" y="733"/>
-      <point x="1814" y="541"/>
-      <point x="1814" y="384" type="qcurve"/>
-      <point x="1814" y="378" type="line"/>
-      <point x="1814" y="201"/>
+      <point x="219" y="970"/>
+      <point x="520" y="825"/>
+      <point x="889" y="781" type="qcurve" smooth="yes"/>
+      <point x="1113" y="754" type="line" smooth="yes"/>
+      <point x="1467" y="711"/>
+      <point x="1814" y="562"/>
+      <point x="1814" y="385" type="qcurve"/>
+      <point x="1814" y="379" type="line"/>
+      <point x="1814" y="202"/>
       <point x="1387" y="-11"/>
     </contour>
     <contour>
       <point x="1008" y="1567" type="qcurve"/>
-      <point x="1008" y="778" type="line"/>
-      <point x="998" y="779" type="line"/>
+      <point x="1008" y="760" type="line"/>
+      <point x="998" y="761" type="line"/>
       <point x="998" y="1567" type="line"/>
       <point x="998" y="1573"/>
       <point x="998" y="1573"/>
@@ -86,8 +86,8 @@
       <point x="998" y="-205"/>
       <point x="998" y="-205"/>
       <point x="998" y="-198" type="qcurve"/>
-      <point x="998" y="779" type="line"/>
-      <point x="1008" y="778" type="line"/>
+      <point x="998" y="761" type="line"/>
+      <point x="1008" y="760" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/e.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/e.glif
@@ -1,55 +1,55 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="e" format="2">
-  <advance width="1812"/>
+  <advance width="1883"/>
   <unicode hex="0065"/>
   <anchor x="916" y="0" name="bottom"/>
   <anchor x="1257" y="0" name="ogonek"/>
   <anchor x="926" y="1020" name="top"/>
   <outline>
     <contour>
-      <point x="915" y="-30" type="qcurve" smooth="yes"/>
-      <point x="552" y="-30"/>
+      <point x="963" y="-30" type="qcurve" smooth="yes"/>
+      <point x="579" y="-30"/>
       <point x="82" y="273"/>
       <point x="82" y="508" type="qcurve"/>
       <point x="82" y="512" type="line"/>
       <point x="82" y="752"/>
-      <point x="541" y="1062"/>
-      <point x="896" y="1062" type="qcurve" smooth="yes"/>
-      <point x="1261" y="1062"/>
-      <point x="1733" y="759"/>
-      <point x="1733" y="525" type="qcurve" smooth="yes"/>
-      <point x="1733" y="513" type="line" smooth="yes"/>
-      <point x="1733" y="505"/>
-      <point x="1733" y="505"/>
-      <point x="1722" y="505" type="qcurve" smooth="yes"/>
+      <point x="567" y="1062"/>
+      <point x="943" y="1062" type="qcurve" smooth="yes"/>
+      <point x="1328" y="1062"/>
+      <point x="1827" y="759"/>
+      <point x="1827" y="525" type="qcurve" smooth="yes"/>
+      <point x="1827" y="513" type="line" smooth="yes"/>
+      <point x="1827" y="505"/>
+      <point x="1827" y="505"/>
+      <point x="1816" y="505" type="qcurve" smooth="yes"/>
       <point x="87" y="505" type="line"/>
       <point x="87" y="515" type="line"/>
-      <point x="1723" y="515" type="line"/>
-      <point x="1723" y="522" type="line" smooth="yes"/>
-      <point x="1723" y="753"/>
-      <point x="1256" y="1052"/>
-      <point x="895" y="1052" type="qcurve" smooth="yes"/>
-      <point x="545" y="1052"/>
-      <point x="92" y="748"/>
-      <point x="92" y="513" type="qcurve"/>
-      <point x="92" y="509" type="line"/>
-      <point x="92" y="278"/>
-      <point x="556" y="-20"/>
-      <point x="915" y="-20" type="qcurve" smooth="yes"/>
-      <point x="1175" y="-20"/>
-      <point x="1635" y="108"/>
-      <point x="1731" y="207" type="qcurve"/>
-      <point x="1731" y="207" type="line"/>
-      <point x="1734" y="210"/>
-      <point x="1734" y="210"/>
-      <point x="1738" y="206" type="qcurve"/>
-      <point x="1738" y="206" type="line"/>
-      <point x="1742" y="203"/>
-      <point x="1742" y="203" name="inserted"/>
-      <point x="1738" y="199" type="qcurve"/>
-      <point x="1738" y="199" type="line"/>
-      <point x="1640" y="99"/>
-      <point x="1176" y="-30"/>
+      <point x="1818" y="515" type="line"/>
+      <point x="1818" y="522" type="line" smooth="yes"/>
+      <point x="1818" y="753"/>
+      <point x="1323" y="1052"/>
+      <point x="941" y="1052" type="qcurve" smooth="yes"/>
+      <point x="571" y="1052"/>
+      <point x="92" y="747"/>
+      <point x="92" y="512" type="qcurve"/>
+      <point x="92" y="508" type="line"/>
+      <point x="92" y="277"/>
+      <point x="583" y="-20"/>
+      <point x="963" y="-20" type="qcurve" smooth="yes"/>
+      <point x="1226" y="-20"/>
+      <point x="1706" y="108"/>
+      <point x="1807" y="207" type="qcurve"/>
+      <point x="1807" y="207" type="line"/>
+      <point x="1810" y="210"/>
+      <point x="1810" y="210"/>
+      <point x="1815" y="206" type="qcurve"/>
+      <point x="1815" y="206" type="line"/>
+      <point x="1819" y="203"/>
+      <point x="1819" y="203" name="inserted"/>
+      <point x="1815" y="199" type="qcurve"/>
+      <point x="1815" y="199" type="line"/>
+      <point x="1711" y="99"/>
+      <point x="1228" y="-30"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/eacute.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/eacute.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="eacute" format="2">
-  <advance width="1812"/>
+  <advance width="1883"/>
   <unicode hex="00E9"/>
   <outline>
     <component base="e"/>
-    <component base="acutecomb" xOffset="926"/>
+    <component base="acutecomb" xOffset="956"/>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/ecaron.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/ecaron.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ecaron" format="2">
-  <advance width="1812"/>
+  <advance width="1883"/>
   <unicode hex="011B"/>
   <outline>
     <component base="e"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/ecircumflex.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/ecircumflex.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ecircumflex" format="2">
-  <advance width="1812"/>
+  <advance width="1883"/>
   <unicode hex="00EA"/>
   <outline>
     <component base="e"/>
-    <component base="circumflexcomb" xOffset="926"/>
+    <component base="circumflexcomb" xOffset="956"/>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/edieresis.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/edieresis.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="edieresis" format="2">
-  <advance width="1812"/>
+  <advance width="1883"/>
   <unicode hex="00EB"/>
   <outline>
     <component base="e"/>
-    <component base="dieresiscomb" xOffset="926"/>
+    <component base="dieresiscomb" xOffset="946"/>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/edotaccent.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/edotaccent.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="edotaccent" format="2">
-  <advance width="1812"/>
+  <advance width="1883"/>
   <unicode hex="0117"/>
   <outline>
     <component base="e"/>
-    <component base="dotaccentcomb" xOffset="926"/>
+    <component base="dotaccentcomb" xOffset="956"/>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/egrave.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/egrave.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="egrave" format="2">
-  <advance width="1812"/>
+  <advance width="1883"/>
   <unicode hex="00E8"/>
   <outline>
     <component base="e"/>
-    <component base="gravecomb" xOffset="926"/>
+    <component base="gravecomb" xOffset="956"/>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/emacron.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/emacron.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="emacron" format="2">
-  <advance width="1812"/>
+  <advance width="1883"/>
   <unicode hex="0113"/>
   <outline>
     <component base="e"/>
-    <component base="macroncomb" xOffset="926"/>
+    <component base="macroncomb" xOffset="956"/>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/eogonek.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/eogonek.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="eogonek" format="2">
-  <advance width="1812"/>
+  <advance width="1883"/>
   <unicode hex="0119"/>
   <outline>
     <component base="e"/>
-    <component base="ogonekcomb" xOffset="1222"/>
+    <component base="ogonekcomb" xOffset="1274"/>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/five.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/five.glif
@@ -4,11 +4,11 @@
   <unicode hex="0035"/>
   <outline>
     <contour>
-      <point x="227" y="653" type="qcurve"/>
-      <point x="392" y="1422" type="line" smooth="yes"/>
-      <point x="394" y="1432"/>
-      <point x="394" y="1432"/>
-      <point x="405" y="1432" type="qcurve"/>
+      <point x="277" y="673" type="qcurve"/>
+      <point x="442" y="1422" type="line" smooth="yes"/>
+      <point x="444" y="1432"/>
+      <point x="444" y="1432"/>
+      <point x="455" y="1432" type="qcurve"/>
       <point x="1885" y="1432" type="line"/>
       <point x="1890" y="1432"/>
       <point x="1890" y="1432"/>
@@ -17,55 +17,55 @@
       <point x="1890" y="1422"/>
       <point x="1890" y="1422"/>
       <point x="1885" y="1422" type="qcurve"/>
-      <point x="402" y="1422" type="line"/>
-      <point x="237" y="651" type="line"/>
-      <point x="237" y="651" type="line"/>
-      <point x="391" y="787"/>
-      <point x="829" y="908"/>
-      <point x="1164" y="908" type="qcurve"/>
-      <point x="1164" y="908" type="line"/>
-      <point x="1568" y="908"/>
+      <point x="452" y="1422" type="line"/>
+      <point x="287" y="671" type="line"/>
+      <point x="287" y="671" type="line"/>
+      <point x="449" y="787"/>
+      <point x="839" y="919"/>
+      <point x="1164" y="919" type="qcurve"/>
+      <point x="1164" y="919" type="line"/>
+      <point x="1568" y="919"/>
       <point x="2003" y="680"/>
       <point x="2003" y="468" type="qcurve"/>
       <point x="2003" y="468" type="line"/>
       <point x="2003" y="227"/>
-      <point x="1553" y="-32"/>
-      <point x="1134" y="-32" type="qcurve"/>
-      <point x="1134" y="-32" type="line"/>
-      <point x="763" y="-32"/>
-      <point x="289" y="77"/>
-      <point x="130" y="199" type="qcurve"/>
-      <point x="130" y="199" type="line"/>
-      <point x="121" y="206"/>
-      <point x="121" y="206"/>
-      <point x="125" y="211" type="qcurve"/>
-      <point x="125" y="211" type="line"/>
-      <point x="128" y="214"/>
-      <point x="128" y="214"/>
-      <point x="137" y="207" type="qcurve"/>
-      <point x="137" y="207" type="line"/>
-      <point x="292" y="86"/>
-      <point x="763" y="-22"/>
-      <point x="1134" y="-22" type="qcurve"/>
-      <point x="1134" y="-22" type="line"/>
-      <point x="1548" y="-22"/>
+      <point x="1543" y="-32"/>
+      <point x="1124" y="-32" type="qcurve"/>
+      <point x="1124" y="-32" type="line"/>
+      <point x="753" y="-32"/>
+      <point x="271" y="97"/>
+      <point x="112" y="219" type="qcurve"/>
+      <point x="112" y="219" type="line"/>
+      <point x="103" y="226"/>
+      <point x="103" y="226"/>
+      <point x="107" y="231" type="qcurve"/>
+      <point x="107" y="231" type="line"/>
+      <point x="110" y="234"/>
+      <point x="110" y="234"/>
+      <point x="119" y="227" type="qcurve"/>
+      <point x="119" y="227" type="line"/>
+      <point x="274" y="106"/>
+      <point x="753" y="-22"/>
+      <point x="1124" y="-22" type="qcurve"/>
+      <point x="1124" y="-22" type="line"/>
+      <point x="1538" y="-22"/>
       <point x="1993" y="232"/>
       <point x="1993" y="468" type="qcurve"/>
       <point x="1993" y="468" type="line"/>
       <point x="1993" y="675"/>
-      <point x="1563" y="898"/>
-      <point x="1164" y="898" type="qcurve"/>
-      <point x="1164" y="898" type="line"/>
-      <point x="825" y="898"/>
-      <point x="387" y="776"/>
-      <point x="238" y="639" type="qcurve"/>
-      <point x="238" y="639" type="line"/>
-      <point x="234" y="635"/>
-      <point x="234" y="635"/>
-      <point x="229" y="637" type="qcurve"/>
-      <point x="229" y="637" type="line"/>
-      <point x="224" y="639"/>
-      <point x="224" y="639" name="inserted"/>
+      <point x="1563" y="909"/>
+      <point x="1164" y="909" type="qcurve"/>
+      <point x="1164" y="909" type="line"/>
+      <point x="835" y="909"/>
+      <point x="445" y="776"/>
+      <point x="288" y="659" type="qcurve"/>
+      <point x="288" y="659" type="line"/>
+      <point x="284" y="655"/>
+      <point x="284" y="655"/>
+      <point x="279" y="657" type="qcurve"/>
+      <point x="279" y="657" type="line"/>
+      <point x="274" y="659"/>
+      <point x="274" y="659" name="inserted"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/o.glif
@@ -9,36 +9,36 @@
   <anchor x="1430" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="1019" y="-30" type="qcurve" smooth="yes"/>
-      <point x="568" y="-30"/>
-      <point x="82" y="254"/>
-      <point x="82" y="518" type="qcurve"/>
-      <point x="82" y="520" type="line"/>
-      <point x="82" y="781"/>
-      <point x="568" y="1062"/>
       <point x="1019" y="1062" type="qcurve" smooth="yes"/>
-      <point x="1469" y="1062"/>
-      <point x="1954" y="782"/>
-      <point x="1954" y="521" type="qcurve"/>
-      <point x="1954" y="518" type="line"/>
-      <point x="1954" y="254"/>
-      <point x="1469" y="-30"/>
+      <point x="1459" y="1062"/>
+      <point x="1954" y="758"/>
+      <point x="1954" y="514" type="qcurve"/>
+      <point x="1954" y="511" type="line"/>
+      <point x="1954" y="270"/>
+      <point x="1459" y="-30"/>
+      <point x="1019" y="-30" type="qcurve" smooth="yes"/>
+      <point x="578" y="-30"/>
+      <point x="82" y="271"/>
+      <point x="82" y="512" type="qcurve"/>
+      <point x="82" y="514" type="line"/>
+      <point x="82" y="758"/>
+      <point x="578" y="1062"/>
     </contour>
     <contour>
-      <point x="1019" y="-20" type="qcurve" smooth="yes"/>
-      <point x="1465" y="-20"/>
-      <point x="1944" y="259"/>
-      <point x="1944" y="518" type="qcurve"/>
-      <point x="1944" y="521" type="line"/>
-      <point x="1944" y="777"/>
-      <point x="1465" y="1052"/>
       <point x="1019" y="1052" type="qcurve" smooth="yes"/>
-      <point x="572" y="1052"/>
-      <point x="92" y="776"/>
-      <point x="92" y="520" type="qcurve"/>
-      <point x="92" y="518" type="line"/>
-      <point x="92" y="259"/>
-      <point x="572" y="-20"/>
+      <point x="582" y="1052"/>
+      <point x="92" y="753"/>
+      <point x="92" y="514" type="qcurve"/>
+      <point x="92" y="512" type="line"/>
+      <point x="92" y="276"/>
+      <point x="582" y="-20"/>
+      <point x="1019" y="-20" type="qcurve" smooth="yes"/>
+      <point x="1455" y="-20"/>
+      <point x="1944" y="275"/>
+      <point x="1944" y="511" type="qcurve"/>
+      <point x="1944" y="514" type="line"/>
+      <point x="1944" y="753"/>
+      <point x="1455" y="1052"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/question-bottom.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/question-bottom.glif
@@ -3,50 +3,50 @@
   <advance width="1597"/>
   <outline>
     <contour>
-      <point x="788" y="-433" type="qcurve" smooth="yes"/>
-      <point x="462" y="-433"/>
-      <point x="112" y="-266"/>
-      <point x="112" y="-110" type="qcurve"/>
-      <point x="112" y="-110" type="line"/>
-      <point x="112" y="17"/>
-      <point x="312" y="154"/>
-      <point x="579" y="212" type="qcurve" smooth="yes"/>
-      <point x="778" y="255"/>
-      <point x="956" y="412"/>
-      <point x="956" y="544" type="qcurve" smooth="yes"/>
-      <point x="956" y="659" type="line"/>
-      <point x="956" y="666" name="inserted"/>
-      <point x="956" y="666"/>
-      <point x="961" y="666" type="qcurve"/>
-      <point x="961" y="666" type="line"/>
-      <point x="966" y="666"/>
-      <point x="966" y="666"/>
-      <point x="966" y="659" type="qcurve"/>
-      <point x="966" y="544" type="line" smooth="yes"/>
-      <point x="966" y="407"/>
-      <point x="784" y="245"/>
-      <point x="581" y="202" type="qcurve" smooth="yes"/>
-      <point x="319" y="146"/>
-      <point x="123" y="13"/>
-      <point x="123" y="-110" type="qcurve"/>
-      <point x="123" y="-110" type="line"/>
-      <point x="123" y="-261"/>
-      <point x="467" y="-423"/>
-      <point x="787" y="-423" type="qcurve" smooth="yes"/>
-      <point x="1085" y="-423"/>
-      <point x="1438" y="-298"/>
-      <point x="1534" y="-159" type="qcurve"/>
-      <point x="1534" y="-159" type="line"/>
-      <point x="1539" y="-152"/>
-      <point x="1539" y="-152"/>
-      <point x="1543" y="-155" type="qcurve"/>
-      <point x="1543" y="-155" type="line"/>
-      <point x="1548" y="-159"/>
-      <point x="1548" y="-159" name="inserted"/>
-      <point x="1543" y="-166" type="qcurve"/>
-      <point x="1543" y="-166" type="line"/>
-      <point x="1444" y="-307"/>
-      <point x="1087" y="-433"/>
+      <point x="794" y="-433" type="qcurve" smooth="yes"/>
+      <point x="468" y="-433"/>
+      <point x="118" y="-230"/>
+      <point x="118" y="-74" type="qcurve"/>
+      <point x="118" y="-74" type="line"/>
+      <point x="118" y="81"/>
+      <point x="321" y="238"/>
+      <point x="585" y="302" type="qcurve" smooth="yes"/>
+      <point x="784" y="350"/>
+      <point x="962" y="522"/>
+      <point x="962" y="654" type="qcurve" smooth="yes"/>
+      <point x="962" y="759" type="line"/>
+      <point x="962" y="766" name="inserted"/>
+      <point x="962" y="766"/>
+      <point x="967" y="766" type="qcurve"/>
+      <point x="967" y="766" type="line"/>
+      <point x="972" y="766"/>
+      <point x="972" y="766"/>
+      <point x="972" y="759" type="qcurve"/>
+      <point x="972" y="654" type="line" smooth="yes"/>
+      <point x="972" y="517"/>
+      <point x="790" y="340"/>
+      <point x="587" y="292" type="qcurve" smooth="yes"/>
+      <point x="328" y="231"/>
+      <point x="129" y="77"/>
+      <point x="129" y="-74" type="qcurve"/>
+      <point x="129" y="-74" type="line"/>
+      <point x="129" y="-225"/>
+      <point x="473" y="-423"/>
+      <point x="793" y="-423" type="qcurve" smooth="yes"/>
+      <point x="1077" y="-423"/>
+      <point x="1443" y="-266"/>
+      <point x="1540" y="-127" type="qcurve"/>
+      <point x="1540" y="-127" type="line"/>
+      <point x="1545" y="-120"/>
+      <point x="1545" y="-120"/>
+      <point x="1549" y="-123" type="qcurve"/>
+      <point x="1549" y="-123" type="line"/>
+      <point x="1553" y="-126"/>
+      <point x="1553" y="-126" name="inserted"/>
+      <point x="1548" y="-133" type="qcurve"/>
+      <point x="1548" y="-133" type="line"/>
+      <point x="1449" y="-274"/>
+      <point x="1079" y="-433"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/question-top.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/question-top.glif
@@ -5,48 +5,48 @@
     <contour>
       <point x="790" y="1482" type="qcurve" smooth="yes"/>
       <point x="1116" y="1482"/>
-      <point x="1466" y="1315"/>
-      <point x="1466" y="1159" type="qcurve"/>
-      <point x="1466" y="1159" type="line"/>
-      <point x="1466" y="1032"/>
-      <point x="1266" y="895"/>
-      <point x="999" y="837" type="qcurve" smooth="yes"/>
-      <point x="800" y="794"/>
-      <point x="622" y="637"/>
-      <point x="622" y="505" type="qcurve" smooth="yes"/>
-      <point x="622" y="390" type="line"/>
-      <point x="622" y="383" name="inserted"/>
-      <point x="622" y="383"/>
-      <point x="617" y="383" type="qcurve"/>
-      <point x="617" y="383" type="line"/>
-      <point x="612" y="383"/>
-      <point x="612" y="383"/>
-      <point x="612" y="390" type="qcurve"/>
-      <point x="612" y="505" type="line" smooth="yes"/>
-      <point x="612" y="642"/>
-      <point x="794" y="804"/>
-      <point x="997" y="847" type="qcurve" smooth="yes"/>
-      <point x="1259" y="903"/>
-      <point x="1455" y="1036"/>
-      <point x="1455" y="1159" type="qcurve"/>
-      <point x="1455" y="1159" type="line"/>
-      <point x="1455" y="1310"/>
+      <point x="1466" y="1279"/>
+      <point x="1466" y="1123" type="qcurve"/>
+      <point x="1466" y="1123" type="line"/>
+      <point x="1466" y="968"/>
+      <point x="1263" y="811"/>
+      <point x="999" y="747" type="qcurve" smooth="yes"/>
+      <point x="800" y="699"/>
+      <point x="622" y="527"/>
+      <point x="622" y="395" type="qcurve" smooth="yes"/>
+      <point x="622" y="290" type="line"/>
+      <point x="622" y="283" name="inserted"/>
+      <point x="622" y="283"/>
+      <point x="617" y="283" type="qcurve"/>
+      <point x="617" y="283" type="line"/>
+      <point x="612" y="283"/>
+      <point x="612" y="283"/>
+      <point x="612" y="290" type="qcurve"/>
+      <point x="612" y="395" type="line" smooth="yes"/>
+      <point x="612" y="532"/>
+      <point x="794" y="709"/>
+      <point x="997" y="757" type="qcurve" smooth="yes"/>
+      <point x="1256" y="818"/>
+      <point x="1455" y="972"/>
+      <point x="1455" y="1123" type="qcurve"/>
+      <point x="1455" y="1123" type="line"/>
+      <point x="1455" y="1274"/>
       <point x="1111" y="1472"/>
       <point x="791" y="1472" type="qcurve" smooth="yes"/>
-      <point x="493" y="1472"/>
-      <point x="140" y="1347"/>
-      <point x="44" y="1208" type="qcurve"/>
-      <point x="44" y="1208" type="line"/>
-      <point x="39" y="1201"/>
-      <point x="39" y="1201"/>
-      <point x="35" y="1204" type="qcurve"/>
-      <point x="35" y="1204" type="line"/>
-      <point x="30" y="1208"/>
-      <point x="30" y="1208" name="inserted"/>
-      <point x="35" y="1215" type="qcurve"/>
-      <point x="35" y="1215" type="line"/>
-      <point x="134" y="1356"/>
-      <point x="491" y="1482"/>
+      <point x="507" y="1472"/>
+      <point x="141" y="1315"/>
+      <point x="44" y="1176" type="qcurve"/>
+      <point x="44" y="1176" type="line"/>
+      <point x="39" y="1169"/>
+      <point x="39" y="1169"/>
+      <point x="35" y="1172" type="qcurve"/>
+      <point x="35" y="1172" type="line"/>
+      <point x="31" y="1175"/>
+      <point x="31" y="1175" name="inserted"/>
+      <point x="36" y="1182" type="qcurve"/>
+      <point x="36" y="1182" type="line"/>
+      <point x="135" y="1323"/>
+      <point x="505" y="1482"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/question.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/glyphs/question.glif
@@ -4,6 +4,6 @@
   <unicode hex="003F"/>
   <outline>
     <component base="question-top" xOffset="18.804878048780495"/>
-    <component base="dot-composite" xOffset="332" yOffset="-10"/>
+    <component base="dot-composite" xOffset="339" yOffset="-10"/>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/C_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/C_.glif
@@ -16,42 +16,42 @@
       <point x="44" y="1087"/>
       <point x="758" y="1471"/>
       <point x="1218" y="1471" type="qcurve" smooth="yes"/>
-      <point x="1660" y="1471"/>
-      <point x="2113" y="1326"/>
-      <point x="2225" y="1236" type="qcurve"/>
-      <point x="2225" y="1236" type="line"/>
-      <point x="2297" y="1169" name="inserted"/>
-      <point x="2299" y="1167"/>
-      <point x="2094" y="941" type="qcurve"/>
-      <point x="2094" y="941" type="line"/>
-      <point x="1893" y="713"/>
-      <point x="1893" y="713"/>
-      <point x="1804" y="779" type="qcurve"/>
-      <point x="1804" y="779" type="line"/>
-      <point x="1702" y="852"/>
-      <point x="1484" y="913"/>
-      <point x="1286" y="913" type="qcurve" smooth="yes"/>
-      <point x="1147" y="913"/>
+      <point x="1584" y="1471"/>
+      <point x="1993" y="1366"/>
+      <point x="2112" y="1301" type="qcurve"/>
+      <point x="2112" y="1301" type="line"/>
+      <point x="2229" y="1232" name="inserted"/>
+      <point x="2230" y="1230"/>
+      <point x="2081" y="970" type="qcurve"/>
+      <point x="2081" y="970" type="line"/>
+      <point x="1942" y="737"/>
+      <point x="1942" y="737"/>
+      <point x="1847" y="793" type="qcurve"/>
+      <point x="1847" y="793" type="line"/>
+      <point x="1738" y="855"/>
+      <point x="1484" y="907"/>
+      <point x="1286" y="907" type="qcurve" smooth="yes"/>
+      <point x="1147" y="907"/>
       <point x="939" y="803"/>
       <point x="939" y="709" type="qcurve"/>
       <point x="939" y="709" type="line"/>
       <point x="939" y="621"/>
-      <point x="1140" y="517"/>
-      <point x="1295" y="517" type="qcurve" smooth="yes"/>
-      <point x="1465" y="517"/>
-      <point x="1669" y="568"/>
-      <point x="1753" y="630" type="qcurve"/>
-      <point x="1753" y="630" type="line"/>
-      <point x="1875" y="723"/>
-      <point x="1875" y="723"/>
-      <point x="2089" y="502" type="qcurve"/>
-      <point x="2089" y="502" type="line"/>
-      <point x="2316" y="267"/>
-      <point x="2316" y="267" name="inserted"/>
-      <point x="2230" y="202" type="qcurve"/>
-      <point x="2230" y="202" type="line"/>
-      <point x="2037" y="54"/>
-      <point x="1588" y="-36"/>
+      <point x="1140" y="521"/>
+      <point x="1308" y="521" type="qcurve" smooth="yes"/>
+      <point x="1535" y="521"/>
+      <point x="1763" y="566"/>
+      <point x="1876" y="621" type="qcurve"/>
+      <point x="1876" y="621" type="line"/>
+      <point x="1953" y="658"/>
+      <point x="1953" y="658"/>
+      <point x="2073" y="446" type="qcurve"/>
+      <point x="2073" y="446" type="line"/>
+      <point x="2218" y="162"/>
+      <point x="2217" y="162" name="inserted"/>
+      <point x="2144" y="123" type="qcurve"/>
+      <point x="2144" y="123" type="line"/>
+      <point x="2014" y="54"/>
+      <point x="1631" y="-36"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/G_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/G_.glif
@@ -15,11 +15,11 @@
       <point x="775" y="1472"/>
       <point x="1322" y="1472" type="qcurve" smooth="yes"/>
       <point x="1599" y="1472"/>
-      <point x="2060" y="1397"/>
-      <point x="2294" y="1263" type="qcurve"/>
-      <point x="2294" y="1263" type="line"/>
-      <point x="2402" y="1198" name="inserted"/>
-      <point x="2403" y="1197"/>
+      <point x="2100" y="1377"/>
+      <point x="2294" y="1269" type="qcurve"/>
+      <point x="2294" y="1269" type="line"/>
+      <point x="2397" y="1208" name="inserted"/>
+      <point x="2397" y="1208"/>
       <point x="2245" y="957" type="qcurve"/>
       <point x="2245" y="957" type="line"/>
       <point x="2128" y="778"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/J_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/J_.glif
@@ -6,36 +6,36 @@
   <anchor x="1468" y="1432" name="top"/>
   <outline>
     <contour>
-      <point x="931.5056179775281" y="-32" type="qcurve" smooth="yes"/>
-      <point x="602.5056179775281" y="-32"/>
-      <point x="183.5056179775281" y="160"/>
-      <point x="56.50561797752809" y="407" type="qcurve"/>
-      <point x="56.50561797752809" y="407" type="line"/>
-      <point x="12.50561797752809" y="526" name="inserted"/>
-      <point x="13.50561797752809" y="525"/>
-      <point x="343.5056179775281" y="679" type="qcurve"/>
-      <point x="343.5056179775281" y="679" type="line"/>
-      <point x="655.5056179775281" y="818"/>
-      <point x="655.5056179775281" y="818"/>
-      <point x="690.5056179775281" y="745" type="qcurve"/>
-      <point x="690.5056179775281" y="745" type="line"/>
-      <point x="717.5056179775281" y="686"/>
-      <point x="798.5056179775281" y="630"/>
-      <point x="868.5056179775281" y="630" type="qcurve" smooth="yes"/>
-      <point x="932.5056179775281" y="630"/>
-      <point x="1005.5056179775281" y="695"/>
-      <point x="1004.5056179775281" y="776" type="qcurve"/>
-      <point x="1004.5056179775281" y="1042" type="line"/>
-      <point x="1004.5056179775281" y="1432"/>
-      <point x="1004.5056179775281" y="1432"/>
-      <point x="1412.5056179775281" y="1432" type="qcurve"/>
-      <point x="1412.5056179775281" y="1432" type="line"/>
-      <point x="1836.5056179775281" y="1432"/>
-      <point x="1836.5056179775281" y="1432" name="inserted"/>
-      <point x="1836.5056179775281" y="1042" type="qcurve" smooth="yes"/>
-      <point x="1836.5056179775281" y="642" type="line" smooth="yes"/>
-      <point x="1836.5056179775281" y="283"/>
-      <point x="1344.5056179775281" y="-32"/>
+      <point x="932" y="-32" type="qcurve" smooth="yes"/>
+      <point x="569" y="-32"/>
+      <point x="184" y="187"/>
+      <point x="91" y="383" type="qcurve"/>
+      <point x="91" y="383" type="line"/>
+      <point x="60" y="468" name="inserted"/>
+      <point x="60" y="468"/>
+      <point x="372" y="605" type="qcurve"/>
+      <point x="372" y="605" type="line"/>
+      <point x="643" y="716"/>
+      <point x="643" y="716"/>
+      <point x="681" y="645" type="qcurve"/>
+      <point x="681" y="645" type="line"/>
+      <point x="715" y="582"/>
+      <point x="794" y="530"/>
+      <point x="864" y="530" type="qcurve" smooth="yes"/>
+      <point x="928" y="530"/>
+      <point x="1005" y="605"/>
+      <point x="1005" y="686" type="qcurve" smooth="yes"/>
+      <point x="1005" y="1042" type="line"/>
+      <point x="1005" y="1432"/>
+      <point x="1005" y="1432"/>
+      <point x="1413" y="1432" type="qcurve"/>
+      <point x="1413" y="1432" type="line"/>
+      <point x="1837" y="1432"/>
+      <point x="1837" y="1432" name="inserted"/>
+      <point x="1837" y="1042" type="qcurve" smooth="yes"/>
+      <point x="1837" y="642" type="line" smooth="yes"/>
+      <point x="1837" y="283"/>
+      <point x="1345" y="-32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/P_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/P_.glif
@@ -28,14 +28,14 @@
       <point x="1294" y="254" type="qcurve"/>
       <point x="402" y="254" type="line"/>
       <point x="402" y="743" type="line"/>
-      <point x="1241" y="743" type="line" smooth="yes"/>
-      <point x="1369" y="743"/>
-      <point x="1485" y="779"/>
-      <point x="1486" y="816" type="qcurve"/>
-      <point x="1486" y="820" type="line"/>
-      <point x="1486" y="859"/>
-      <point x="1359" y="887"/>
-      <point x="1236" y="887" type="qcurve" smooth="yes"/>
+      <point x="1191" y="743" type="line" smooth="yes"/>
+      <point x="1341" y="743"/>
+      <point x="1435" y="779"/>
+      <point x="1436" y="819" type="qcurve"/>
+      <point x="1436" y="819" type="line"/>
+      <point x="1436" y="859"/>
+      <point x="1331" y="887"/>
+      <point x="1186" y="887" type="qcurve" smooth="yes"/>
       <point x="948" y="887" type="line"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/R_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/R_.glif
@@ -28,14 +28,14 @@
       <point x="1350" y="325" type="qcurve"/>
       <point x="500" y="325" type="line"/>
       <point x="500" y="761" type="line"/>
-      <point x="1274" y="761" type="line" smooth="yes"/>
-      <point x="1443" y="761"/>
-      <point x="1506" y="794"/>
-      <point x="1506" y="822" type="qcurve"/>
-      <point x="1506" y="822" type="line"/>
-      <point x="1506" y="850"/>
-      <point x="1432" y="885"/>
-      <point x="1271" y="885" type="qcurve" smooth="yes"/>
+      <point x="1234" y="761" type="line" smooth="yes"/>
+      <point x="1403" y="761"/>
+      <point x="1466" y="794"/>
+      <point x="1466" y="822" type="qcurve"/>
+      <point x="1466" y="822" type="line"/>
+      <point x="1466" y="850"/>
+      <point x="1392" y="885"/>
+      <point x="1231" y="885" type="qcurve" smooth="yes"/>
       <point x="928" y="885" type="line"/>
     </contour>
     <contour>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/S_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/S_.glif
@@ -7,30 +7,30 @@
   <outline>
     <contour>
       <point x="1073" y="-45" type="qcurve" smooth="yes"/>
-      <point x="608" y="-45"/>
-      <point x="229" y="47"/>
-      <point x="107" y="115" type="qcurve"/>
-      <point x="107" y="115" type="line"/>
-      <point x="-30" y="191" name="inserted"/>
-      <point x="-30" y="191"/>
+      <point x="683" y="-45"/>
+      <point x="254" y="48"/>
+      <point x="111" y="124" type="qcurve"/>
+      <point x="111" y="124" type="line"/>
+      <point x="-29" y="193" name="inserted"/>
+      <point x="-29" y="193"/>
       <point x="66" y="378" type="qcurve"/>
       <point x="66" y="378" type="line"/>
-      <point x="183" y="589"/>
-      <point x="183" y="589"/>
-      <point x="340" y="522" type="qcurve"/>
-      <point x="340" y="522" type="line"/>
-      <point x="484" y="459"/>
-      <point x="815" y="401"/>
-      <point x="1032" y="401" type="qcurve" smooth="yes"/>
+      <point x="186" y="608"/>
+      <point x="186" y="608"/>
+      <point x="342" y="533" type="qcurve"/>
+      <point x="342" y="533" type="line"/>
+      <point x="486" y="470"/>
+      <point x="845" y="401"/>
+      <point x="1042" y="401" type="qcurve" smooth="yes"/>
       <point x="1160" y="401"/>
       <point x="1233" y="412"/>
       <point x="1233" y="434" type="qcurve"/>
       <point x="1233" y="434" type="line"/>
       <point x="1233" y="452"/>
-      <point x="1093" y="467"/>
-      <point x="940" y="478" type="qcurve" smooth="yes"/>
-      <point x="744" y="492" type="line" smooth="yes"/>
-      <point x="430" y="514"/>
+      <point x="1093" y="469"/>
+      <point x="940" y="479" type="qcurve" smooth="yes"/>
+      <point x="805" y="489" type="line" smooth="yes"/>
+      <point x="460" y="515"/>
       <point x="10" y="737"/>
       <point x="10" y="980" type="qcurve"/>
       <point x="10" y="980" type="line"/>
@@ -38,18 +38,18 @@
       <point x="593" y="1473"/>
       <point x="1018" y="1473" type="qcurve" smooth="yes"/>
       <point x="1396" y="1473"/>
-      <point x="1765" y="1387"/>
-      <point x="1883" y="1329" type="qcurve"/>
-      <point x="1883" y="1329" type="line"/>
-      <point x="2012" y="1262" name="inserted"/>
-      <point x="2012" y="1262"/>
-      <point x="1909" y="1074" type="qcurve"/>
-      <point x="1909" y="1074" type="line"/>
-      <point x="1786" y="839"/>
-      <point x="1786" y="839"/>
-      <point x="1621" y="919" type="qcurve"/>
-      <point x="1621" y="919" type="line"/>
-      <point x="1507" y="972"/>
+      <point x="1726" y="1421"/>
+      <point x="1852" y="1383" type="qcurve"/>
+      <point x="1852" y="1383" type="line"/>
+      <point x="1990" y="1338" name="inserted"/>
+      <point x="1990" y="1338"/>
+      <point x="1919" y="1136" type="qcurve"/>
+      <point x="1919" y="1136" type="line"/>
+      <point x="1835" y="884"/>
+      <point x="1835" y="884"/>
+      <point x="1659" y="936" type="qcurve"/>
+      <point x="1659" y="936" type="line"/>
+      <point x="1522" y="977"/>
       <point x="1163" y="1034"/>
       <point x="1035" y="1034" type="qcurve" smooth="yes"/>
       <point x="902" y="1034"/>
@@ -57,10 +57,10 @@
       <point x="833" y="996" type="qcurve"/>
       <point x="833" y="996" type="line"/>
       <point x="833" y="976"/>
-      <point x="898" y="965"/>
+      <point x="898" y="967"/>
       <point x="1036" y="960" type="qcurve" smooth="yes"/>
-      <point x="1236" y="953" type="line" smooth="yes"/>
-      <point x="1705" y="937"/>
+      <point x="1236" y="950" type="line" smooth="yes"/>
+      <point x="1705" y="927"/>
       <point x="2056" y="698"/>
       <point x="2056" y="487" type="qcurve"/>
       <point x="2056" y="487" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/a.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/a.glif
@@ -32,23 +32,23 @@
       <point x="1304" y="620" type="qcurve"/>
       <point x="1304" y="633" type="line" smooth="yes"/>
       <point x="1304" y="683"/>
-      <point x="1189" y="729"/>
-      <point x="1023" y="729" type="qcurve" smooth="yes"/>
-      <point x="847" y="729"/>
-      <point x="538" y="649"/>
-      <point x="438" y="602" type="qcurve"/>
-      <point x="438" y="602" type="line"/>
-      <point x="283" y="534"/>
-      <point x="283" y="534"/>
-      <point x="193" y="718" type="qcurve"/>
-      <point x="193" y="718" type="line"/>
-      <point x="109" y="912"/>
-      <point x="109" y="914" name="inserted"/>
-      <point x="245" y="965" type="qcurve"/>
-      <point x="245" y="965" type="line"/>
-      <point x="394" y="1020"/>
-      <point x="753" y="1080"/>
-      <point x="1013" y="1080" type="qcurve" smooth="yes"/>
+      <point x="1196" y="732"/>
+      <point x="1029" y="732" type="qcurve" smooth="yes"/>
+      <point x="805" y="732"/>
+      <point x="469" y="698"/>
+      <point x="312" y="658" type="qcurve"/>
+      <point x="312" y="658" type="line"/>
+      <point x="218" y="635"/>
+      <point x="218" y="635"/>
+      <point x="160" y="795" type="qcurve"/>
+      <point x="160" y="795" type="line"/>
+      <point x="103" y="975"/>
+      <point x="103" y="975" name="inserted"/>
+      <point x="194" y="996" type="qcurve"/>
+      <point x="194" y="996" type="line"/>
+      <point x="361" y="1036"/>
+      <point x="763" y="1080"/>
+      <point x="1079" y="1080" type="qcurve" smooth="yes"/>
       <point x="1490" y="1080"/>
       <point x="2048" y="871"/>
       <point x="2048" y="600" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/at.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/at.glif
@@ -5,31 +5,31 @@
   <outline>
     <contour>
       <point x="1236" y="-115" type="qcurve" smooth="yes"/>
-      <point x="754" y="-115"/>
+      <point x="683" y="-115"/>
       <point x="20" y="327"/>
       <point x="20" y="673" type="qcurve" smooth="yes"/>
       <point x="20" y="1017"/>
-      <point x="766" y="1457"/>
-      <point x="1262" y="1457" type="qcurve" smooth="yes"/>
-      <point x="1773" y="1457"/>
+      <point x="726" y="1457"/>
+      <point x="1247" y="1457" type="qcurve" smooth="yes"/>
+      <point x="1813" y="1457"/>
       <point x="2494" y="1038"/>
       <point x="2494" y="727" type="qcurve" smooth="yes"/>
       <point x="2494" y="497"/>
-      <point x="2132" y="252"/>
-      <point x="1902" y="252" type="qcurve" smooth="yes"/>
-      <point x="1774" y="252"/>
-      <point x="1565" y="298"/>
-      <point x="1467" y="361" type="qcurve"/>
-      <point x="1391" y="318"/>
-      <point x="1192" y="276"/>
-      <point x="1103" y="276" type="qcurve" smooth="yes"/>
-      <point x="887" y="276"/>
+      <point x="2132" y="281"/>
+      <point x="1902" y="281" type="qcurve" smooth="yes"/>
+      <point x="1774" y="281"/>
+      <point x="1550" y="339"/>
+      <point x="1457" y="421" type="qcurve"/>
+      <point x="1389" y="348"/>
+      <point x="1162" y="276"/>
+      <point x="1073" y="276" type="qcurve" smooth="yes"/>
+      <point x="847" y="276"/>
       <point x="540" y="498"/>
       <point x="540" y="672" type="qcurve" smooth="yes"/>
       <point x="540" y="875"/>
-      <point x="903" y="1067"/>
-      <point x="1098" y="1067" type="qcurve" smooth="yes"/>
-      <point x="1201" y="1067"/>
+      <point x="854" y="1067"/>
+      <point x="1068" y="1067" type="qcurve" smooth="yes"/>
+      <point x="1171" y="1067"/>
       <point x="1358" y="1022"/>
       <point x="1402" y="978" type="qcurve"/>
       <point x="1402" y="978" type="line"/>
@@ -41,21 +41,21 @@
       <point x="1857" y="1053"/>
       <point x="1857" y="1053" name="inserted"/>
       <point x="1857" y="893" type="qcurve" smooth="yes"/>
-      <point x="1857" y="729" type="line" smooth="yes"/>
-      <point x="1857" y="649"/>
-      <point x="1910" y="575"/>
-      <point x="1982" y="575" type="qcurve" smooth="yes"/>
-      <point x="2044" y="575"/>
-      <point x="2119" y="648"/>
-      <point x="2119" y="731" type="qcurve" smooth="yes"/>
-      <point x="2119" y="960"/>
-      <point x="1669" y="1189"/>
-      <point x="1251" y="1189" type="qcurve" smooth="yes"/>
-      <point x="867" y="1189"/>
-      <point x="418" y="914"/>
-      <point x="418" y="666" type="qcurve" smooth="yes"/>
-      <point x="418" y="439"/>
-      <point x="867" y="148"/>
+      <point x="1857" y="759" type="line" smooth="yes"/>
+      <point x="1857" y="679"/>
+      <point x="1920" y="575"/>
+      <point x="1992" y="575" type="qcurve" smooth="yes"/>
+      <point x="2064" y="575"/>
+      <point x="2149" y="648"/>
+      <point x="2149" y="731" type="qcurve" smooth="yes"/>
+      <point x="2149" y="940"/>
+      <point x="1719" y="1189"/>
+      <point x="1248" y="1189" type="qcurve" smooth="yes"/>
+      <point x="787" y="1189"/>
+      <point x="388" y="904"/>
+      <point x="388" y="666" type="qcurve" smooth="yes"/>
+      <point x="388" y="439"/>
+      <point x="809" y="148"/>
       <point x="1222" y="148" type="qcurve" smooth="yes"/>
       <point x="1389" y="148"/>
       <point x="1541" y="166"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/dollar.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/dollar.glif
@@ -6,26 +6,26 @@
     <contour>
       <point x="1102" y="-17" type="qcurve" smooth="yes"/>
       <point x="690" y="-17"/>
-      <point x="265" y="59"/>
-      <point x="149" y="114" type="qcurve"/>
-      <point x="149" y="114" type="line"/>
+      <point x="264" y="55"/>
+      <point x="89" y="136" type="qcurve"/>
+      <point x="89" y="136" type="line"/>
       <point x="-29" y="193" name="inserted"/>
       <point x="-29" y="193"/>
       <point x="68" y="392" type="qcurve"/>
       <point x="68" y="392" type="line"/>
-      <point x="183" y="606"/>
-      <point x="183" y="606"/>
-      <point x="369" y="529" type="qcurve"/>
-      <point x="369" y="529" type="line"/>
-      <point x="480" y="481"/>
+      <point x="183" y="607"/>
+      <point x="183" y="607"/>
+      <point x="311" y="543" type="qcurve"/>
+      <point x="311" y="543" type="line"/>
+      <point x="480" y="471"/>
       <point x="844" y="412"/>
       <point x="1061" y="412" type="qcurve" smooth="yes"/>
-      <point x="1189" y="412"/>
+      <point x="1179" y="412"/>
       <point x="1262" y="423"/>
       <point x="1262" y="441" type="qcurve"/>
       <point x="1262" y="441" type="line"/>
       <point x="1262" y="461"/>
-      <point x="1122" y="476"/>
+      <point x="1143" y="474"/>
       <point x="969" y="486" type="qcurve" smooth="yes"/>
       <point x="773" y="499" type="line" smooth="yes"/>
       <point x="459" y="521"/>
@@ -33,32 +33,32 @@
       <point x="39" y="952" type="qcurve"/>
       <point x="39" y="968" type="line"/>
       <point x="39" y="1207"/>
-      <point x="622" y="1442"/>
-      <point x="1047" y="1442" type="qcurve" smooth="yes"/>
-      <point x="1324" y="1442"/>
-      <point x="1706" y="1395"/>
-      <point x="1840" y="1343" type="qcurve"/>
-      <point x="1841" y="1343" type="line"/>
-      <point x="2013" y="1272" name="inserted"/>
-      <point x="2013" y="1272"/>
+      <point x="622" y="1459"/>
+      <point x="1047" y="1459" type="qcurve" smooth="yes"/>
+      <point x="1324" y="1459"/>
+      <point x="1736" y="1404"/>
+      <point x="1899" y="1345" type="qcurve"/>
+      <point x="1899" y="1345" type="line"/>
+      <point x="2026" y="1298" name="inserted"/>
+      <point x="2026" y="1298"/>
       <point x="1931" y="1066" type="qcurve"/>
       <point x="1931" y="1066" type="line"/>
-      <point x="1842" y="837"/>
-      <point x="1842" y="837"/>
-      <point x="1631" y="919" type="qcurve"/>
-      <point x="1631" y="919" type="line"/>
-      <point x="1506" y="959"/>
-      <point x="1192" y="1020"/>
-      <point x="1064" y="1020" type="qcurve" smooth="yes"/>
-      <point x="931" y="1020"/>
-      <point x="862" y="1005"/>
-      <point x="862" y="984" type="qcurve"/>
-      <point x="862" y="984" type="line"/>
-      <point x="862" y="964"/>
-      <point x="927" y="954"/>
-      <point x="1065" y="950" type="qcurve" smooth="yes"/>
-      <point x="1265" y="943" type="line" smooth="yes"/>
-      <point x="1734" y="927"/>
+      <point x="1852" y="878"/>
+      <point x="1852" y="878"/>
+      <point x="1702" y="928" type="qcurve"/>
+      <point x="1702" y="928" type="line"/>
+      <point x="1545" y="972"/>
+      <point x="1192" y="1023"/>
+      <point x="1064" y="1023" type="qcurve" smooth="yes"/>
+      <point x="941" y="1023"/>
+      <point x="862" y="1012"/>
+      <point x="862" y="991" type="qcurve"/>
+      <point x="862" y="991" type="line"/>
+      <point x="862" y="972"/>
+      <point x="927" y="962"/>
+      <point x="1065" y="953" type="qcurve" smooth="yes"/>
+      <point x="1265" y="940" type="line" smooth="yes"/>
+      <point x="1734" y="910"/>
       <point x="2085" y="697"/>
       <point x="2085" y="494" type="qcurve"/>
       <point x="2085" y="489" type="line"/>
@@ -66,16 +66,16 @@
       <point x="1522" y="-17"/>
     </contour>
     <contour>
-      <point x="1304" y="1411" type="qcurve"/>
-      <point x="1304" y="1253" type="line"/>
-      <point x="840" y="1253" type="line"/>
-      <point x="840" y="1413" type="line"/>
-      <point x="840" y="1630"/>
-      <point x="840" y="1630"/>
-      <point x="1069" y="1630" type="qcurve"/>
-      <point x="1069" y="1630" type="line"/>
-      <point x="1304" y="1630"/>
-      <point x="1304" y="1630" name="inserted"/>
+      <point x="1304" y="1481" type="qcurve"/>
+      <point x="1304" y="1323" type="line"/>
+      <point x="840" y="1323" type="line"/>
+      <point x="840" y="1483" type="line"/>
+      <point x="840" y="1700"/>
+      <point x="840" y="1700"/>
+      <point x="1069" y="1700" type="qcurve"/>
+      <point x="1069" y="1700" type="line"/>
+      <point x="1304" y="1700"/>
+      <point x="1304" y="1700" name="inserted"/>
     </contour>
     <contour>
       <point x="1293" y="-86" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/registered.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/registered.glif
@@ -69,9 +69,9 @@
       <point x="1034" y="789"/>
       <point x="1034" y="789"/>
       <point x="985" y="825" type="qcurve"/>
-      <point x="985" y="825" type="line"/>
-      <point x="913" y="880" type="line"/>
+      <point x="911" y="880" type="line"/>
       <point x="789" y="880" type="line"/>
+      <point x="789" y="838" type="line"/>
       <point x="789" y="790"/>
       <point x="789" y="790"/>
       <point x="651" y="790" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/s.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/s.glif
@@ -15,18 +15,18 @@
       <point x="-3" y="55"/>
       <point x="42" y="218" type="qcurve"/>
       <point x="42" y="218" type="line"/>
-      <point x="98" y="417"/>
-      <point x="95" y="410"/>
-      <point x="214" y="373" type="qcurve"/>
-      <point x="214" y="373" type="line"/>
-      <point x="320" y="337"/>
-      <point x="672" y="288"/>
-      <point x="948" y="288" type="qcurve" smooth="yes"/>
-      <point x="1129" y="288"/>
-      <point x="1186" y="294"/>
+      <point x="94" y="398"/>
+      <point x="94" y="398"/>
+      <point x="213" y="361" type="qcurve"/>
+      <point x="213" y="361" type="line"/>
+      <point x="319" y="325"/>
+      <point x="692" y="283"/>
+      <point x="948" y="283" type="qcurve" smooth="yes"/>
+      <point x="1129" y="283"/>
+      <point x="1186" y="297"/>
       <point x="1186" y="310" type="qcurve"/>
       <point x="1186" y="310" type="line"/>
-      <point x="1186" y="325"/>
+      <point x="1186" y="322"/>
       <point x="1113" y="327"/>
       <point x="935" y="335" type="qcurve" smooth="yes"/>
       <point x="728" y="344" type="line" smooth="yes"/>
@@ -37,27 +37,27 @@
       <point x="59" y="873"/>
       <point x="576" y="1094"/>
       <point x="999" y="1094" type="qcurve" smooth="yes"/>
-      <point x="1324" y="1094"/>
-      <point x="1614" y="1056"/>
-      <point x="1714" y="1040" type="qcurve"/>
-      <point x="1714" y="1040" type="line"/>
-      <point x="1836" y="1019" name="inserted"/>
-      <point x="1836" y="1019"/>
+      <point x="1276" y="1094"/>
+      <point x="1614" y="1051"/>
+      <point x="1714" y="1030" type="qcurve"/>
+      <point x="1714" y="1030" type="line"/>
+      <point x="1832" y="1004" name="inserted"/>
+      <point x="1833" y="1005"/>
       <point x="1786" y="828" type="qcurve"/>
       <point x="1786" y="828" type="line"/>
       <point x="1745" y="656"/>
       <point x="1747" y="656"/>
       <point x="1655" y="678" type="qcurve"/>
       <point x="1655" y="678" type="line"/>
-      <point x="1488" y="710"/>
-      <point x="1152" y="759"/>
+      <point x="1495" y="714"/>
+      <point x="1121" y="759"/>
       <point x="983" y="759" type="qcurve" smooth="yes"/>
-      <point x="805" y="759"/>
-      <point x="766" y="752"/>
+      <point x="815" y="759"/>
+      <point x="766" y="751"/>
       <point x="766" y="735" type="qcurve"/>
       <point x="766" y="735" type="line"/>
-      <point x="766" y="720"/>
-      <point x="812" y="716"/>
+      <point x="766" y="721"/>
+      <point x="822" y="716"/>
       <point x="975" y="709" type="qcurve" smooth="yes"/>
       <point x="1236" y="697" type="line" smooth="yes"/>
       <point x="1544" y="683"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght400-ROND0.ufo/glyphs/five.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght400-ROND0.ufo/glyphs/five.glif
@@ -17,51 +17,51 @@
       <point x="1866" y="1289"/>
       <point x="1866" y="1289" name="inserted"/>
       <point x="1795" y="1289" type="qcurve"/>
-      <point x="449" y="1289" type="line"/>
-      <point x="321" y="790" type="line"/>
-      <point x="321" y="790" type="line"/>
-      <point x="410" y="841"/>
-      <point x="777" y="930"/>
-      <point x="1109" y="930" type="qcurve"/>
-      <point x="1109" y="930" type="line"/>
-      <point x="1583" y="930"/>
-      <point x="1985" y="676"/>
-      <point x="1985" y="464" type="qcurve"/>
-      <point x="1985" y="464" type="line"/>
-      <point x="1985" y="260"/>
-      <point x="1577" y="-32"/>
-      <point x="1107" y="-32" type="qcurve"/>
-      <point x="1107" y="-32" type="line"/>
-      <point x="671" y="-32"/>
-      <point x="213" y="101"/>
-      <point x="97" y="172" type="qcurve"/>
-      <point x="97" y="172" type="line"/>
-      <point x="59" y="197" name="inserted"/>
-      <point x="59" y="197"/>
-      <point x="91" y="252" type="qcurve"/>
-      <point x="91" y="252" type="line"/>
-      <point x="135" y="319"/>
-      <point x="135" y="319"/>
-      <point x="177" y="295" type="qcurve"/>
-      <point x="177" y="295" type="line"/>
-      <point x="273" y="241"/>
+      <point x="444" y="1289" type="line"/>
+      <point x="326" y="790" type="line"/>
+      <point x="326" y="790" type="line"/>
+      <point x="435" y="842"/>
+      <point x="844" y="930"/>
+      <point x="1129" y="930" type="qcurve"/>
+      <point x="1129" y="930" type="line"/>
+      <point x="1588" y="930"/>
+      <point x="1985" y="686"/>
+      <point x="1985" y="469" type="qcurve"/>
+      <point x="1985" y="469" type="line"/>
+      <point x="1985" y="243"/>
+      <point x="1572" y="-32"/>
+      <point x="1143" y="-32" type="qcurve"/>
+      <point x="1143" y="-32" type="line"/>
+      <point x="700" y="-32"/>
+      <point x="214" y="105"/>
+      <point x="98" y="176" type="qcurve"/>
+      <point x="98" y="176" type="line"/>
+      <point x="60" y="201" name="inserted"/>
+      <point x="60" y="201"/>
+      <point x="97" y="261" type="qcurve"/>
+      <point x="97" y="261" type="line"/>
+      <point x="136" y="322"/>
+      <point x="136" y="323"/>
+      <point x="178" y="299" type="qcurve"/>
+      <point x="178" y="299" type="line"/>
+      <point x="274" y="245"/>
       <point x="722" y="108"/>
-      <point x="1107" y="108" type="qcurve"/>
-      <point x="1107" y="108" type="line"/>
+      <point x="1138" y="108" type="qcurve"/>
+      <point x="1138" y="108" type="line"/>
       <point x="1521" y="108"/>
-      <point x="1834" y="322"/>
+      <point x="1834" y="309"/>
       <point x="1834" y="464" type="qcurve"/>
       <point x="1834" y="464" type="line"/>
-      <point x="1834" y="602"/>
-      <point x="1515" y="791"/>
-      <point x="1108" y="791" type="qcurve"/>
-      <point x="1108" y="791" type="line"/>
-      <point x="807" y="791"/>
-      <point x="444" y="715"/>
-      <point x="341" y="656" type="qcurve"/>
-      <point x="341" y="656" type="line"/>
-      <point x="285" y="624"/>
-      <point x="285" y="624"/>
+      <point x="1834" y="618"/>
+      <point x="1515" y="793"/>
+      <point x="1127" y="793" type="qcurve"/>
+      <point x="1127" y="793" type="line"/>
+      <point x="835" y="793"/>
+      <point x="462" y="707"/>
+      <point x="339" y="649" type="qcurve"/>
+      <point x="339" y="649" type="line"/>
+      <point x="280" y="624"/>
+      <point x="280" y="624"/>
       <point x="224" y="651" type="qcurve"/>
       <point x="224" y="651" type="line"/>
       <point x="159" y="681"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght400-ROND0.ufo/glyphs/one.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght400-ROND0.ufo/glyphs/one.glif
@@ -13,16 +13,16 @@
       <point x="987" y="0"/>
       <point x="987" y="69" type="qcurve" smooth="yes"/>
       <point x="987" y="1245" type="line"/>
-      <point x="159" y="663" type="line" smooth="yes"/>
-      <point x="114" y="632" name="inserted"/>
-      <point x="114" y="632"/>
-      <point x="64" y="700" type="qcurve"/>
-      <point x="64" y="700" type="line"/>
-      <point x="29" y="749"/>
-      <point x="29" y="749"/>
-      <point x="96" y="795" type="qcurve" smooth="yes"/>
+      <point x="205" y="732" type="line" smooth="yes"/>
+      <point x="160" y="703" name="inserted"/>
+      <point x="160" y="701"/>
+      <point x="110" y="769" type="qcurve"/>
+      <point x="110" y="769" type="line"/>
+      <point x="75" y="818"/>
+      <point x="73" y="820"/>
+      <point x="142" y="864" type="qcurve" smooth="yes"/>
       <point x="944.6153846153846" y="1379" type="line" smooth="yes"/>
-      <point x="1022" y="1432"/>
+      <point x="1023" y="1429"/>
       <point x="1022" y="1432"/>
       <point x="1067" y="1432" type="qcurve"/>
       <point x="1067" y="1432" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght400-ROND0.ufo/glyphs/three.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght400-ROND0.ufo/glyphs/three.glif
@@ -4,78 +4,78 @@
   <unicode hex="0033"/>
   <outline>
     <contour>
-      <point x="953" y="675" type="qcurve"/>
-      <point x="428" y="672" type="line"/>
-      <point x="358" y="672" name="inserted"/>
-      <point x="358" y="672"/>
-      <point x="358" y="742" type="qcurve"/>
-      <point x="358" y="742" type="line"/>
-      <point x="358" y="810"/>
-      <point x="358" y="810"/>
-      <point x="428" y="810" type="qcurve"/>
-      <point x="944" y="808" type="line"/>
-      <point x="1428" y="807"/>
-      <point x="1631" y="948"/>
-      <point x="1631" y="1066" type="qcurve"/>
-      <point x="1631" y="1066" type="line"/>
-      <point x="1631" y="1179"/>
-      <point x="1389.5" y="1324"/>
-      <point x="1018.5" y="1324" type="qcurve"/>
-      <point x="1004.5" y="1324" type="line"/>
-      <point x="655.5" y="1324"/>
-      <point x="325.5" y="1236"/>
-      <point x="237.5" y="1191" type="qcurve"/>
-      <point x="237.5" y="1191" type="line"/>
-      <point x="190" y="1170"/>
-      <point x="190" y="1170"/>
-      <point x="156" y="1249" type="qcurve"/>
-      <point x="156" y="1249" type="line"/>
-      <point x="130" y="1307"/>
-      <point x="130" y="1307" name="inserted"/>
-      <point x="177.5" y="1329" type="qcurve"/>
-      <point x="177.5" y="1329" type="line"/>
-      <point x="273.5" y="1378"/>
-      <point x="647.5" y="1464"/>
-      <point x="996.5" y="1464" type="qcurve"/>
-      <point x="1019.5" y="1464" type="line"/>
-      <point x="1457.5" y="1464"/>
+      <point x="953" y="685" type="qcurve"/>
+      <point x="508" y="682" type="line"/>
+      <point x="438" y="682" name="inserted"/>
+      <point x="438" y="682"/>
+      <point x="438" y="752" type="qcurve"/>
+      <point x="438" y="752" type="line"/>
+      <point x="438" y="820"/>
+      <point x="438" y="820"/>
+      <point x="508" y="820" type="qcurve"/>
+      <point x="944" y="818" type="line"/>
+      <point x="1408" y="817"/>
+      <point x="1631" y="955"/>
+      <point x="1631" y="1076" type="qcurve"/>
+      <point x="1631" y="1076" type="line"/>
+      <point x="1631" y="1193"/>
+      <point x="1370" y="1324"/>
+      <point x="1049" y="1324" type="qcurve"/>
+      <point x="1049" y="1324" type="line"/>
+      <point x="749" y="1324"/>
+      <point x="337" y="1242"/>
+      <point x="230" y="1203" type="qcurve"/>
+      <point x="230" y="1203" type="line"/>
+      <point x="183" y="1188"/>
+      <point x="183" y="1188"/>
+      <point x="156" y="1263" type="qcurve"/>
+      <point x="156" y="1263" type="line"/>
+      <point x="136" y="1318"/>
+      <point x="136" y="1318" name="inserted"/>
+      <point x="184" y="1334" type="qcurve"/>
+      <point x="184" y="1334" type="line"/>
+      <point x="287" y="1373"/>
+      <point x="713" y="1464"/>
+      <point x="1042" y="1464" type="qcurve"/>
+      <point x="1043" y="1464" type="line"/>
+      <point x="1428" y="1464"/>
       <point x="1782" y="1255"/>
       <point x="1782" y="1079" type="qcurve"/>
       <point x="1782" y="1079" type="line"/>
       <point x="1782" y="942"/>
-      <point x="1589" y="767"/>
-      <point x="1423" y="749" type="qcurve"/>
-      <point x="1423" y="749" type="line"/>
-      <point x="1613" y="724"/>
+      <point x="1589" y="774"/>
+      <point x="1423" y="756" type="qcurve"/>
+      <point x="1423" y="756" type="line"/>
+      <point x="1613" y="731"/>
       <point x="1828" y="564"/>
       <point x="1828" y="418" type="qcurve"/>
       <point x="1828" y="418" type="line"/>
       <point x="1828" y="230"/>
-      <point x="1459.5" y="-28"/>
-      <point x="980.5" y="-28" type="qcurve"/>
-      <point x="970.5" y="-28" type="line"/>
-      <point x="581.5" y="-28"/>
-      <point x="163.5" y="91"/>
-      <point x="47.5" y="169" type="qcurve"/>
-      <point x="47.5" y="169" type="line"/>
-      <point x="1" y="207" name="inserted"/>
-      <point x="1" y="207"/>
+      <point x="1460" y="-28"/>
+      <point x="1021" y="-28" type="qcurve"/>
+      <point x="1021" y="-28" type="line"/>
+      <point x="622" y="-28"/>
+      <point x="164" y="91"/>
+      <point x="48" y="169" type="qcurve"/>
+      <point x="48" y="169" type="line"/>
+      <point x="0" y="205" name="inserted"/>
+      <point x="0" y="205"/>
       <point x="42" y="266" type="qcurve"/>
       <point x="42" y="266" type="line"/>
       <point x="86" y="326"/>
       <point x="86" y="326"/>
-      <point x="125.5" y="298" type="qcurve"/>
-      <point x="125.5" y="298" type="line"/>
-      <point x="245.5" y="216"/>
-      <point x="610.5" y="107"/>
-      <point x="969.5" y="107" type="qcurve"/>
-      <point x="977" y="107" type="line"/>
+      <point x="126" y="298" type="qcurve"/>
+      <point x="126" y="298" type="line"/>
+      <point x="246" y="216"/>
+      <point x="652" y="107"/>
+      <point x="1019" y="107" type="qcurve"/>
+      <point x="1019" y="107" type="line"/>
       <point x="1391" y="107"/>
       <point x="1676" y="282"/>
       <point x="1676" y="417" type="qcurve"/>
       <point x="1676" y="417" type="line"/>
       <point x="1676" y="530"/>
-      <point x="1410" y="675"/>
+      <point x="1410" y="685"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght400-ROND0.ufo/glyphs/two.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght400-ROND0.ufo/glyphs/two.glif
@@ -8,45 +8,45 @@
       <point x="105" y="0" type="line"/>
       <point x="31" y="0" name="inserted"/>
       <point x="31" y="0"/>
-      <point x="31" y="88" type="qcurve"/>
-      <point x="31" y="88" type="line"/>
-      <point x="31" y="168"/>
-      <point x="31" y="168"/>
-      <point x="79" y="194" type="qcurve" smooth="yes"/>
-      <point x="874" y="618" type="line" smooth="yes"/>
-      <point x="1143" y="761"/>
-      <point x="1473" y="965"/>
-      <point x="1473" y="1077" type="qcurve"/>
-      <point x="1473" y="1077" type="line"/>
-      <point x="1473" y="1200"/>
-      <point x="1223" y="1321"/>
-      <point x="878" y="1321" type="qcurve"/>
-      <point x="878" y="1321" type="line"/>
-      <point x="583" y="1321"/>
-      <point x="265" y="1230"/>
-      <point x="173" y="1153" type="qcurve"/>
-      <point x="173" y="1153" type="line"/>
-      <point x="142" y="1127"/>
-      <point x="142" y="1127"/>
-      <point x="93" y="1184" type="qcurve"/>
-      <point x="93" y="1184" type="line"/>
-      <point x="54" y="1231"/>
-      <point x="54" y="1231" name="inserted"/>
-      <point x="94" y="1266" type="qcurve"/>
-      <point x="94" y="1266" type="line"/>
-      <point x="200" y="1357"/>
-      <point x="559" y="1454"/>
-      <point x="877" y="1454" type="qcurve"/>
-      <point x="877" y="1454" type="line"/>
-      <point x="1254" y="1454"/>
-      <point x="1614" y="1255"/>
-      <point x="1614" y="1075" type="qcurve"/>
-      <point x="1614" y="1075" type="line"/>
-      <point x="1614" y="913"/>
-      <point x="1242" y="672"/>
-      <point x="939" y="513" type="qcurve" smooth="yes"/>
-      <point x="215" y="132" type="line"/>
-      <point x="215" y="132" type="line"/>
+      <point x="31" y="77" type="qcurve"/>
+      <point x="31" y="77" type="line"/>
+      <point x="31" y="146"/>
+      <point x="29" y="149"/>
+      <point x="77" y="174" type="qcurve" smooth="yes"/>
+      <point x="874" y="588" type="line" smooth="yes"/>
+      <point x="1143" y="728"/>
+      <point x="1473" y="955"/>
+      <point x="1473" y="1067" type="qcurve"/>
+      <point x="1473" y="1067" type="line"/>
+      <point x="1473" y="1190"/>
+      <point x="1213" y="1321"/>
+      <point x="915" y="1321" type="qcurve"/>
+      <point x="915" y="1321" type="line"/>
+      <point x="634" y="1321"/>
+      <point x="262" y="1233"/>
+      <point x="163" y="1180" type="qcurve"/>
+      <point x="163" y="1180" type="line"/>
+      <point x="127" y="1162"/>
+      <point x="127" y="1162"/>
+      <point x="91" y="1223" type="qcurve"/>
+      <point x="91" y="1223" type="line"/>
+      <point x="61" y="1277"/>
+      <point x="61" y="1277" name="inserted"/>
+      <point x="108" y="1303" type="qcurve"/>
+      <point x="108" y="1303" type="line"/>
+      <point x="218" y="1365"/>
+      <point x="605" y="1454"/>
+      <point x="917" y="1454" type="qcurve"/>
+      <point x="917" y="1454" type="line"/>
+      <point x="1264" y="1454"/>
+      <point x="1614" y="1252"/>
+      <point x="1614" y="1072" type="qcurve"/>
+      <point x="1614" y="1072" type="line"/>
+      <point x="1614" y="910"/>
+      <point x="1245" y="638"/>
+      <point x="939" y="483" type="qcurve" smooth="yes"/>
+      <point x="248" y="132" type="line"/>
+      <point x="248" y="132" type="line"/>
       <point x="1584" y="132" type="line" smooth="yes"/>
       <point x="1645" y="132"/>
       <point x="1645" y="132"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/a.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/a.glif
@@ -15,7 +15,7 @@
       <point x="338" y="0"/>
       <point x="338" y="0"/>
       <point x="338" y="2" type="qcurve"/>
-      <point x="338" y="119" type="line"/>
+      <point x="338" y="123" type="line"/>
       <point x="338" y="123" type="line"/>
       <point x="327" y="56"/>
       <point x="257" y="-4"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/caroncomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/caroncomb.glif
@@ -5,34 +5,34 @@
   <anchor x="0" y="1354" name="top"/>
   <outline>
     <contour>
-      <point x="-4" y="1111" type="qcurve"/>
-      <point x="-123" y="1352" type="line"/>
-      <point x="-123" y="1352" type="line"/>
-      <point x="-124" y="1354"/>
-      <point x="-124" y="1354"/>
-      <point x="-122" y="1354" type="qcurve"/>
-      <point x="-122" y="1354" type="line"/>
-      <point x="-120" y="1354"/>
-      <point x="-120" y="1354" name="inserted"/>
-      <point x="-119" y="1352" type="qcurve"/>
-      <point x="-1" y="1114" type="line"/>
-      <point x="1" y="1114" type="line"/>
-      <point x="120" y="1352" type="line"/>
-      <point x="121" y="1354"/>
-      <point x="121" y="1354"/>
+      <point x="-3" y="1111" type="qcurve"/>
+      <point x="-122" y="1352" type="line"/>
+      <point x="-122" y="1352" type="line"/>
+      <point x="-123" y="1354"/>
+      <point x="-123" y="1354"/>
+      <point x="-121" y="1354" type="qcurve"/>
+      <point x="-121" y="1354" type="line"/>
+      <point x="-119" y="1354"/>
+      <point x="-119" y="1354" name="inserted"/>
+      <point x="0" y="1114" type="qcurve"/>
+      <point x="0" y="1114" type="line"/>
+      <point x="0" y="1114" type="line"/>
+      <point x="0" y="1114" type="line"/>
+      <point x="120" y="1354"/>
+      <point x="120" y="1354"/>
       <point x="122" y="1354" type="qcurve"/>
       <point x="122" y="1354" type="line"/>
-      <point x="125" y="1354"/>
-      <point x="125" y="1354" name="inserted"/>
-      <point x="124" y="1352" type="qcurve"/>
-      <point x="124" y="1352" type="line"/>
-      <point x="4" y="1111" type="line"/>
-      <point x="3" y="1109"/>
-      <point x="3" y="1109"/>
+      <point x="124" y="1354"/>
+      <point x="124" y="1354" name="inserted"/>
+      <point x="123" y="1352" type="qcurve"/>
+      <point x="123" y="1352" type="line"/>
+      <point x="3" y="1111" type="line"/>
+      <point x="2" y="1109"/>
+      <point x="2" y="1109"/>
       <point x="0" y="1109" type="qcurve"/>
       <point x="0" y="1109" type="line"/>
-      <point x="-3" y="1109"/>
-      <point x="-3" y="1109" name="inserted"/>
+      <point x="-2" y="1109"/>
+      <point x="-2" y="1109" name="inserted"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/circumflexcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/circumflexcomb.glif
@@ -5,34 +5,34 @@
   <anchor x="0" y="1354" name="top"/>
   <outline>
     <contour>
-      <point x="-124" y="1111" type="qcurve"/>
-      <point x="-124" y="1111" type="line"/>
-      <point x="-4" y="1352" type="line"/>
-      <point x="-3" y="1354"/>
-      <point x="-3" y="1354"/>
+      <point x="-123" y="1111" type="qcurve"/>
+      <point x="-123" y="1111" type="line"/>
+      <point x="-3" y="1352" type="line"/>
+      <point x="-2" y="1354"/>
+      <point x="-2" y="1354"/>
       <point x="0" y="1354" type="qcurve"/>
       <point x="0" y="1354" type="line"/>
-      <point x="3" y="1354"/>
-      <point x="3" y="1354" name="inserted"/>
-      <point x="4" y="1352" type="qcurve"/>
-      <point x="123" y="1111" type="line"/>
-      <point x="123" y="1111" type="line"/>
-      <point x="124" y="1109"/>
-      <point x="124" y="1109"/>
-      <point x="122" y="1109" type="qcurve"/>
-      <point x="122" y="1109" type="line"/>
-      <point x="120" y="1109"/>
-      <point x="120" y="1109" name="inserted"/>
-      <point x="119" y="1111" type="qcurve"/>
-      <point x="1" y="1349" type="line"/>
-      <point x="-1" y="1349" type="line"/>
-      <point x="-120" y="1111" type="line"/>
-      <point x="-121" y="1109"/>
-      <point x="-121" y="1109"/>
+      <point x="2" y="1354"/>
+      <point x="2" y="1354" name="inserted"/>
+      <point x="3" y="1352" type="qcurve"/>
+      <point x="122" y="1111" type="line"/>
+      <point x="122" y="1111" type="line"/>
+      <point x="123" y="1109"/>
+      <point x="123" y="1109"/>
+      <point x="121" y="1109" type="qcurve"/>
+      <point x="121" y="1109" type="line"/>
+      <point x="119" y="1109"/>
+      <point x="119" y="1109" name="inserted"/>
+      <point x="0" y="1349" type="qcurve"/>
+      <point x="0" y="1349" type="line"/>
+      <point x="0" y="1349" type="line"/>
+      <point x="0" y="1349" type="line"/>
+      <point x="-120" y="1109"/>
+      <point x="-120" y="1109"/>
       <point x="-122" y="1109" type="qcurve"/>
       <point x="-122" y="1109" type="line"/>
-      <point x="-125" y="1109"/>
-      <point x="-125" y="1109" name="inserted"/>
+      <point x="-124" y="1109"/>
+      <point x="-124" y="1109" name="inserted"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/comma.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/comma.glif
@@ -4,11 +4,11 @@
   <unicode hex="002C"/>
   <outline>
     <contour>
-      <point x="43" y="-97" type="line"/>
-      <point x="38" y="-104" name="inserted"/>
-      <point x="38" y="-104"/>
-      <point x="36" y="-103" type="qcurve"/>
-      <point x="35" y="-102" type="line"/>
+      <point x="42" y="-99" type="line"/>
+      <point x="39" y="-104" name="inserted"/>
+      <point x="39" y="-104"/>
+      <point x="36" y="-102" type="qcurve"/>
+      <point x="36" y="-101" type="line"/>
       <point x="100" y="6" type="line"/>
       <point x="92" y="4"/>
       <point x="80" y="14"/>
@@ -20,7 +20,7 @@
       <point x="112" y="26"/>
       <point x="112" y="20" type="qcurve" smooth="yes"/>
       <point x="112" y="16" name="inserted"/>
-      <point x="104" y="4"/>
+      <point x="106" y="6"/>
       <point x="102" y="0" type="qcurve" smooth="yes"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -4,11 +4,11 @@
   <anchor x="0" y="0" name="_bottom"/>
   <outline>
     <contour>
-      <point x="-53" y="-246" type="line"/>
-      <point x="-58" y="-253" name="inserted"/>
-      <point x="-58" y="-253"/>
-      <point x="-60" y="-252" type="qcurve"/>
-      <point x="-61" y="-251" type="line"/>
+      <point x="-54" y="-248" type="line"/>
+      <point x="-57" y="-253" name="inserted"/>
+      <point x="-57" y="-253"/>
+      <point x="-60" y="-251" type="qcurve"/>
+      <point x="-60" y="-250" type="line"/>
       <point x="4" y="-143" type="line"/>
       <point x="-4" y="-145"/>
       <point x="-16" y="-135"/>
@@ -20,7 +20,7 @@
       <point x="16" y="-123"/>
       <point x="16" y="-129" type="qcurve" smooth="yes"/>
       <point x="16" y="-133" name="inserted"/>
-      <point x="8" y="-145"/>
+      <point x="10" y="-143"/>
       <point x="6" y="-149" type="qcurve" smooth="yes"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/commaturnedabovecomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/commaturnedabovecomb.glif
@@ -5,11 +5,11 @@
   <anchor x="0" y="1712" name="top"/>
   <outline>
     <contour>
-      <point x="53" y="1299" type="line"/>
-      <point x="58" y="1306" name="inserted"/>
-      <point x="58" y="1306"/>
-      <point x="60" y="1305" type="qcurve"/>
-      <point x="61" y="1304" type="line"/>
+      <point x="54" y="1301" type="line"/>
+      <point x="57" y="1306" name="inserted"/>
+      <point x="57" y="1306"/>
+      <point x="60" y="1304" type="qcurve"/>
+      <point x="60" y="1303" type="line"/>
       <point x="-4" y="1196" type="line"/>
       <point x="4" y="1198"/>
       <point x="16" y="1188"/>
@@ -21,7 +21,7 @@
       <point x="-16" y="1176"/>
       <point x="-16" y="1182" type="qcurve" smooth="yes"/>
       <point x="-16" y="1186" name="inserted"/>
-      <point x="-8" y="1198"/>
+      <point x="-10" y="1196"/>
       <point x="-6" y="1202" type="qcurve" smooth="yes"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/germandbls.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/germandbls.glif
@@ -16,10 +16,10 @@
       <point x="353" y="1203" type="qcurve"/>
       <point x="353" y="1003" type="line"/>
       <point x="353" y="896"/>
-      <point x="292" y="782"/>
-      <point x="224" y="773" type="qcurve"/>
-      <point x="224" y="772" type="line"/>
-      <point x="313" y="762"/>
+      <point x="292" y="781"/>
+      <point x="218" y="772" type="qcurve"/>
+      <point x="218" y="772" type="line"/>
+      <point x="309" y="766"/>
       <point x="393" y="632"/>
       <point x="393" y="503" type="qcurve"/>
       <point x="393" y="303" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/m.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/m.glif
@@ -52,8 +52,8 @@
       <point x="94" y="1020"/>
       <point x="94" y="1020" name="inserted"/>
       <point x="94" y="1018" type="qcurve"/>
-      <point x="94" y="846" type="line"/>
-      <point x="92" y="846" type="line"/>
+      <point x="94" y="855" type="line"/>
+      <point x="94" y="855" type="line"/>
       <point x="94" y="936"/>
       <point x="170" y="1032"/>
       <point x="234" y="1032" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/n.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/n.glif
@@ -37,8 +37,8 @@
       <point x="94" y="1020"/>
       <point x="94" y="1020" name="inserted"/>
       <point x="94" y="1018" type="qcurve"/>
-      <point x="94" y="846" type="line"/>
-      <point x="92" y="846" type="line"/>
+      <point x="94" y="855" type="line"/>
+      <point x="94" y="855" type="line"/>
       <point x="94" y="936"/>
       <point x="170" y="1032"/>
       <point x="234" y="1032" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/ordfeminine.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/ordfeminine.glif
@@ -60,8 +60,8 @@
       <point x="338" y="550"/>
       <point x="338" y="550"/>
       <point x="338" y="552" type="qcurve"/>
-      <point x="338" y="813" type="line"/>
-      <point x="337" y="813" type="line"/>
+      <point x="338" y="821" type="line"/>
+      <point x="338" y="821" type="line"/>
       <point x="325" y="646"/>
       <point x="259" y="544"/>
     </contour>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/q.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/q.glif
@@ -28,7 +28,7 @@
       <point x="136" y="1032"/>
       <point x="216" y="1032" type="qcurve" smooth="yes"/>
       <point x="277" y="1032"/>
-      <point x="352" y="950"/>
+      <point x="355" y="945"/>
       <point x="364" y="863" type="qcurve"/>
       <point x="364" y="863" type="line"/>
       <point x="364" y="1018" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/semicolon.glif
@@ -18,11 +18,11 @@
       <point x="150" y="962"/>
     </contour>
     <contour>
-      <point x="75" y="-100" type="line"/>
-      <point x="72" y="-105" name="inserted"/>
-      <point x="72" y="-105"/>
-      <point x="69" y="-104" type="qcurve"/>
-      <point x="69" y="-102" type="line"/>
+      <point x="76" y="-99" type="line"/>
+      <point x="73" y="-104" name="inserted"/>
+      <point x="73" y="-104"/>
+      <point x="70" y="-102" type="qcurve"/>
+      <point x="70" y="-101" type="line"/>
       <point x="134" y="6" type="line"/>
       <point x="126" y="4"/>
       <point x="114" y="14"/>
@@ -34,7 +34,7 @@
       <point x="146" y="26"/>
       <point x="146" y="20" type="qcurve" smooth="yes"/>
       <point x="146" y="16" name="inserted"/>
-      <point x="138" y="4"/>
+      <point x="140" y="6"/>
       <point x="136" y="0" type="qcurve" smooth="yes"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/sterling.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/sterling.glif
@@ -47,9 +47,9 @@
       <point x="157" y="561" type="qcurve"/>
       <point x="157" y="387" type="line"/>
       <point x="157" y="265"/>
-      <point x="103" y="67"/>
-      <point x="52" y="5" type="qcurve"/>
-      <point x="52" y="4" type="line"/>
+      <point x="103" y="66"/>
+      <point x="51" y="4" type="qcurve"/>
+      <point x="51" y="4" type="line"/>
       <point x="304" y="4" type="line"/>
       <point x="362" y="4"/>
       <point x="417" y="134"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/u.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/glyphs/u.glif
@@ -44,8 +44,8 @@
       <point x="334" y="0"/>
       <point x="334" y="0" name="inserted"/>
       <point x="334" y="2" type="qcurve"/>
-      <point x="334" y="174" type="line"/>
-      <point x="336" y="174" type="line"/>
+      <point x="335" y="166" type="line"/>
+      <point x="335" y="166" type="line"/>
       <point x="334" y="88"/>
       <point x="259" y="-4"/>
     </contour>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/A_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/A_.glif
@@ -7,46 +7,46 @@
   <anchor x="627" y="1432" name="top"/>
   <outline>
     <contour>
-      <point x="1196.248366013072" y="295" type="line"/>
+      <point x="1196" y="295" type="line"/>
       <point x="1262" y="0"/>
       <point x="1262" y="0"/>
       <point x="1005" y="0" type="qcurve"/>
       <point x="1005" y="0" type="line"/>
       <point x="713" y="0"/>
       <point x="713" y="0" name="inserted"/>
-      <point x="693.2483660130719" y="192" type="qcurve" smooth="yes"/>
-      <point x="638.2483660130719" y="716" type="line"/>
-      <point x="628.2483660130719" y="806" type="line"/>
-      <point x="626.2483660130719" y="806" type="line"/>
-      <point x="618.2483660130719" y="716" type="line"/>
-      <point x="555.2483660130719" y="191" type="line" smooth="yes"/>
+      <point x="693" y="192" type="qcurve" smooth="yes"/>
+      <point x="638" y="716" type="line"/>
+      <point x="627" y="811" type="line"/>
+      <point x="627" y="811" type="line"/>
+      <point x="618" y="716" type="line"/>
+      <point x="555" y="191" type="line" smooth="yes"/>
       <point x="532" y="0" name="inserted"/>
       <point x="532" y="0"/>
       <point x="246" y="0" type="qcurve"/>
       <point x="246" y="0" type="line"/>
       <point x="-10" y="0"/>
       <point x="-10" y="0"/>
-      <point x="56.248366013071895" y="293" type="qcurve" smooth="yes"/>
-      <point x="252.2483660130719" y="1165" type="line" smooth="yes"/>
+      <point x="56" y="293" type="qcurve" smooth="yes"/>
+      <point x="252" y="1165" type="line" smooth="yes"/>
       <point x="312" y="1432" name="inserted"/>
       <point x="310" y="1432"/>
       <point x="617" y="1432" type="qcurve"/>
       <point x="633" y="1432" type="line"/>
       <point x="944" y="1432"/>
       <point x="944" y="1432"/>
-      <point x="1002.2483660130719" y="1168" type="qcurve" smooth="yes"/>
+      <point x="1002" y="1168" type="qcurve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="998.2483660130719" y="172" type="line"/>
-      <point x="626.2483660130719" y="172" type="line"/>
-      <point x="626.2483660130719" y="524" type="line"/>
-      <point x="920.2483660130719" y="524" type="line"/>
+      <point x="998" y="172" type="line"/>
+      <point x="626" y="172" type="line"/>
+      <point x="626" y="524" type="line"/>
+      <point x="920" y="524" type="line"/>
     </contour>
     <contour>
-      <point x="626.2483660130719" y="172" type="line"/>
-      <point x="252.2483660130719" y="172" type="line"/>
-      <point x="322.2483660130719" y="524" type="line"/>
-      <point x="626.2483660130719" y="524" type="line"/>
+      <point x="626" y="172" type="line"/>
+      <point x="252" y="172" type="line"/>
+      <point x="322" y="524" type="line"/>
+      <point x="626" y="524" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/E_th-bar.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/E_th-bar.glif
@@ -4,22 +4,22 @@
   <guideline x="430" y="0" angle="90" identifier="5RU0K4tdaF"/>
   <outline>
     <contour>
-      <point x="31" y="588" type="line"/>
-      <point x="-30" y="588"/>
-      <point x="-30" y="588"/>
-      <point x="-30" y="706" type="qcurve"/>
-      <point x="-30" y="706" type="line"/>
-      <point x="-30" y="824"/>
-      <point x="-30" y="824" name="inserted"/>
-      <point x="31" y="824" type="qcurve"/>
-      <point x="602" y="824" type="line"/>
-      <point x="665" y="824" name="inserted"/>
-      <point x="665" y="824"/>
-      <point x="665" y="707" type="qcurve"/>
-      <point x="665" y="707" type="line"/>
-      <point x="665" y="588"/>
-      <point x="665" y="588"/>
-      <point x="602" y="588" type="qcurve"/>
+      <point x="160" y="588" type="line"/>
+      <point x="99" y="588"/>
+      <point x="99" y="588"/>
+      <point x="99" y="706" type="qcurve"/>
+      <point x="99" y="706" type="line"/>
+      <point x="99" y="824"/>
+      <point x="99" y="824" name="inserted"/>
+      <point x="160" y="824" type="qcurve"/>
+      <point x="731" y="824" type="line"/>
+      <point x="794" y="824" name="inserted"/>
+      <point x="794" y="824"/>
+      <point x="794" y="707" type="qcurve"/>
+      <point x="794" y="707" type="line"/>
+      <point x="794" y="588"/>
+      <point x="794" y="588"/>
+      <point x="731" y="588" type="qcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/E_th.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/E_th.glif
@@ -4,7 +4,7 @@
   <unicode hex="00D0"/>
   <outline>
     <component base="D"/>
-    <component base="Eth-bar"/>
+    <component base="Eth-bar" xOffset="-129"/>
   </outline>
   <lib>
     <dict>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/M_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/M_.glif
@@ -9,51 +9,51 @@
     <contour>
       <point x="586" y="265" type="line" smooth="yes"/>
       <point x="586" y="0" name="inserted"/>
-      <point x="585" y="0"/>
+      <point x="586" y="0"/>
       <point x="304" y="0" type="qcurve"/>
       <point x="304" y="0" type="line"/>
-      <point x="41" y="0"/>
+      <point x="42" y="0"/>
       <point x="42" y="0"/>
       <point x="42" y="265" type="qcurve"/>
       <point x="42" y="1081" type="line"/>
-      <point x="42" y="1432"/>
-      <point x="41" y="1433"/>
+      <point x="42" y="1433"/>
+      <point x="42" y="1433"/>
       <point x="391" y="1433" type="qcurve"/>
       <point x="391" y="1433" type="line"/>
-      <point x="745" y="1433"/>
-      <point x="747" y="1432" name="inserted"/>
+      <point x="746" y="1433"/>
+      <point x="746" y="1433" name="inserted"/>
       <point x="779" y="1081" type="qcurve" smooth="yes"/>
-      <point x="815" y="688" type="line"/>
-      <point x="817" y="688" type="line"/>
+      <point x="816" y="683" type="line"/>
+      <point x="816" y="683" type="line"/>
       <point x="847" y="1081" type="line" smooth="yes"/>
       <point x="874" y="1433"/>
-      <point x="873" y="1433"/>
+      <point x="874" y="1433"/>
       <point x="1211" y="1433" type="qcurve"/>
       <point x="1211" y="1433" type="line"/>
       <point x="1584" y="1433"/>
-      <point x="1584" y="1432" name="inserted"/>
+      <point x="1584" y="1433" name="inserted"/>
       <point x="1584" y="1081" type="qcurve"/>
       <point x="1584" y="254" type="line"/>
       <point x="1584" y="0" name="inserted"/>
-      <point x="1584" y="1"/>
+      <point x="1584" y="0"/>
       <point x="1316" y="0" type="qcurve"/>
       <point x="1316" y="0" type="line"/>
       <point x="1066" y="0"/>
-      <point x="1066" y="1"/>
+      <point x="1066" y="0"/>
       <point x="1066" y="254" type="qcurve"/>
       <point x="1066" y="432" type="line"/>
-      <point x="1068" y="576" type="line"/>
-      <point x="1066" y="576" type="line"/>
+      <point x="1067" y="582" type="line"/>
+      <point x="1067" y="582" type="line"/>
       <point x="1031" y="194" type="line" smooth="yes"/>
-      <point x="1013" y="1" name="inserted"/>
-      <point x="1012" y="1"/>
-      <point x="825" y="1" type="qcurve"/>
-      <point x="825" y="1" type="line"/>
-      <point x="654" y="1"/>
-      <point x="655" y="1"/>
+      <point x="1013" y="0" name="inserted"/>
+      <point x="1013" y="0"/>
+      <point x="825" y="0" type="qcurve"/>
+      <point x="825" y="0" type="line"/>
+      <point x="655" y="0"/>
+      <point x="655" y="0"/>
       <point x="632" y="194" type="qcurve" smooth="yes"/>
-      <point x="586" y="578" type="line"/>
-      <point x="584" y="578" type="line"/>
+      <point x="585" y="584" type="line"/>
+      <point x="585" y="584" type="line"/>
       <point x="586" y="436" type="line"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/N_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/N_.glif
@@ -8,13 +8,13 @@
     <contour>
       <point x="1214" y="276" type="line" smooth="yes"/>
       <point x="1214" y="0"/>
-      <point x="1213" y="0"/>
+      <point x="1214" y="0"/>
       <point x="940" y="0" type="qcurve"/>
       <point x="940" y="0" type="line"/>
       <point x="695" y="0"/>
-      <point x="695" y="0" name="inserted"/>
+      <point x="697" y="0" name="inserted"/>
       <point x="650" y="211" type="qcurve" smooth="yes"/>
-      <point x="592" y="482" type="line"/>
+      <point x="590" y="482" type="line"/>
       <point x="590" y="482" type="line"/>
       <point x="590" y="482" type="line"/>
       <point x="590" y="267" type="line" smooth="yes"/>
@@ -22,27 +22,27 @@
       <point x="590" y="0"/>
       <point x="307" y="0" type="qcurve"/>
       <point x="307" y="0" type="line"/>
-      <point x="43" y="0"/>
+      <point x="42" y="0"/>
       <point x="42" y="0"/>
       <point x="42" y="267" type="qcurve" smooth="yes"/>
       <point x="42" y="1146" type="line"/>
-      <point x="42" y="1431"/>
+      <point x="42" y="1432"/>
       <point x="42" y="1432"/>
       <point x="325" y="1432" type="qcurve"/>
       <point x="325" y="1432" type="line"/>
       <point x="581" y="1432"/>
-      <point x="581" y="1431" name="inserted"/>
+      <point x="581" y="1432" name="inserted"/>
       <point x="625" y="1213" type="qcurve" smooth="yes"/>
       <point x="678" y="950" type="line"/>
       <point x="678" y="950" type="line"/>
       <point x="678" y="950" type="line"/>
       <point x="678" y="1173" type="line" smooth="yes"/>
       <point x="678" y="1432"/>
-      <point x="679" y="1432"/>
+      <point x="678" y="1432"/>
       <point x="937" y="1432" type="qcurve"/>
       <point x="937" y="1432" type="line"/>
-      <point x="1213" y="1432"/>
-      <point x="1214" y="1433" name="inserted"/>
+      <point x="1214" y="1432"/>
+      <point x="1214" y="1432" name="inserted"/>
       <point x="1214" y="1173" type="qcurve" smooth="yes"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/W_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/W_.glif
@@ -7,11 +7,11 @@
   <outline>
     <contour>
       <point x="1608" y="263" type="line" smooth="yes"/>
-      <point x="1558" y="1" name="inserted"/>
-      <point x="1558" y="1"/>
-      <point x="1284" y="1" type="qcurve"/>
-      <point x="1280" y="1" type="line"/>
-      <point x="993" y="1"/>
+      <point x="1557" y="0" name="inserted"/>
+      <point x="1557" y="0"/>
+      <point x="1284" y="0" type="qcurve"/>
+      <point x="1284" y="0" type="line"/>
+      <point x="993" y="0"/>
       <point x="993" y="0"/>
       <point x="951" y="260" type="qcurve" smooth="yes"/>
       <point x="919" y="459" type="line"/>
@@ -19,31 +19,31 @@
       <point x="896" y="602" type="line"/>
       <point x="873" y="459" type="line"/>
       <point x="842" y="263" type="line" smooth="yes"/>
-      <point x="801" y="1" name="inserted"/>
-      <point x="800" y="1"/>
-      <point x="518" y="1" type="qcurve"/>
-      <point x="514" y="1" type="line"/>
-      <point x="236" y="0"/>
-      <point x="235" y="-1"/>
-      <point x="185" y="260" type="qcurve" smooth="yes"/>
+      <point x="800" y="0" name="inserted"/>
+      <point x="800" y="0"/>
+      <point x="518" y="0" type="qcurve"/>
+      <point x="518" y="0" type="line"/>
+      <point x="235" y="0"/>
+      <point x="239" y="0"/>
+      <point x="185" y="260" type="qcurve"/>
       <point x="16" y="1148" type="line" smooth="yes"/>
       <point x="-38" y="1432"/>
-      <point x="-39" y="1432"/>
+      <point x="-38" y="1432"/>
       <point x="225" y="1432" type="qcurve"/>
       <point x="225" y="1432" type="line"/>
-      <point x="511" y="1432"/>
-      <point x="510" y="1431" name="inserted"/>
+      <point x="510" y="1432"/>
+      <point x="510" y="1432" name="inserted"/>
       <point x="536" y="1233" type="qcurve" smooth="yes"/>
       <point x="583" y="875" type="line"/>
       <point x="598" y="766" type="line"/>
       <point x="598" y="766" type="line"/>
       <point x="610" y="874" type="line"/>
       <point x="649" y="1240" type="line" smooth="yes"/>
-      <point x="670" y="1433"/>
-      <point x="670" y="1433"/>
-      <point x="894" y="1433" type="qcurve"/>
-      <point x="897" y="1433" type="line"/>
-      <point x="1116" y="1433"/>
+      <point x="669" y="1432"/>
+      <point x="669" y="1432"/>
+      <point x="894" y="1432" type="qcurve"/>
+      <point x="894" y="1432" type="line"/>
+      <point x="1116" y="1432"/>
       <point x="1116" y="1432" name="inserted"/>
       <point x="1139" y="1238" type="qcurve" smooth="yes"/>
       <point x="1182" y="878" type="line"/>
@@ -51,8 +51,8 @@
       <point x="1197" y="764" type="line"/>
       <point x="1214" y="878" type="line"/>
       <point x="1278" y="1244" type="line" smooth="yes"/>
-      <point x="1311" y="1431" name="inserted"/>
-      <point x="1310" y="1432"/>
+      <point x="1311" y="1432" name="inserted"/>
+      <point x="1311" y="1432"/>
       <point x="1587" y="1432" type="qcurve"/>
       <point x="1587" y="1432" type="line"/>
       <point x="1832" y="1432"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/a.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/a.glif
@@ -15,8 +15,8 @@
       <point x="617" y="0"/>
       <point x="617" y="0"/>
       <point x="617" y="104" type="qcurve"/>
-      <point x="615" y="104" type="line"/>
-      <point x="615" y="104" type="line"/>
+      <point x="617" y="104" type="line"/>
+      <point x="617" y="104" type="line"/>
       <point x="573" y="44"/>
       <point x="415" y="-24"/>
       <point x="333" y="-24" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/b.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/b.glif
@@ -30,7 +30,7 @@
       <point x="532" y="1203" type="qcurve"/>
       <point x="532" y="1044" type="line"/>
       <point x="532" y="976" type="line"/>
-      <point x="538" y="976" type="line"/>
+      <point x="532" y="976" type="line"/>
       <point x="569" y="1008"/>
       <point x="681" y="1040"/>
       <point x="750" y="1040" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/braceright.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/braceright.glif
@@ -25,8 +25,8 @@
       <point x="203" y="387" type="line" smooth="yes"/>
       <point x="203" y="497"/>
       <point x="307" y="589"/>
-      <point x="413" y="611" type="qcurve"/>
-      <point x="413" y="621" type="line"/>
+      <point x="423" y="616" type="qcurve"/>
+      <point x="423" y="616" type="line"/>
       <point x="307" y="649"/>
       <point x="203" y="745"/>
       <point x="203" y="853" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/caroncomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/caroncomb.glif
@@ -5,34 +5,34 @@
   <anchor x="0" y="1481" name="top"/>
   <outline>
     <contour>
-      <point x="-221" y="1257" type="qcurve" smooth="yes"/>
-      <point x="-250" y="1298" type="line"/>
-      <point x="-275" y="1332" type="line"/>
-      <point x="-383" y="1481"/>
-      <point x="-383" y="1481"/>
-      <point x="-197" y="1481" type="qcurve"/>
-      <point x="-177" y="1481" type="line"/>
-      <point x="-50" y="1481"/>
-      <point x="-50" y="1481" name="inserted"/>
-      <point x="15" y="1328" type="qcurve"/>
-      <point x="30" y="1310" type="line"/>
-      <point x="-22" y="1310" type="line"/>
-      <point x="-8" y="1328" type="line"/>
-      <point x="51" y="1481" name="inserted"/>
-      <point x="51" y="1481"/>
-      <point x="199" y="1481" type="qcurve"/>
-      <point x="219" y="1481" type="line"/>
-      <point x="382" y="1481"/>
-      <point x="382" y="1482"/>
-      <point x="277" y="1333" type="qcurve" smooth="yes"/>
-      <point x="257" y="1304" type="line"/>
-      <point x="227" y="1262" type="line" smooth="yes"/>
-      <point x="130" y="1122"/>
-      <point x="130" y="1122"/>
-      <point x="2" y="1122" type="qcurve"/>
-      <point x="2" y="1122" type="line"/>
-      <point x="-124" y="1122"/>
-      <point x="-124" y="1122"/>
+      <point x="-224" y="1257" type="qcurve" smooth="yes"/>
+      <point x="-253" y="1298" type="line"/>
+      <point x="-278" y="1332" type="line" smooth="yes"/>
+      <point x="-387" y="1481"/>
+      <point x="-387" y="1481"/>
+      <point x="-220" y="1481" type="qcurve"/>
+      <point x="-220" y="1481" type="line"/>
+      <point x="-53" y="1481"/>
+      <point x="-53" y="1481" name="inserted"/>
+      <point x="0" y="1356" type="qcurve"/>
+      <point x="0" y="1356" type="line"/>
+      <point x="0" y="1356" type="line"/>
+      <point x="0" y="1356" type="line"/>
+      <point x="48" y="1481" name="inserted"/>
+      <point x="48" y="1481"/>
+      <point x="212" y="1481" type="qcurve"/>
+      <point x="212" y="1481" type="line"/>
+      <point x="376" y="1481"/>
+      <point x="376" y="1481"/>
+      <point x="274" y="1333" type="qcurve" smooth="yes"/>
+      <point x="254" y="1304" type="line"/>
+      <point x="224" y="1262" type="line" smooth="yes"/>
+      <point x="124" y="1122"/>
+      <point x="124" y="1122"/>
+      <point x="-1" y="1122" type="qcurve"/>
+      <point x="-1" y="1122" type="line"/>
+      <point x="-127" y="1122"/>
+      <point x="-127" y="1122"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/circumflexcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/circumflexcomb.glif
@@ -19,20 +19,20 @@
       <point x="274" y="1271" type="line"/>
       <point x="382" y="1122"/>
       <point x="382" y="1122"/>
-      <point x="196" y="1122" type="qcurve"/>
-      <point x="176" y="1122" type="line"/>
+      <point x="216" y="1122" type="qcurve"/>
+      <point x="216" y="1122" type="line"/>
       <point x="49" y="1122"/>
       <point x="49" y="1122" name="inserted"/>
-      <point x="-16" y="1275" type="qcurve"/>
-      <point x="-31" y="1293" type="line"/>
-      <point x="21" y="1293" type="line"/>
-      <point x="7" y="1275" type="line"/>
+      <point x="-4" y="1246" type="qcurve"/>
+      <point x="-4" y="1246" type="line"/>
+      <point x="-4" y="1246" type="line"/>
+      <point x="-4" y="1246" type="line"/>
       <point x="-52" y="1122" name="inserted"/>
       <point x="-52" y="1122"/>
-      <point x="-200" y="1122" type="qcurve"/>
-      <point x="-220" y="1122" type="line"/>
-      <point x="-383" y="1122"/>
-      <point x="-383" y="1121"/>
+      <point x="-217" y="1122" type="qcurve"/>
+      <point x="-217" y="1122" type="line"/>
+      <point x="-382" y="1122"/>
+      <point x="-382" y="1122"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/comma.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/comma.glif
@@ -4,11 +4,11 @@
   <unicode hex="002C"/>
   <outline>
     <contour>
-      <point x="354" y="-112" type="line" smooth="yes"/>
-      <point x="219" y="-293" name="inserted"/>
-      <point x="219" y="-293"/>
-      <point x="14" y="-160" type="qcurve"/>
-      <point x="14" y="-124" type="line"/>
+      <point x="372" y="-98" type="line"/>
+      <point x="233" y="-302" name="inserted"/>
+      <point x="233" y="-302"/>
+      <point x="24" y="-166" type="qcurve"/>
+      <point x="24" y="-108" type="line"/>
       <point x="132" y="62" type="line"/>
       <point x="96" y="79"/>
       <point x="36" y="157"/>
@@ -20,7 +20,7 @@
       <point x="529" y="341"/>
       <point x="529" y="240" type="qcurve" smooth="yes"/>
       <point x="529" y="190"/>
-      <point x="499" y="84"/>
+      <point x="496" y="84"/>
       <point x="458" y="28" type="qcurve" smooth="yes"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -4,11 +4,11 @@
   <anchor x="0" y="0" name="_bottom"/>
   <outline>
     <contour>
-      <point x="71" y="-493" type="line" smooth="yes"/>
-      <point x="-33" y="-642" name="inserted"/>
-      <point x="-33" y="-642"/>
-      <point x="-187" y="-545" type="qcurve"/>
-      <point x="-174" y="-526" type="line"/>
+      <point x="73" y="-493" type="line" smooth="yes"/>
+      <point x="-30" y="-646" name="inserted"/>
+      <point x="-30" y="-646"/>
+      <point x="-170" y="-555" type="qcurve"/>
+      <point x="-170" y="-519" type="line"/>
       <point x="-98" y="-403" type="line"/>
       <point x="-131" y="-385"/>
       <point x="-178" y="-321"/>
@@ -20,7 +20,7 @@
       <point x="177" y="-188"/>
       <point x="177" y="-261" type="qcurve" smooth="yes"/>
       <point x="177" y="-297"/>
-      <point x="155" y="-372"/>
+      <point x="154" y="-372"/>
       <point x="126" y="-414" type="qcurve" smooth="yes"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/commaturnedabovecomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/commaturnedabovecomb.glif
@@ -5,23 +5,23 @@
   <anchor x="0" y="1655" name="top"/>
   <outline>
     <contour>
-      <point x="-72" y="1506" type="line" smooth="yes"/>
-      <point x="32" y="1655" name="inserted"/>
-      <point x="32" y="1655"/>
-      <point x="185" y="1558" type="qcurve"/>
-      <point x="173" y="1539" type="line"/>
+      <point x="-74" y="1506" type="line" smooth="yes"/>
+      <point x="29" y="1659" name="inserted"/>
+      <point x="29" y="1659"/>
+      <point x="169" y="1568" type="qcurve"/>
+      <point x="169" y="1532" type="line"/>
       <point x="97" y="1416" type="line"/>
-      <point x="129" y="1398"/>
+      <point x="130" y="1398"/>
       <point x="177" y="1334"/>
       <point x="177" y="1274" type="qcurve" smooth="yes"/>
       <point x="177" y="1201"/>
       <point x="71" y="1102"/>
       <point x="0" y="1102" type="qcurve" smooth="yes"/>
-      <point x="-75" y="1102"/>
-      <point x="-179" y="1201"/>
-      <point x="-179" y="1274" type="qcurve" smooth="yes"/>
-      <point x="-179" y="1310"/>
-      <point x="-156" y="1385"/>
+      <point x="-74" y="1102"/>
+      <point x="-178" y="1201"/>
+      <point x="-178" y="1274" type="qcurve" smooth="yes"/>
+      <point x="-178" y="1310"/>
+      <point x="-155" y="1385"/>
       <point x="-127" y="1427" type="qcurve" smooth="yes"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/eight.numerator.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/eight.numerator.glif
@@ -15,8 +15,8 @@
       <point x="20" y="902" type="line"/>
       <point x="20" y="986"/>
       <point x="96" y="1076"/>
-      <point x="135" y="1088" type="qcurve"/>
-      <point x="135" y="1093" type="line"/>
+      <point x="140" y="1091" type="qcurve"/>
+      <point x="140" y="1091" type="line"/>
       <point x="98" y="1107"/>
       <point x="50" y="1182"/>
       <point x="50" y="1242" type="qcurve"/>
@@ -31,8 +31,8 @@
       <point x="634" y="1251" type="line"/>
       <point x="634" y="1182"/>
       <point x="575" y="1107"/>
-      <point x="535" y="1093" type="qcurve"/>
-      <point x="535" y="1088" type="line"/>
+      <point x="530" y="1091" type="qcurve"/>
+      <point x="530" y="1091" type="line"/>
       <point x="575" y="1077"/>
       <point x="665" y="989"/>
       <point x="665" y="902" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/f.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/f.glif
@@ -6,11 +6,11 @@
   <anchor x="480" y="1428" name="top"/>
   <outline>
     <contour>
-      <point x="595" y="241" type="line" smooth="yes"/>
-      <point x="595" y="0" name="inserted"/>
-      <point x="595" y="0"/>
-      <point x="339" y="0" type="qcurve"/>
-      <point x="339" y="0" type="line"/>
+      <point x="570" y="241" type="line" smooth="yes"/>
+      <point x="570" y="0" name="inserted"/>
+      <point x="570" y="0"/>
+      <point x="332" y="0" type="qcurve"/>
+      <point x="332" y="0" type="line"/>
       <point x="88" y="0"/>
       <point x="88" y="0"/>
       <point x="88" y="241" type="qcurve"/>
@@ -30,14 +30,14 @@
       <point x="700" y="1052"/>
       <point x="624" y="1076" type="qcurve"/>
       <point x="624" y="1076" type="line"/>
-      <point x="611" y="1080"/>
+      <point x="612" y="1080"/>
       <point x="592" y="1086"/>
       <point x="585" y="1086" type="qcurve" smooth="yes"/>
-      <point x="575" y="1086"/>
-      <point x="562" y="1070"/>
-      <point x="562" y="1050" type="qcurve" smooth="yes"/>
-      <point x="562" y="897" type="line"/>
-      <point x="595" y="844" type="line"/>
+      <point x="577" y="1086"/>
+      <point x="570" y="1070"/>
+      <point x="570" y="1050" type="qcurve" smooth="yes"/>
+      <point x="570" y="897" type="line"/>
+      <point x="570" y="844" type="line"/>
     </contour>
     <contour>
       <point x="553" y="606" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/four.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/four.glif
@@ -4,8 +4,8 @@
   <unicode hex="0034"/>
   <outline>
     <contour>
-      <point x="497" y="217" type="qcurve"/>
-      <point x="497" y="420" type="line"/>
+      <point x="518" y="217" type="qcurve"/>
+      <point x="518" y="420" type="line"/>
       <point x="518" y="492" type="line"/>
       <point x="518" y="1233" type="line"/>
       <point x="518" y="1432" name="inserted"/>
@@ -20,15 +20,15 @@
       <point x="965" y="0"/>
       <point x="728" y="0" type="qcurve"/>
       <point x="728" y="0" type="line"/>
-      <point x="497" y="0"/>
-      <point x="497" y="0"/>
+      <point x="518" y="0"/>
+      <point x="518" y="0"/>
     </contour>
     <contour>
       <point x="207" y="193" type="line" smooth="yes"/>
       <point x="-6" y="193" name="inserted"/>
       <point x="-6" y="192"/>
-      <point x="-6" y="430" type="qcurve"/>
-      <point x="-6" y="430" type="line"/>
+      <point x="-6" y="362" type="qcurve"/>
+      <point x="-6" y="362" type="line"/>
       <point x="-6" y="533"/>
       <point x="-6" y="533"/>
       <point x="105" y="732" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/four.numerator.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/four.numerator.glif
@@ -3,8 +3,8 @@
   <advance width="683"/>
   <outline>
     <contour>
-      <point x="309" y="798" type="qcurve"/>
-      <point x="309" y="904" type="line"/>
+      <point x="322" y="798" type="qcurve"/>
+      <point x="322" y="904" type="line"/>
       <point x="322" y="942" type="line"/>
       <point x="322" y="1432" type="line"/>
       <point x="322" y="1432" name="inserted"/>
@@ -19,8 +19,8 @@
       <point x="602" y="685"/>
       <point x="454" y="685" type="qcurve"/>
       <point x="454" y="685" type="line"/>
-      <point x="309" y="685"/>
-      <point x="309" y="685"/>
+      <point x="322" y="685"/>
+      <point x="322" y="685"/>
     </contour>
     <contour>
       <point x="128" y="786" type="line" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/four.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/four.tf.glif
@@ -3,8 +3,8 @@
   <advance width="1052"/>
   <outline>
     <contour>
-      <point x="497" y="217" type="qcurve"/>
-      <point x="497" y="420" type="line"/>
+      <point x="518" y="217" type="qcurve"/>
+      <point x="518" y="420" type="line"/>
       <point x="518" y="492" type="line"/>
       <point x="518" y="1233" type="line"/>
       <point x="518" y="1432" name="inserted"/>
@@ -19,8 +19,8 @@
       <point x="965" y="0"/>
       <point x="728" y="0" type="qcurve"/>
       <point x="728" y="0" type="line"/>
-      <point x="497" y="0"/>
-      <point x="497" y="0"/>
+      <point x="518" y="0"/>
+      <point x="518" y="0"/>
     </contour>
     <contour>
       <point x="207" y="193" type="line" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/g.alt.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/g.alt.glif
@@ -4,11 +4,11 @@
   <outline>
     <contour>
       <point x="1029" y="1020" type="line" smooth="yes"/>
-      <point x="1155" y="1020"/>
-      <point x="1154" y="1020"/>
-      <point x="1157" y="904" type="qcurve"/>
-      <point x="1157" y="876" type="line"/>
-      <point x="1157" y="702"/>
+      <point x="1157" y="1020"/>
+      <point x="1157" y="1020"/>
+      <point x="1157" y="862" type="qcurve"/>
+      <point x="1157" y="862" type="line"/>
+      <point x="1157" y="703"/>
       <point x="1157" y="703"/>
       <point x="1036" y="705" type="qcurve" smooth="yes"/>
       <point x="764" y="710" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/germandbls.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/germandbls.glif
@@ -17,8 +17,8 @@
       <point x="1146" y="1080" type="line"/>
       <point x="1147" y="918"/>
       <point x="957" y="771"/>
-      <point x="820" y="772" type="qcurve"/>
-      <point x="820" y="770" type="line"/>
+      <point x="813" y="771" type="qcurve"/>
+      <point x="813" y="771" type="line"/>
       <point x="973" y="760"/>
       <point x="1198" y="576"/>
       <point x="1198" y="401" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/greater.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/greater.glif
@@ -4,32 +4,32 @@
   <unicode hex="003E"/>
   <outline>
     <contour>
-      <point x="341" y="118" type="line" smooth="yes"/>
-      <point x="122" y="-7"/>
-      <point x="122" y="-7"/>
-      <point x="122" y="159" type="qcurve"/>
-      <point x="122" y="159" type="line"/>
-      <point x="122" y="394"/>
-      <point x="122" y="394" name="inserted"/>
-      <point x="142" y="406" type="qcurve" smooth="yes"/>
-      <point x="370" y="537" type="line"/>
-      <point x="370" y="545" type="line"/>
-      <point x="145" y="676" type="line" smooth="yes"/>
-      <point x="121" y="690" name="inserted"/>
-      <point x="122" y="690"/>
-      <point x="122" y="933" type="qcurve"/>
-      <point x="122" y="933" type="line"/>
-      <point x="122" y="1113"/>
-      <point x="122" y="1114"/>
-      <point x="344" y="985" type="qcurve" smooth="yes"/>
-      <point x="641" y="812" type="line" smooth="yes"/>
-      <point x="782" y="730"/>
-      <point x="782" y="731"/>
-      <point x="783" y="557" type="qcurve"/>
-      <point x="783" y="557" type="line"/>
-      <point x="783" y="369"/>
-      <point x="783" y="371" name="inserted"/>
-      <point x="668" y="305" type="qcurve" smooth="yes"/>
+      <point x="341" y="122" type="line" smooth="yes"/>
+      <point x="122" y="-3"/>
+      <point x="123" y="-3"/>
+      <point x="123" y="197" type="qcurve"/>
+      <point x="123" y="197" type="line"/>
+      <point x="123" y="398"/>
+      <point x="122" y="398" name="inserted"/>
+      <point x="142" y="410" type="qcurve" smooth="yes"/>
+      <point x="370" y="541" type="line"/>
+      <point x="370" y="541" type="line"/>
+      <point x="145" y="672" type="line" smooth="yes"/>
+      <point x="122" y="686" name="inserted"/>
+      <point x="122" y="686"/>
+      <point x="122" y="898" type="qcurve"/>
+      <point x="122" y="898" type="line"/>
+      <point x="122" y="1110"/>
+      <point x="122" y="1110"/>
+      <point x="344" y="981" type="qcurve" smooth="yes"/>
+      <point x="641" y="808" type="line" smooth="yes"/>
+      <point x="783" y="725"/>
+      <point x="783" y="725"/>
+      <point x="783" y="550" type="qcurve"/>
+      <point x="783" y="550" type="line"/>
+      <point x="783" y="375"/>
+      <point x="783" y="375" name="inserted"/>
+      <point x="668" y="309" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/less.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/less.glif
@@ -4,32 +4,32 @@
   <unicode hex="003C"/>
   <outline>
     <contour>
-      <point x="550" y="119" type="qcurve" smooth="yes"/>
-      <point x="253" y="292" type="line"/>
-      <point x="110" y="375"/>
-      <point x="111" y="375"/>
+      <point x="550" y="123" type="qcurve" smooth="yes"/>
+      <point x="253" y="296" type="line"/>
+      <point x="111" y="379"/>
+      <point x="111" y="379"/>
       <point x="111" y="547" type="qcurve"/>
       <point x="111" y="547" type="line"/>
-      <point x="111" y="734"/>
-      <point x="112" y="734" name="inserted"/>
-      <point x="226" y="799" type="qcurve" smooth="yes"/>
-      <point x="553" y="986" type="line" smooth="yes"/>
-      <point x="772" y="1111"/>
-      <point x="772" y="1111"/>
-      <point x="772" y="945" type="qcurve"/>
-      <point x="772" y="945" type="line"/>
-      <point x="772" y="709"/>
-      <point x="771" y="709" name="inserted"/>
-      <point x="752" y="698" type="qcurve" smooth="yes"/>
-      <point x="524" y="567" type="line"/>
-      <point x="524" y="559" type="line"/>
+      <point x="111" y="729"/>
+      <point x="111" y="729" name="inserted"/>
+      <point x="226" y="795" type="qcurve" smooth="yes"/>
+      <point x="553" y="982" type="line" smooth="yes"/>
+      <point x="772" y="1107"/>
+      <point x="772" y="1107"/>
+      <point x="772" y="906" type="qcurve"/>
+      <point x="772" y="906" type="line"/>
+      <point x="772" y="705"/>
+      <point x="772" y="705" name="inserted"/>
+      <point x="752" y="694" type="qcurve" smooth="yes"/>
+      <point x="524" y="563" type="line"/>
+      <point x="524" y="563" type="line"/>
       <point x="749" y="428" type="line" smooth="yes"/>
       <point x="771" y="415" name="inserted"/>
-      <point x="771" y="415"/>
-      <point x="771" y="171" type="qcurve"/>
-      <point x="771" y="171" type="line"/>
-      <point x="771" y="-10"/>
-      <point x="771" y="-10"/>
+      <point x="771" y="419"/>
+      <point x="771" y="206" type="qcurve"/>
+      <point x="771" y="206" type="line"/>
+      <point x="771" y="-6"/>
+      <point x="771" y="-5"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/mu.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/mu.glif
@@ -47,14 +47,14 @@
       <point x="939" y="-16" type="qcurve"/>
       <point x="802" y="-16"/>
       <point x="675" y="23"/>
-      <point x="652" y="58" type="qcurve"/>
-      <point x="648" y="58" type="line"/>
-      <point x="621" y="26"/>
-      <point x="556" y="0"/>
+      <point x="650" y="61" type="qcurve"/>
+      <point x="650" y="61" type="line"/>
+      <point x="621" y="27"/>
+      <point x="562" y="0"/>
       <point x="538" y="0" type="qcurve"/>
       <point x="537" y="0"/>
       <point x="535" y="0"/>
-      <point x="534" y="0" type="qcurve"/>
+      <point x="532" y="0" type="qcurve"/>
       <point x="532" y="0" type="line"/>
       <point x="536" y="-80" type="line"/>
       <point x="536" y="-193" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/n.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/n.glif
@@ -31,8 +31,8 @@
       <point x="36" y="0"/>
       <point x="36" y="241" type="qcurve"/>
       <point x="36" y="797" type="line"/>
-      <point x="35" y="1020"/>
-      <point x="35" y="1020"/>
+      <point x="36" y="1020"/>
+      <point x="36" y="1020"/>
       <point x="287" y="1020" type="qcurve"/>
       <point x="287" y="1020" type="line"/>
       <point x="521" y="1020"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/one.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/one.tf.glif
@@ -4,12 +4,12 @@
   <outline>
     <contour>
       <point x="749" y="218" type="line" smooth="yes"/>
-      <point x="749" y="0"/>
+      <point x="749" y="-1"/>
       <point x="749" y="-1"/>
       <point x="494" y="-1" type="qcurve"/>
       <point x="494" y="-1" type="line"/>
       <point x="249" y="-1"/>
-      <point x="249" y="0"/>
+      <point x="249" y="-1"/>
       <point x="249" y="218" type="qcurve"/>
       <point x="249" y="807" type="line"/>
       <point x="243" y="801" type="line"/>
@@ -17,15 +17,15 @@
       <point x="168" y="727"/>
       <point x="50" y="917" type="qcurve"/>
       <point x="50" y="917" type="line"/>
-      <point x="-53" y="1088"/>
+      <point x="-53" y="1087"/>
       <point x="-53" y="1087"/>
       <point x="59" y="1168" type="qcurve" smooth="yes"/>
-      <point x="343" y="1373" type="line"/>
-      <point x="424" y="1434"/>
-      <point x="425" y="1433"/>
-      <point x="524" y="1433" type="qcurve"/>
-      <point x="524" y="1433" type="line"/>
-      <point x="747" y="1433"/>
+      <point x="343" y="1373" type="line" smooth="yes"/>
+      <point x="426" y="1433"/>
+      <point x="426" y="1433"/>
+      <point x="587" y="1433" type="qcurve"/>
+      <point x="587" y="1433" type="line"/>
+      <point x="749" y="1433"/>
       <point x="749" y="1433" name="inserted"/>
       <point x="749" y="1227" type="qcurve"/>
     </contour>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/ordfeminine.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/ordfeminine.glif
@@ -60,9 +60,9 @@
       <point x="639" y="572"/>
       <point x="639" y="572"/>
       <point x="630" y="628" type="qcurve"/>
-      <point x="629" y="634" type="line"/>
-      <point x="620" y="634" type="line"/>
-      <point x="595" y="591"/>
+      <point x="627" y="645" type="line"/>
+      <point x="627" y="645" type="line"/>
+      <point x="598" y="592"/>
       <point x="486" y="544"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/q.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/q.glif
@@ -14,7 +14,7 @@
       <point x="631" y="-432"/>
       <point x="631" y="-432" name="inserted"/>
       <point x="631" y="-206" type="qcurve"/>
-      <point x="631" y="-12" type="line"/>
+      <point x="631" y="54" type="line"/>
       <point x="631" y="54" type="line"/>
       <point x="631" y="54" type="line"/>
       <point x="603" y="30"/>
@@ -32,8 +32,8 @@
       <point x="648" y="949" type="qcurve"/>
       <point x="648" y="949" type="line"/>
       <point x="648" y="949" type="line"/>
-      <point x="647" y="1020" name="inserted"/>
-      <point x="647" y="1020"/>
+      <point x="648" y="1020" name="inserted"/>
+      <point x="648" y="1020"/>
       <point x="883" y="1020" type="qcurve"/>
       <point x="883" y="1020" type="line"/>
       <point x="1126" y="1020"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/r.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/r.glif
@@ -23,7 +23,7 @@
       <point x="481" y="1020" name="inserted"/>
       <point x="511" y="895" type="qcurve"/>
       <point x="511" y="895" type="line"/>
-      <point x="511" y="896" type="line"/>
+      <point x="511" y="895" type="line"/>
       <point x="532" y="980"/>
       <point x="630" y="1048"/>
       <point x="684" y="1048" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/registered.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/registered.glif
@@ -61,15 +61,15 @@
       <point x="726" y="1005"/>
       <point x="700" y="982" type="qcurve"/>
       <point x="700" y="982" type="line"/>
-      <point x="723" y="924" type="line"/>
-      <point x="728" y="911" type="line"/>
-      <point x="783" y="777" name="inserted"/>
-      <point x="783" y="777"/>
-      <point x="696" y="778" type="qcurve"/>
-      <point x="696" y="778" type="line"/>
-      <point x="579" y="777"/>
-      <point x="579" y="777"/>
-      <point x="567" y="828" type="qcurve" smooth="yes"/>
+      <point x="737" y="888" type="line"/>
+      <point x="737" y="888" type="line"/>
+      <point x="779" y="778" name="inserted"/>
+      <point x="779" y="778"/>
+      <point x="681" y="778" type="qcurve"/>
+      <point x="681" y="778" type="line"/>
+      <point x="579" y="778"/>
+      <point x="579" y="778"/>
+      <point x="559" y="859" type="qcurve" smooth="yes"/>
       <point x="538" y="948" type="line"/>
       <point x="526" y="948" type="line"/>
       <point x="526" y="865" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/semicolon.glif
@@ -18,11 +18,11 @@
       <point x="543" y="904"/>
     </contour>
     <contour>
-      <point x="364" y="-112" type="line" smooth="yes"/>
-      <point x="229" y="-293" name="inserted"/>
-      <point x="229" y="-293"/>
-      <point x="24" y="-160" type="qcurve"/>
-      <point x="24" y="-124" type="line"/>
+      <point x="382" y="-98" type="line"/>
+      <point x="243" y="-302" name="inserted"/>
+      <point x="243" y="-302"/>
+      <point x="34" y="-166" type="qcurve"/>
+      <point x="34" y="-108" type="line"/>
       <point x="142" y="62" type="line"/>
       <point x="106" y="79"/>
       <point x="46" y="157"/>
@@ -34,7 +34,7 @@
       <point x="539" y="341"/>
       <point x="539" y="240" type="qcurve" smooth="yes"/>
       <point x="539" y="190"/>
-      <point x="509" y="84"/>
+      <point x="506" y="84"/>
       <point x="468" y="28" type="qcurve" smooth="yes"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/seven.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/seven.glif
@@ -13,22 +13,22 @@
       <point x="65" y="137" name="inserted"/>
       <point x="155" y="413" type="qcurve"/>
       <point x="345" y="985" type="line"/>
-      <point x="342" y="985" type="line"/>
+      <point x="345" y="985" type="line"/>
       <point x="210" y="985" type="line" smooth="yes"/>
       <point x="-5" y="985" name="inserted"/>
-      <point x="-5" y="984"/>
+      <point x="-5" y="985"/>
       <point x="-5" y="1214" type="qcurve"/>
       <point x="-5" y="1214" type="line"/>
-      <point x="-5" y="1433"/>
+      <point x="-5" y="1432"/>
       <point x="-5" y="1432"/>
       <point x="210" y="1432" type="qcurve"/>
       <point x="716" y="1432" type="line"/>
-      <point x="928" y="1432" name="inserted"/>
-      <point x="929" y="1433"/>
-      <point x="929" y="1238" type="qcurve"/>
-      <point x="929" y="1234" type="line"/>
-      <point x="929" y="1114"/>
-      <point x="930" y="1113" name="inserted"/>
+      <point x="929" y="1432" name="inserted"/>
+      <point x="929" y="1432"/>
+      <point x="929" y="1272" type="qcurve"/>
+      <point x="929" y="1272" type="line"/>
+      <point x="929" y="1111"/>
+      <point x="929" y="1111" name="inserted"/>
       <point x="880" y="946" type="qcurve"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/seven.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/seven.tf.glif
@@ -5,17 +5,17 @@
     <contour>
       <point x="691" y="307" type="line"/>
       <point x="599" y="-17"/>
-      <point x="599" y="-16"/>
+      <point x="599" y="-17"/>
       <point x="335" y="57" type="qcurve"/>
       <point x="335" y="57" type="line"/>
       <point x="65" y="136"/>
-      <point x="65" y="137" name="inserted"/>
+      <point x="65" y="136" name="inserted"/>
       <point x="155" y="413" type="qcurve"/>
       <point x="345" y="985" type="line"/>
-      <point x="342" y="985" type="line"/>
+      <point x="345" y="985" type="line"/>
       <point x="210" y="985" type="line" smooth="yes"/>
       <point x="-5" y="985" name="inserted"/>
-      <point x="-5" y="984"/>
+      <point x="-5" y="985"/>
       <point x="-5" y="1214" type="qcurve"/>
       <point x="-5" y="1214" type="line"/>
       <point x="-5" y="1433"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/six.numerator.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/six.numerator.glif
@@ -39,7 +39,7 @@
       <point x="510" y="1289" type="qcurve" smooth="yes"/>
       <point x="440" y="1228" type="line" smooth="yes"/>
       <point x="427" y="1216"/>
-      <point x="400" y="1189"/>
+      <point x="408" y="1198"/>
       <point x="394" y="1185" type="qcurve"/>
       <point x="394" y="1185" type="line"/>
       <point x="394" y="1185" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/sterling.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/sterling.glif
@@ -46,10 +46,10 @@
       <point x="558" y="655"/>
       <point x="558" y="559" type="qcurve"/>
       <point x="558" y="559" type="line"/>
-      <point x="558" y="433"/>
-      <point x="381" y="268"/>
-      <point x="233" y="268" type="qcurve"/>
-      <point x="233" y="402" type="line"/>
+      <point x="558" y="506"/>
+      <point x="535" y="435"/>
+      <point x="513" y="402" type="qcurve"/>
+      <point x="513" y="402" type="line"/>
       <point x="663" y="402" type="line"/>
       <point x="697" y="402"/>
       <point x="741" y="419"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/t.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/t.glif
@@ -25,11 +25,11 @@
       <point x="615" y="414"/>
       <point x="634" y="414" type="qcurve" smooth="yes"/>
       <point x="651" y="414"/>
-      <point x="666" y="418"/>
+      <point x="666" y="417"/>
       <point x="679" y="421" type="qcurve"/>
       <point x="679" y="421" type="line"/>
-      <point x="719" y="434"/>
-      <point x="720" y="433"/>
+      <point x="720" y="434"/>
+      <point x="720" y="434"/>
       <point x="764" y="268" type="qcurve"/>
       <point x="764" y="268" type="line"/>
       <point x="814" y="100"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/thorn.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/thorn.glif
@@ -23,8 +23,8 @@
       <point x="522" y="1432" name="inserted"/>
       <point x="522" y="1196" type="qcurve"/>
       <point x="522" y="1017" type="line"/>
-      <point x="518" y="964" type="line"/>
-      <point x="522" y="964" type="line"/>
+      <point x="518" y="959" type="line"/>
+      <point x="518" y="959" type="line"/>
       <point x="542" y="990"/>
       <point x="656" y="1040"/>
       <point x="716" y="1040" type="qcurve" smooth="yes"/>
@@ -35,10 +35,10 @@
       <point x="1146" y="226"/>
       <point x="890" y="-4"/>
       <point x="716" y="-4" type="qcurve" smooth="yes"/>
-      <point x="656" y="-4"/>
-      <point x="558" y="30"/>
-      <point x="544" y="44" type="qcurve"/>
-      <point x="540" y="44" type="line"/>
+      <point x="662" y="-4"/>
+      <point x="563" y="26"/>
+      <point x="540" y="49" type="qcurve"/>
+      <point x="540" y="49" type="line"/>
       <point x="546" y="-8" type="line"/>
     </contour>
     <contour>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/three.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/three.glif
@@ -44,8 +44,8 @@
       <point x="953" y="1098" type="line"/>
       <point x="953" y="971"/>
       <point x="856" y="838"/>
-      <point x="770" y="806" type="qcurve"/>
-      <point x="770" y="798" type="line"/>
+      <point x="762" y="802" type="qcurve"/>
+      <point x="762" y="802" type="line"/>
       <point x="870" y="776"/>
       <point x="1002" y="614"/>
       <point x="1001" y="447" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/three.numerator.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/three.numerator.glif
@@ -43,8 +43,8 @@
       <point x="590" y="1245" type="line"/>
       <point x="590" y="1191"/>
       <point x="542" y="1122"/>
-      <point x="501" y="1105" type="qcurve"/>
-      <point x="501" y="1101" type="line"/>
+      <point x="497" y="1103" type="qcurve"/>
+      <point x="497" y="1103" type="line"/>
       <point x="551" y="1089"/>
       <point x="616" y="1000"/>
       <point x="616" y="939" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/three.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/three.tf.glif
@@ -43,8 +43,8 @@
       <point x="953" y="1098" type="line"/>
       <point x="953" y="971"/>
       <point x="856" y="838"/>
-      <point x="770" y="806" type="qcurve"/>
-      <point x="770" y="798" type="line"/>
+      <point x="762" y="802" type="qcurve"/>
+      <point x="762" y="802" type="line"/>
       <point x="870" y="776"/>
       <point x="1002" y="614"/>
       <point x="1001" y="447" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/two.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/two.glif
@@ -45,7 +45,7 @@
       <point x="986" y="904"/>
       <point x="843" y="682"/>
       <point x="793" y="615" type="qcurve"/>
-      <point x="662" y="439" type="line"/>
+      <point x="661" y="437" type="line"/>
       <point x="661" y="437" type="line"/>
       <point x="821" y="437" type="line"/>
       <point x="1002" y="437"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/two.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/two.tf.glif
@@ -5,12 +5,12 @@
     <contour>
       <point x="821" y="0" type="qcurve"/>
       <point x="244" y="0" type="line"/>
-      <point x="12" y="0" name="inserted"/>
-      <point x="13" y="1"/>
-      <point x="9" y="252" type="qcurve"/>
-      <point x="9" y="252" type="line"/>
-      <point x="9" y="326"/>
-      <point x="10" y="326"/>
+      <point x="9" y="0" name="inserted"/>
+      <point x="9" y="0"/>
+      <point x="9" y="162" type="qcurve"/>
+      <point x="9" y="162" type="line"/>
+      <point x="9" y="325"/>
+      <point x="9" y="325"/>
       <point x="71" y="403" type="qcurve"/>
       <point x="234" y="607" type="line" smooth="yes"/>
       <point x="301" y="691"/>
@@ -43,14 +43,14 @@
       <point x="986" y="1040" type="line"/>
       <point x="986" y="904"/>
       <point x="843" y="682"/>
-      <point x="793" y="615" type="qcurve"/>
-      <point x="662" y="439" type="line"/>
+      <point x="793" y="615" type="qcurve" smooth="yes"/>
+      <point x="661" y="437" type="line"/>
       <point x="661" y="437" type="line"/>
       <point x="821" y="437" type="line"/>
-      <point x="1002" y="437"/>
-      <point x="1001" y="436"/>
-      <point x="1001" y="240" type="qcurve"/>
-      <point x="1001" y="209" type="line"/>
+      <point x="1001" y="437"/>
+      <point x="1001" y="437"/>
+      <point x="1001" y="218" type="qcurve"/>
+      <point x="1001" y="218" type="line"/>
       <point x="1001" y="0"/>
       <point x="1001" y="0" name="inserted"/>
     </contour>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/y.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/y.glif
@@ -17,8 +17,8 @@
       <point x="458" y="1020" name="inserted"/>
       <point x="484" y="854" type="qcurve" smooth="yes"/>
       <point x="512" y="675" type="line"/>
-      <point x="525" y="590" type="line"/>
-      <point x="526" y="590" type="line"/>
+      <point x="525" y="587" type="line"/>
+      <point x="525" y="587" type="line"/>
       <point x="539" y="676" type="line"/>
       <point x="566" y="854" type="line" smooth="yes"/>
       <point x="591" y="1020" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/yen.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/yen.glif
@@ -15,8 +15,8 @@
       <point x="509" y="1432" name="inserted"/>
       <point x="532" y="1299" type="qcurve" smooth="yes"/>
       <point x="585" y="996" type="line"/>
-      <point x="596" y="934" type="line"/>
-      <point x="604" y="934" type="line"/>
+      <point x="600" y="911" type="line"/>
+      <point x="600" y="911" type="line"/>
       <point x="613" y="996" type="line"/>
       <point x="660" y="1313" type="line" smooth="yes"/>
       <point x="677" y="1431" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/G_ermandbls.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/G_ermandbls.glif
@@ -54,8 +54,8 @@
       <point x="315" y="587" type="line"/>
       <point x="315" y="657"/>
       <point x="291" y="715"/>
-      <point x="249" y="715" type="qcurve"/>
-      <point x="243" y="715" type="line"/>
+      <point x="246" y="715" type="qcurve"/>
+      <point x="246" y="715" type="line"/>
       <point x="211" y="715"/>
       <point x="211" y="715"/>
       <point x="211" y="760" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/M_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/M_.glif
@@ -22,8 +22,8 @@
       <point x="187" y="1432"/>
       <point x="187" y="1432" name="inserted"/>
       <point x="195" y="1368" type="qcurve" smooth="yes"/>
-      <point x="330" y="338" type="line"/>
-      <point x="332" y="338" type="line"/>
+      <point x="331" y="334" type="line"/>
+      <point x="331" y="334" type="line"/>
       <point x="467" y="1368" type="line" smooth="yes"/>
       <point x="475" y="1432" name="inserted"/>
       <point x="475" y="1432"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/W_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/W_.glif
@@ -9,20 +9,20 @@
       <point x="557" y="65" type="line" smooth="yes"/>
       <point x="552" y="0" name="inserted"/>
       <point x="552" y="0"/>
-      <point x="496" y="0" type="qcurve"/>
-      <point x="496" y="0" type="line"/>
+      <point x="492" y="0" type="qcurve"/>
+      <point x="492" y="0" type="line"/>
       <point x="432" y="0"/>
       <point x="432" y="0"/>
       <point x="425" y="65" type="qcurve" smooth="yes"/>
       <point x="350" y="896" type="line"/>
-      <point x="344" y="1048" type="line"/>
-      <point x="340" y="1048" type="line"/>
+      <point x="342" y="1060" type="line"/>
+      <point x="342" y="1060" type="line"/>
       <point x="334" y="896" type="line"/>
       <point x="270" y="65" type="line" smooth="yes"/>
       <point x="265" y="0" name="inserted"/>
       <point x="265" y="0"/>
-      <point x="202" y="0" type="qcurve"/>
-      <point x="202" y="0" type="line"/>
+      <point x="204" y="0" type="qcurve"/>
+      <point x="204" y="0" type="line"/>
       <point x="144" y="0"/>
       <point x="144" y="0"/>
       <point x="138" y="65" type="qcurve" smooth="yes"/>
@@ -35,8 +35,8 @@
       <point x="144" y="1432"/>
       <point x="148" y="1357" type="qcurve" smooth="yes"/>
       <point x="190" y="650" type="line"/>
-      <point x="199" y="484" type="line"/>
-      <point x="201" y="484" type="line"/>
+      <point x="200" y="479" type="line"/>
+      <point x="200" y="479" type="line"/>
       <point x="208" y="650" type="line"/>
       <point x="279" y="1369" type="line" smooth="yes"/>
       <point x="285" y="1432"/>
@@ -47,8 +47,8 @@
       <point x="403" y="1432" name="inserted"/>
       <point x="410" y="1369" type="qcurve" smooth="yes"/>
       <point x="486" y="650" type="line"/>
-      <point x="498" y="484" type="line"/>
-      <point x="500" y="484" type="line"/>
+      <point x="499" y="479" type="line"/>
+      <point x="499" y="479" type="line"/>
       <point x="508" y="650" type="line"/>
       <point x="559" y="1365" type="line" smooth="yes"/>
       <point x="564" y="1432"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/Y_.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/Y_.glif
@@ -28,8 +28,8 @@
       <point x="144" y="1432"/>
       <point x="153" y="1345" type="qcurve" smooth="yes"/>
       <point x="194" y="942" type="line"/>
-      <point x="196" y="920" type="line"/>
-      <point x="200" y="920" type="line"/>
+      <point x="198" y="899" type="line"/>
+      <point x="198" y="899" type="line"/>
       <point x="202" y="942" type="line"/>
       <point x="240" y="1347" type="line" smooth="yes"/>
       <point x="248" y="1432"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/a.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/a.glif
@@ -14,9 +14,9 @@
       <point x="312" y="0" type="line"/>
       <point x="255" y="0"/>
       <point x="255" y="0" name="inserted"/>
-      <point x="254" y="46" type="qcurve"/>
-      <point x="254" y="46" type="line"/>
-      <point x="254" y="46" type="line"/>
+      <point x="255" y="46" type="qcurve"/>
+      <point x="255" y="46" type="line"/>
+      <point x="255" y="46" type="line"/>
       <point x="240" y="20"/>
       <point x="194" y="-6"/>
       <point x="162" y="-6" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/braceleft.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/braceleft.glif
@@ -39,8 +39,8 @@
       <point x="247" y="875" type="line"/>
       <point x="247" y="774"/>
       <point x="196" y="655"/>
-      <point x="130" y="629" type="qcurve"/>
-      <point x="130" y="620" type="line"/>
+      <point x="123" y="625" type="qcurve"/>
+      <point x="123" y="625" type="line"/>
       <point x="196" y="593"/>
       <point x="247" y="475"/>
       <point x="247" y="375" type="qcurve" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/braceright.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/braceright.glif
@@ -25,8 +25,8 @@
       <point x="175" y="375" type="line" smooth="yes"/>
       <point x="175" y="475"/>
       <point x="226" y="593"/>
-      <point x="292" y="620" type="qcurve"/>
-      <point x="292" y="629" type="line"/>
+      <point x="299" y="625" type="qcurve"/>
+      <point x="299" y="625" type="line"/>
       <point x="226" y="655"/>
       <point x="175" y="774"/>
       <point x="175" y="875" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/caroncomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/caroncomb.glif
@@ -6,34 +6,34 @@
   <anchor x="0" y="1346" name="top"/>
   <outline>
     <contour>
-      <point x="-65" y="1141" type="qcurve" smooth="yes"/>
-      <point x="-161" y="1335" type="line"/>
-      <point x="-163" y="1339" type="line"/>
-      <point x="-163" y="1346"/>
-      <point x="-163" y="1346"/>
-      <point x="-108" y="1346" type="qcurve"/>
-      <point x="-108" y="1346" type="line"/>
-      <point x="-49" y="1346"/>
-      <point x="-49" y="1346" name="inserted"/>
-      <point x="-32" y="1300" type="qcurve" smooth="yes"/>
-      <point x="-2" y="1220" type="line"/>
-      <point x="5" y="1220" type="line"/>
-      <point x="34" y="1300" type="line" smooth="yes"/>
-      <point x="51" y="1346" name="inserted"/>
-      <point x="51" y="1346"/>
-      <point x="106" y="1346" type="qcurve"/>
-      <point x="106" y="1346" type="line"/>
-      <point x="163" y="1346"/>
-      <point x="163" y="1346"/>
-      <point x="163" y="1339" type="qcurve"/>
-      <point x="161" y="1335" type="line"/>
-      <point x="66" y="1141" type="line" smooth="yes"/>
-      <point x="50" y="1109" name="inserted"/>
-      <point x="50" y="1109"/>
+      <point x="-63" y="1141" type="qcurve" smooth="yes"/>
+      <point x="-159" y="1335" type="line"/>
+      <point x="-161" y="1339" type="line"/>
+      <point x="-161" y="1346"/>
+      <point x="-161" y="1346"/>
+      <point x="-104" y="1346" type="qcurve"/>
+      <point x="-104" y="1346" type="line"/>
+      <point x="-47" y="1346"/>
+      <point x="-47" y="1346" name="inserted"/>
+      <point x="0" y="1220" type="qcurve"/>
+      <point x="0" y="1220" type="line"/>
+      <point x="0" y="1220" type="line"/>
+      <point x="0" y="1220" type="line"/>
+      <point x="46" y="1346" name="inserted"/>
+      <point x="46" y="1346"/>
+      <point x="102" y="1346" type="qcurve"/>
+      <point x="102" y="1346" type="line"/>
+      <point x="158" y="1346"/>
+      <point x="158" y="1346"/>
+      <point x="158" y="1339" type="qcurve"/>
+      <point x="156" y="1335" type="line"/>
+      <point x="61" y="1141" type="line" smooth="yes"/>
+      <point x="45" y="1109" name="inserted"/>
+      <point x="45" y="1109"/>
       <point x="1" y="1109" type="qcurve"/>
       <point x="1" y="1109" type="line"/>
-      <point x="-49" y="1109"/>
-      <point x="-49" y="1109"/>
+      <point x="-47" y="1109"/>
+      <point x="-47" y="1109"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/circumflexcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/circumflexcomb.glif
@@ -5,34 +5,34 @@
   <anchor x="0" y="1346" name="top"/>
   <outline>
     <contour>
-      <point x="-163" y="1116" type="qcurve"/>
-      <point x="-161" y="1120" type="line"/>
-      <point x="-66" y="1314" type="line" smooth="yes"/>
-      <point x="-50" y="1346" name="inserted"/>
-      <point x="-50" y="1346"/>
+      <point x="-158" y="1116" type="qcurve"/>
+      <point x="-156" y="1120" type="line"/>
+      <point x="-61" y="1314" type="line" smooth="yes"/>
+      <point x="-45" y="1346" name="inserted"/>
+      <point x="-45" y="1346"/>
       <point x="-1" y="1346" type="qcurve"/>
       <point x="-1" y="1346" type="line"/>
-      <point x="49" y="1346"/>
-      <point x="49" y="1346"/>
-      <point x="65" y="1314" type="qcurve" smooth="yes"/>
-      <point x="161" y="1120" type="line"/>
-      <point x="163" y="1116" type="line"/>
-      <point x="163" y="1109"/>
-      <point x="163" y="1109"/>
-      <point x="108" y="1109" type="qcurve"/>
-      <point x="108" y="1109" type="line"/>
-      <point x="49" y="1109"/>
-      <point x="49" y="1109" name="inserted"/>
-      <point x="32" y="1155" type="qcurve" smooth="yes"/>
-      <point x="2" y="1235" type="line"/>
-      <point x="-5" y="1235" type="line"/>
-      <point x="-34" y="1155" type="line" smooth="yes"/>
-      <point x="-51" y="1109" name="inserted"/>
-      <point x="-51" y="1109"/>
-      <point x="-106" y="1109" type="qcurve"/>
-      <point x="-106" y="1109" type="line"/>
-      <point x="-163" y="1109"/>
-      <point x="-163" y="1109"/>
+      <point x="47" y="1346"/>
+      <point x="47" y="1346"/>
+      <point x="63" y="1314" type="qcurve" smooth="yes"/>
+      <point x="159" y="1120" type="line"/>
+      <point x="161" y="1116" type="line"/>
+      <point x="161" y="1109"/>
+      <point x="161" y="1109"/>
+      <point x="106" y="1109" type="qcurve"/>
+      <point x="106" y="1109" type="line"/>
+      <point x="47" y="1109"/>
+      <point x="47" y="1109" name="inserted"/>
+      <point x="0" y="1235" type="qcurve"/>
+      <point x="0" y="1235" type="line"/>
+      <point x="0" y="1235" type="line"/>
+      <point x="0" y="1235" type="line"/>
+      <point x="-46" y="1109" name="inserted"/>
+      <point x="-46" y="1109"/>
+      <point x="-101" y="1109" type="qcurve"/>
+      <point x="-101" y="1109" type="line"/>
+      <point x="-158" y="1109"/>
+      <point x="-158" y="1109"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/comma.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/comma.glif
@@ -4,11 +4,11 @@
   <unicode hex="002C"/>
   <outline>
     <contour>
-      <point x="163" y="-160" type="line"/>
-      <point x="129" y="-220" name="inserted"/>
-      <point x="129" y="-220"/>
-      <point x="57" y="-173" type="qcurve"/>
-      <point x="46" y="-165" type="line"/>
+      <point x="160" y="-162" type="line" smooth="yes"/>
+      <point x="129" y="-214" name="inserted"/>
+      <point x="129" y="-214"/>
+      <point x="51" y="-169" type="qcurve"/>
+      <point x="51" y="-157" type="line"/>
       <point x="146" y="-2" type="line"/>
       <point x="112" y="8"/>
       <point x="70" y="62"/>
@@ -20,8 +20,8 @@
       <point x="294" y="146"/>
       <point x="294" y="100" type="qcurve" smooth="yes"/>
       <point x="294" y="84"/>
-      <point x="284" y="50"/>
-      <point x="244" y="-20" type="qcurve"/>
+      <point x="285" y="50"/>
+      <point x="244" y="-20" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -4,24 +4,24 @@
   <anchor x="0" y="0" name="_bottom"/>
   <outline>
     <contour>
-      <point x="-16" y="-368" type="line"/>
+      <point x="-18" y="-374" type="line" smooth="yes"/>
       <point x="-43" y="-416" name="inserted"/>
       <point x="-43" y="-416"/>
-      <point x="-100" y="-378" type="qcurve"/>
-      <point x="-109" y="-372" type="line"/>
-      <point x="-29" y="-242" type="line"/>
-      <point x="-56" y="-234"/>
-      <point x="-90" y="-190"/>
-      <point x="-90" y="-160" type="qcurve" smooth="yes"/>
-      <point x="-90" y="-123"/>
+      <point x="-106" y="-380" type="qcurve"/>
+      <point x="-106" y="-370" type="line"/>
+      <point x="-29" y="-243" type="line"/>
+      <point x="-57" y="-235"/>
+      <point x="-91" y="-191"/>
+      <point x="-91" y="-161" type="qcurve" smooth="yes"/>
+      <point x="-91" y="-123"/>
       <point x="-39" y="-72"/>
       <point x="0" y="-72" type="qcurve" smooth="yes"/>
-      <point x="36" y="-72"/>
-      <point x="89" y="-123"/>
-      <point x="89" y="-160" type="qcurve" smooth="yes"/>
-      <point x="89" y="-173"/>
-      <point x="81" y="-200"/>
-      <point x="49" y="-256" type="qcurve"/>
+      <point x="37" y="-72"/>
+      <point x="90" y="-123"/>
+      <point x="90" y="-161" type="qcurve" smooth="yes"/>
+      <point x="90" y="-173"/>
+      <point x="83" y="-201"/>
+      <point x="50" y="-257" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/commaturnedabovecomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/commaturnedabovecomb.glif
@@ -5,24 +5,24 @@
   <anchor x="0" y="1443" name="top"/>
   <outline>
     <contour>
-      <point x="16" y="1395" type="line"/>
+      <point x="18" y="1401" type="line" smooth="yes"/>
       <point x="43" y="1443" name="inserted"/>
       <point x="43" y="1443"/>
-      <point x="100" y="1405" type="qcurve"/>
-      <point x="109" y="1399" type="line"/>
-      <point x="29" y="1269" type="line"/>
-      <point x="56" y="1261"/>
-      <point x="90" y="1217"/>
-      <point x="90" y="1187" type="qcurve" smooth="yes"/>
-      <point x="90" y="1150"/>
+      <point x="106" y="1407" type="qcurve"/>
+      <point x="106" y="1397" type="line"/>
+      <point x="29" y="1270" type="line"/>
+      <point x="57" y="1262"/>
+      <point x="91" y="1218"/>
+      <point x="91" y="1188" type="qcurve" smooth="yes"/>
+      <point x="91" y="1150"/>
       <point x="39" y="1099"/>
       <point x="0" y="1099" type="qcurve" smooth="yes"/>
-      <point x="-36" y="1099"/>
-      <point x="-89" y="1150"/>
-      <point x="-89" y="1187" type="qcurve" smooth="yes"/>
-      <point x="-89" y="1200"/>
-      <point x="-81" y="1227"/>
-      <point x="-49" y="1283" type="qcurve"/>
+      <point x="-37" y="1099"/>
+      <point x="-90" y="1150"/>
+      <point x="-90" y="1188" type="qcurve" smooth="yes"/>
+      <point x="-90" y="1200"/>
+      <point x="-83" y="1228"/>
+      <point x="-50" y="1284" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/eight.numerator.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/eight.numerator.glif
@@ -15,8 +15,8 @@
       <point x="40" y="982" type="line"/>
       <point x="40" y="1018"/>
       <point x="73" y="1069"/>
-      <point x="101" y="1077" type="qcurve"/>
-      <point x="101" y="1081" type="line"/>
+      <point x="104" y="1079" type="qcurve"/>
+      <point x="104" y="1079" type="line"/>
       <point x="74" y="1091"/>
       <point x="46" y="1138"/>
       <point x="46" y="1170" type="qcurve"/>
@@ -31,8 +31,8 @@
       <point x="308" y="1170" type="line"/>
       <point x="308" y="1140"/>
       <point x="278" y="1092"/>
-      <point x="250" y="1081" type="qcurve"/>
-      <point x="250" y="1077" type="line"/>
+      <point x="247" y="1079" type="qcurve"/>
+      <point x="247" y="1079" type="line"/>
       <point x="280" y="1069"/>
       <point x="313" y="1019"/>
       <point x="313" y="982" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/eight.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/eight.tf.glif
@@ -14,8 +14,8 @@
       <point x="44" y="582" type="line" smooth="yes"/>
       <point x="44" y="647"/>
       <point x="90" y="740"/>
-      <point x="130" y="756" type="qcurve"/>
-      <point x="130" y="764" type="line"/>
+      <point x="137" y="760" type="qcurve"/>
+      <point x="137" y="760" type="line"/>
       <point x="95" y="780"/>
       <point x="58" y="861"/>
       <point x="58" y="916" type="qcurve"/>
@@ -30,8 +30,8 @@
       <point x="426" y="916" type="line" smooth="yes"/>
       <point x="426" y="864"/>
       <point x="386" y="782"/>
-      <point x="350" y="764" type="qcurve"/>
-      <point x="350" y="756" type="line"/>
+      <point x="343" y="760" type="qcurve"/>
+      <point x="343" y="760" type="line"/>
       <point x="392" y="740"/>
       <point x="438" y="650"/>
       <point x="438" y="582" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/five.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/five.glif
@@ -19,7 +19,7 @@
       <point x="311" y="1284" type="qcurve"/>
       <point x="160" y="1284" type="line"/>
       <point x="144" y="870" type="line"/>
-      <point x="146" y="870" type="line"/>
+      <point x="144" y="870" type="line"/>
       <point x="151" y="888"/>
       <point x="204" y="916"/>
       <point x="230" y="916" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/five.numerator.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/five.numerator.glif
@@ -17,8 +17,8 @@
       <point x="294" y="1327" name="inserted"/>
       <point x="229" y="1327" type="qcurve"/>
       <point x="148" y="1327" type="line"/>
-      <point x="139" y="1150" type="line"/>
-      <point x="140" y="1150" type="line"/>
+      <point x="139" y="1148" type="line"/>
+      <point x="139" y="1148" type="line"/>
       <point x="143" y="1159"/>
       <point x="172" y="1174"/>
       <point x="190" y="1174" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/five.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/five.tf.glif
@@ -17,10 +17,10 @@
       <point x="376" y="1284" name="inserted"/>
       <point x="311" y="1284" type="qcurve"/>
       <point x="160" y="1284" type="line"/>
-      <point x="144" y="870" type="line"/>
-      <point x="146" y="870" type="line"/>
-      <point x="151" y="888"/>
-      <point x="204" y="916"/>
+      <point x="144" y="866" type="line"/>
+      <point x="144" y="866" type="line"/>
+      <point x="151" y="889"/>
+      <point x="205" y="916"/>
       <point x="230" y="916" type="qcurve"/>
       <point x="238" y="916" type="line" smooth="yes"/>
       <point x="314" y="916"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/greater.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/greater.glif
@@ -4,32 +4,32 @@
   <unicode hex="003E"/>
   <outline>
     <contour>
-      <point x="156" y="256" type="line" smooth="yes"/>
-      <point x="80" y="198"/>
-      <point x="80" y="198"/>
-      <point x="80" y="285" type="qcurve"/>
-      <point x="80" y="285" type="line"/>
-      <point x="80" y="355"/>
-      <point x="80" y="355" name="inserted"/>
-      <point x="141" y="398" type="qcurve"/>
-      <point x="323" y="531" type="line"/>
-      <point x="323" y="534" type="line"/>
-      <point x="144" y="665" type="line"/>
-      <point x="80" y="712" name="inserted"/>
-      <point x="80" y="712"/>
-      <point x="80" y="783" type="qcurve"/>
-      <point x="80" y="783" type="line"/>
-      <point x="80" y="873"/>
-      <point x="80" y="873"/>
-      <point x="158" y="812" type="qcurve" smooth="yes"/>
-      <point x="411" y="616" type="line" smooth="yes"/>
-      <point x="446" y="589"/>
-      <point x="446" y="589"/>
+      <point x="156" y="258" type="line" smooth="yes"/>
+      <point x="80" y="200"/>
+      <point x="80" y="200"/>
+      <point x="80" y="279" type="qcurve"/>
+      <point x="80" y="279" type="line"/>
+      <point x="80" y="357"/>
+      <point x="80" y="357" name="inserted"/>
+      <point x="141" y="400" type="qcurve"/>
+      <point x="323" y="533" type="line"/>
+      <point x="323" y="533" type="line"/>
+      <point x="144" y="664" type="line"/>
+      <point x="80" y="711" name="inserted"/>
+      <point x="80" y="711"/>
+      <point x="80" y="792" type="qcurve"/>
+      <point x="80" y="792" type="line"/>
+      <point x="80" y="872"/>
+      <point x="80" y="872"/>
+      <point x="158" y="811" type="qcurve" smooth="yes"/>
+      <point x="411" y="615" type="line" smooth="yes"/>
+      <point x="446" y="588"/>
+      <point x="446" y="588"/>
       <point x="446" y="535" type="qcurve"/>
       <point x="446" y="535" type="line"/>
-      <point x="446" y="479"/>
-      <point x="446" y="479" name="inserted"/>
-      <point x="415" y="455" type="qcurve" smooth="yes"/>
+      <point x="446" y="481"/>
+      <point x="446" y="481" name="inserted"/>
+      <point x="415" y="457" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/less.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/less.glif
@@ -4,32 +4,32 @@
   <unicode hex="003C"/>
   <outline>
     <contour>
-      <point x="358" y="262" type="qcurve" smooth="yes"/>
-      <point x="105" y="458" type="line" smooth="yes"/>
-      <point x="70" y="485"/>
-      <point x="70" y="485"/>
+      <point x="358" y="264" type="qcurve" smooth="yes"/>
+      <point x="105" y="460" type="line" smooth="yes"/>
+      <point x="70" y="487"/>
+      <point x="70" y="487"/>
       <point x="70" y="539" type="qcurve"/>
       <point x="70" y="539" type="line"/>
-      <point x="70" y="595"/>
-      <point x="70" y="595" name="inserted"/>
-      <point x="101" y="619" type="qcurve" smooth="yes"/>
-      <point x="360" y="818" type="line" smooth="yes"/>
-      <point x="436" y="876"/>
-      <point x="436" y="876"/>
-      <point x="436" y="789" type="qcurve"/>
-      <point x="436" y="789" type="line"/>
-      <point x="436" y="719"/>
-      <point x="436" y="719" name="inserted"/>
-      <point x="388" y="685" type="qcurve"/>
-      <point x="193" y="543" type="line"/>
-      <point x="193" y="540" type="line"/>
-      <point x="385" y="400" type="line"/>
-      <point x="436" y="364" name="inserted"/>
-      <point x="436" y="364"/>
-      <point x="436" y="291" type="qcurve"/>
-      <point x="436" y="291" type="line"/>
-      <point x="436" y="202"/>
-      <point x="436" y="202"/>
+      <point x="70" y="594"/>
+      <point x="70" y="594" name="inserted"/>
+      <point x="101" y="618" type="qcurve" smooth="yes"/>
+      <point x="360" y="817" type="line" smooth="yes"/>
+      <point x="436" y="875"/>
+      <point x="436" y="875"/>
+      <point x="436" y="788" type="qcurve"/>
+      <point x="436" y="788" type="line"/>
+      <point x="436" y="718"/>
+      <point x="436" y="718" name="inserted"/>
+      <point x="388" y="684" type="qcurve"/>
+      <point x="193" y="542" type="line"/>
+      <point x="193" y="542" type="line"/>
+      <point x="385" y="402" type="line"/>
+      <point x="436" y="366" name="inserted"/>
+      <point x="436" y="366"/>
+      <point x="436" y="293" type="qcurve"/>
+      <point x="436" y="293" type="line"/>
+      <point x="436" y="204"/>
+      <point x="436" y="204"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/m.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/m.glif
@@ -51,10 +51,10 @@
       <point x="99" y="1020" type="line"/>
       <point x="162" y="1020"/>
       <point x="162" y="1020" name="inserted"/>
-      <point x="162" y="966" type="qcurve"/>
-      <point x="162" y="966" type="line"/>
-      <point x="166" y="966" type="line"/>
-      <point x="180" y="996"/>
+      <point x="162" y="959" type="qcurve"/>
+      <point x="162" y="959" type="line"/>
+      <point x="162" y="959" type="line"/>
+      <point x="179" y="996"/>
       <point x="230" y="1028"/>
       <point x="268" y="1028" type="qcurve" smooth="yes"/>
       <point x="306" y="1028"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/mu.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/mu.glif
@@ -47,7 +47,7 @@
       <point x="356" y="-9" type="qcurve"/>
       <point x="314" y="-9"/>
       <point x="264" y="36"/>
-      <point x="258" y="89" type="qcurve"/>
+      <point x="259" y="89" type="qcurve"/>
       <point x="259" y="89" type="line"/>
       <point x="250" y="33"/>
       <point x="229" y="-8"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/n.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/n.glif
@@ -36,10 +36,10 @@
       <point x="99" y="1020" type="line"/>
       <point x="162" y="1020"/>
       <point x="162" y="1020" name="inserted"/>
-      <point x="162" y="966" type="qcurve"/>
-      <point x="162" y="966" type="line"/>
-      <point x="166" y="966" type="line"/>
-      <point x="180" y="994"/>
+      <point x="162" y="959" type="qcurve"/>
+      <point x="162" y="959" type="line"/>
+      <point x="162" y="959" type="line"/>
+      <point x="180" y="995"/>
       <point x="240" y="1028"/>
       <point x="274" y="1028" type="qcurve" smooth="yes"/>
       <point x="330" y="1028"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/one.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/one.tf.glif
@@ -23,8 +23,8 @@
       <point x="106" y="1379" type="line" smooth="yes"/>
       <point x="178" y="1432"/>
       <point x="178" y="1432"/>
-      <point x="209" y="1432" type="qcurve"/>
-      <point x="209" y="1432" type="line"/>
+      <point x="224" y="1432" type="qcurve"/>
+      <point x="224" y="1432" type="line"/>
       <point x="270" y="1432"/>
       <point x="270" y="1432" name="inserted"/>
       <point x="270" y="1368" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/registered.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/registered.glif
@@ -58,8 +58,8 @@
       <point x="499" y="1086" type="qcurve"/>
       <point x="499" y="1027"/>
       <point x="475" y="971"/>
-      <point x="450" y="962" type="qcurve"/>
-      <point x="449" y="957" type="line"/>
+      <point x="448" y="961" type="qcurve"/>
+      <point x="448" y="961" type="line"/>
       <point x="489" y="840" type="line"/>
       <point x="489" y="840" type="line"/>
       <point x="511" y="778" name="inserted"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/semicolon.glif
@@ -18,11 +18,11 @@
       <point x="304" y="974"/>
     </contour>
     <contour>
-      <point x="183" y="-147" type="line"/>
-      <point x="141" y="-220" name="inserted"/>
-      <point x="141" y="-220"/>
-      <point x="71" y="-174" type="qcurve"/>
-      <point x="58" y="-166" type="line"/>
+      <point x="172" y="-162" type="line" smooth="yes"/>
+      <point x="141" y="-214" name="inserted"/>
+      <point x="141" y="-214"/>
+      <point x="63" y="-169" type="qcurve"/>
+      <point x="63" y="-157" type="line"/>
       <point x="158" y="-2" type="line"/>
       <point x="124" y="8"/>
       <point x="82" y="62"/>
@@ -34,8 +34,8 @@
       <point x="306" y="146"/>
       <point x="306" y="100" type="qcurve" smooth="yes"/>
       <point x="306" y="84"/>
-      <point x="296" y="50"/>
-      <point x="256" y="-20" type="qcurve"/>
+      <point x="297" y="50"/>
+      <point x="256" y="-20" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/sterling.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/sterling.glif
@@ -46,10 +46,10 @@
       <point x="243" y="601"/>
       <point x="242" y="509" type="qcurve"/>
       <point x="242" y="509" type="line"/>
-      <point x="242" y="372"/>
-      <point x="180" y="165"/>
-      <point x="139" y="110" type="qcurve"/>
-      <point x="86" y="134" type="line"/>
+      <point x="242" y="391"/>
+      <point x="200" y="218"/>
+      <point x="155" y="134" type="qcurve"/>
+      <point x="155" y="134" type="line"/>
       <point x="232" y="134" type="line"/>
       <point x="264" y="134"/>
       <point x="305" y="214"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/three.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/three.glif
@@ -44,8 +44,8 @@
       <point x="372" y="974" type="line" smooth="yes"/>
       <point x="372" y="892"/>
       <point x="326" y="804"/>
-      <point x="274" y="782" type="qcurve"/>
-      <point x="274" y="774" type="line"/>
+      <point x="266" y="778" type="qcurve"/>
+      <point x="266" y="778" type="line"/>
       <point x="334" y="756"/>
       <point x="390" y="676"/>
       <point x="390" y="594" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/three.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/three.tf.glif
@@ -43,8 +43,8 @@
       <point x="372" y="974" type="line" smooth="yes"/>
       <point x="372" y="892"/>
       <point x="326" y="804"/>
-      <point x="274" y="782" type="qcurve"/>
-      <point x="274" y="774" type="line"/>
+      <point x="266" y="778" type="qcurve"/>
+      <point x="266" y="778" type="line"/>
       <point x="334" y="756"/>
       <point x="390" y="676"/>
       <point x="390" y="594" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/w.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/w.glif
@@ -35,8 +35,8 @@
       <point x="124" y="1020"/>
       <point x="129" y="972" type="qcurve" smooth="yes"/>
       <point x="176" y="490" type="line"/>
-      <point x="182" y="330" type="line"/>
-      <point x="184" y="330" type="line"/>
+      <point x="183" y="326" type="line"/>
+      <point x="183" y="326" type="line"/>
       <point x="200" y="490" type="line"/>
       <point x="258" y="959" type="line" smooth="yes"/>
       <point x="266" y="1020"/>
@@ -47,8 +47,8 @@
       <point x="382" y="1020"/>
       <point x="389" y="959" type="qcurve" smooth="yes"/>
       <point x="444" y="490" type="line"/>
-      <point x="458" y="332" type="line"/>
-      <point x="460" y="332" type="line"/>
+      <point x="459" y="326" type="line"/>
+      <point x="459" y="326" type="line"/>
       <point x="472" y="490" type="line"/>
       <point x="523" y="975" type="line" smooth="yes"/>
       <point x="528" y="1020"/>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/yen.glif
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/glyphs/yen.glif
@@ -15,8 +15,8 @@
       <point x="135" y="1432"/>
       <point x="142" y="1348" type="qcurve"/>
       <point x="189" y="853" type="line"/>
-      <point x="195" y="703" type="line"/>
-      <point x="198" y="703" type="line"/>
+      <point x="197" y="703" type="line"/>
+      <point x="197" y="703" type="line"/>
       <point x="203" y="853" type="line"/>
       <point x="247" y="1348" type="line"/>
       <point x="254" y="1432"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/comma.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/comma.glif
@@ -10,7 +10,7 @@
       <point x="151" y="-173" type="qcurve"/>
       <point x="151" y="-163" type="line"/>
       <point x="273" y="2" type="line"/>
-      <point x="232" y="6"/>
+      <point x="236" y="2"/>
       <point x="202" y="39"/>
       <point x="202" y="64" type="qcurve" smooth="yes"/>
       <point x="202" y="94"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -1,14 +1,15 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="commaaccentcomb" format="2">
   <unicode hex="0326"/>
+  <guideline x="-71" y="-413" angle="90" identifier="8z7zYiuzGu"/>
   <anchor x="0" y="0" name="_bottom"/>
   <outline>
     <contour>
       <point x="-43" y="-421" type="line" smooth="yes"/>
       <point x="-55" y="-437" name="inserted"/>
       <point x="-55" y="-437"/>
-      <point x="-76" y="-425" type="qcurve"/>
-      <point x="-76" y="-425" type="line"/>
+      <point x="-73" y="-427" type="qcurve"/>
+      <point x="-73" y="-421" type="line"/>
       <point x="23" y="-289" type="line"/>
       <point x="-8" y="-294"/>
       <point x="-59" y="-258"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/commaturnedabovecomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/commaturnedabovecomb.glif
@@ -8,8 +8,8 @@
       <point x="43" y="1508" type="line" smooth="yes"/>
       <point x="55" y="1524" name="inserted"/>
       <point x="55" y="1524"/>
-      <point x="76" y="1512" type="qcurve"/>
-      <point x="76" y="1512" type="line"/>
+      <point x="73" y="1514" type="qcurve"/>
+      <point x="73" y="1508" type="line"/>
       <point x="-23" y="1376" type="line"/>
       <point x="8" y="1381"/>
       <point x="59" y="1345"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/nine.glif
@@ -4,57 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="62.007246376811594" y="996" type="line"/>
-      <point x="61.007246376811594" y="808"/>
-      <point x="325.0072463768116" y="570"/>
-      <point x="505.0072463768116" y="570" type="qcurve"/>
-      <point x="505.0072463768116" y="570" type="line"/>
-      <point x="669.0072463768116" y="570"/>
-      <point x="951.0072463768116" y="792"/>
-      <point x="951.0072463768116" y="996" type="qcurve"/>
-      <point x="951.0072463768116" y="996" type="line"/>
-      <point x="951.0072463768116" y="1162"/>
-      <point x="713.0072463768116" y="1432"/>
-      <point x="505.0072463768116" y="1431" type="qcurve"/>
-      <point x="505.0072463768116" y="1431" type="line"/>
-      <point x="315.0072463768116" y="1432"/>
-      <point x="61.007246376811594" y="1180"/>
-      <point x="62.007246376811594" y="996" type="qcurve"/>
+      <point x="504" y="1462" type="line"/>
+      <point x="712" y="1462"/>
+      <point x="983" y="1190"/>
+      <point x="983" y="996" type="qcurve"/>
+      <point x="983" y="996" type="line"/>
+      <point x="983" y="797"/>
+      <point x="680" y="540"/>
+      <point x="498" y="540" type="qcurve"/>
+      <point x="498" y="540" type="line"/>
+      <point x="313" y="540"/>
+      <point x="29" y="796"/>
+      <point x="30" y="994" type="qcurve"/>
+      <point x="30" y="994" type="line"/>
+      <point x="29" y="1190"/>
+      <point x="303" y="1462"/>
+      <point x="504" y="1462" type="qcurve"/>
     </contour>
     <contour>
-      <point x="413" y="-21" type="line"/>
-      <point x="404" y="-34" name="inserted"/>
-      <point x="404.0072463768116" y="-34"/>
-      <point x="391.0072463768116" y="-25" type="qcurve"/>
-      <point x="391.0072463768116" y="-25" type="line"/>
-      <point x="377.0072463768116" y="-15"/>
-      <point x="377.0072463768116" y="-15"/>
-      <point x="386.0072463768116" y="-2" type="qcurve"/>
-      <point x="694" y="459" type="line" smooth="yes"/>
-      <point x="730" y="513"/>
-      <point x="803" y="626"/>
-      <point x="844" y="675" type="qcurve" smooth="yes"/>
-      <point x="872" y="709" type="line"/>
-      <point x="867" y="713" type="line"/>
-      <point x="825" y="650"/>
-      <point x="625.0072463768116" y="540"/>
-      <point x="498.0072463768116" y="540" type="qcurve"/>
-      <point x="498.0072463768116" y="540" type="line"/>
-      <point x="313.0072463768116" y="540"/>
-      <point x="29.007246376811594" y="796"/>
-      <point x="30.007246376811594" y="994" type="qcurve"/>
-      <point x="30.007246376811594" y="994" type="line"/>
-      <point x="29.007246376811594" y="1190"/>
-      <point x="303.0072463768116" y="1462"/>
-      <point x="504.0072463768116" y="1462" type="qcurve"/>
-      <point x="504.0072463768116" y="1462" type="line"/>
-      <point x="727.0072463768116" y="1462"/>
-      <point x="983" y="1180"/>
-      <point x="983.0072463768116" y="994" type="qcurve"/>
-      <point x="983" y="994" type="line"/>
-      <point x="983" y="871"/>
-      <point x="916" y="737"/>
-      <point x="802" y="566" type="qcurve" smooth="yes"/>
+      <point x="976" y="996" type="line"/>
+      <point x="983" y="996" type="line"/>
+      <point x="983" y="846"/>
+      <point x="870" y="659"/>
+      <point x="772" y="523" type="qcurve" smooth="yes"/>
+      <point x="388" y="-12" type="line"/>
+      <point x="374" y="-31"/>
+      <point x="374" y="-31"/>
+      <point x="362" y="-23" type="qcurve"/>
+      <point x="362" y="-23" type="line"/>
+      <point x="348" y="-14"/>
+      <point x="348" y="-14"/>
+      <point x="360" y="5" type="qcurve"/>
+      <point x="735" y="523" type="line"/>
+      <point x="769" y="572"/>
+      <point x="833" y="658"/>
+      <point x="889" y="725" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="505" y="1431" type="qcurve"/>
+      <point x="505" y="1432" type="line"/>
+      <point x="315" y="1433"/>
+      <point x="61" y="1181"/>
+      <point x="62" y="997" type="qcurve"/>
+      <point x="62" y="996" type="line"/>
+      <point x="61" y="808"/>
+      <point x="325" y="570"/>
+      <point x="505" y="570" type="qcurve"/>
+      <point x="505" y="570" type="line"/>
+      <point x="669" y="570"/>
+      <point x="951" y="792"/>
+      <point x="951" y="996" type="qcurve"/>
+      <point x="951" y="996" type="line"/>
+      <point x="951" y="1182"/>
+      <point x="698" y="1432"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/registered.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/registered.glif
@@ -61,8 +61,8 @@
       <point x="603" y="980"/>
       <point x="559" y="967" type="qcurve"/>
       <point x="558" y="966" type="line"/>
-      <point x="656" y="808" type="line"/>
-      <point x="663" y="797" type="line" smooth="yes"/>
+      <point x="663" y="797" type="line"/>
+      <point x="663" y="797" type="line"/>
       <point x="677" y="775" name="inserted"/>
       <point x="677" y="775"/>
       <point x="657" y="775" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/semicolon.glif
@@ -24,7 +24,7 @@
       <point x="111" y="-173" type="qcurve"/>
       <point x="111" y="-163" type="line"/>
       <point x="233" y="2" type="line"/>
-      <point x="192" y="6"/>
+      <point x="196" y="2"/>
       <point x="162" y="39"/>
       <point x="162" y="64" type="qcurve" smooth="yes"/>
       <point x="162" y="94"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/glyphs/six.glif
@@ -4,48 +4,13 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="82" y="434" type="line"/>
-      <point x="82" y="268"/>
-      <point x="320" y="-2"/>
-      <point x="528" y="-1" type="qcurve"/>
-      <point x="528" y="-1" type="line"/>
-      <point x="718" y="-2"/>
-      <point x="972" y="250"/>
-      <point x="971" y="434" type="qcurve"/>
-      <point x="971" y="434" type="line"/>
-      <point x="972" y="622"/>
-      <point x="708" y="860"/>
-      <point x="528" y="860" type="qcurve"/>
-      <point x="528" y="860" type="line"/>
-      <point x="364" y="860"/>
-      <point x="82" y="638"/>
-      <point x="82" y="434" type="qcurve"/>
-    </contour>
-    <contour>
       <point x="529" y="-32" type="line"/>
-      <point x="306" y="-32"/>
-      <point x="50" y="248"/>
-      <point x="50" y="426" type="qcurve"/>
-      <point x="50" y="426" type="line"/>
-      <point x="50" y="532"/>
-      <point x="99" y="663"/>
-      <point x="182" y="790" type="qcurve"/>
-      <point x="621" y="1454" type="line"/>
-      <point x="628" y="1465" name="inserted"/>
-      <point x="628" y="1465"/>
-      <point x="641" y="1456" type="qcurve"/>
-      <point x="641" y="1456" type="line"/>
-      <point x="655" y="1447"/>
-      <point x="655" y="1447"/>
-      <point x="648" y="1435" type="qcurve"/>
-      <point x="339" y="971" type="line"/>
-      <point x="303" y="917"/>
-      <point x="223" y="804"/>
-      <point x="185" y="752" type="qcurve" smooth="yes"/>
-      <point x="160" y="718" type="line"/>
-      <point x="164" y="717" type="line"/>
-      <point x="213" y="781"/>
-      <point x="408" y="890"/>
+      <point x="321" y="-32"/>
+      <point x="50" y="240"/>
+      <point x="50" y="434" type="qcurve"/>
+      <point x="50" y="434" type="line"/>
+      <point x="50" y="633"/>
+      <point x="353" y="890"/>
       <point x="535" y="890" type="qcurve"/>
       <point x="535" y="890" type="line"/>
       <point x="720" y="890"/>
@@ -55,6 +20,43 @@
       <point x="1004" y="240"/>
       <point x="730" y="-32"/>
       <point x="529" y="-32" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="57" y="434" type="line"/>
+      <point x="50" y="434" type="line"/>
+      <point x="50" y="584"/>
+      <point x="163" y="771"/>
+      <point x="261" y="907" type="qcurve" smooth="yes"/>
+      <point x="645" y="1442" type="line"/>
+      <point x="659" y="1461"/>
+      <point x="659" y="1461"/>
+      <point x="671" y="1453" type="qcurve"/>
+      <point x="671" y="1453" type="line"/>
+      <point x="685" y="1444"/>
+      <point x="685" y="1444"/>
+      <point x="673" y="1425" type="qcurve"/>
+      <point x="298" y="907" type="line"/>
+      <point x="264" y="858"/>
+      <point x="200" y="772"/>
+      <point x="144" y="705" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="528" y="-1" type="qcurve"/>
+      <point x="528" y="-2" type="line"/>
+      <point x="718" y="-3"/>
+      <point x="972" y="249"/>
+      <point x="971" y="433" type="qcurve"/>
+      <point x="971" y="434" type="line"/>
+      <point x="972" y="622"/>
+      <point x="708" y="860"/>
+      <point x="528" y="860" type="qcurve"/>
+      <point x="528" y="860" type="line"/>
+      <point x="364" y="860"/>
+      <point x="82" y="638"/>
+      <point x="82" y="434" type="qcurve"/>
+      <point x="82" y="434" type="line"/>
+      <point x="82" y="248"/>
+      <point x="335" y="-2"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/comma.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/comma.glif
@@ -7,8 +7,8 @@
       <point x="489" y="-113" type="line" smooth="yes"/>
       <point x="333" y="-325" name="inserted"/>
       <point x="333" y="-325"/>
-      <point x="71" y="-161" type="qcurve"/>
-      <point x="71" y="-161" type="line"/>
+      <point x="86" y="-170" type="qcurve"/>
+      <point x="86" y="-140" type="line"/>
       <point x="244" y="88" type="line"/>
       <point x="199" y="114"/>
       <point x="131" y="220"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -1,14 +1,15 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="commaaccentcomb" format="2">
   <unicode hex="0326"/>
+  <guideline x="-499" y="-600" angle="90" identifier="Y3JUJPOwlr"/>
   <anchor x="0" y="0" name="_bottom"/>
   <outline>
     <contour>
       <point x="108" y="-808" type="line" smooth="yes"/>
       <point x="-54" y="-1027" name="inserted"/>
       <point x="-54" y="-1027"/>
-      <point x="-316" y="-863" type="qcurve"/>
-      <point x="-316" y="-863" type="line"/>
+      <point x="-302" y="-872" type="qcurve"/>
+      <point x="-302" y="-842" type="line"/>
       <point x="-143" y="-614" type="line"/>
       <point x="-188" y="-588"/>
       <point x="-256" y="-482"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/commaturnedabovecomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/commaturnedabovecomb.glif
@@ -1,15 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="commaturnedabovecomb" format="2">
   <unicode hex="0312"/>
+  <guideline x="141" y="2122" angle="0" identifier="k2W08WRka7"/>
   <anchor x="0" y="1020" name="_top"/>
-  <anchor x="0" y="1978" name="top"/>
+  <anchor x="0" y="2122" name="top"/>
   <outline>
     <contour>
       <point x="-100" y="1911" type="line" smooth="yes"/>
       <point x="54" y="2120" name="inserted"/>
       <point x="54" y="2120"/>
-      <point x="316" y="1956" type="qcurve"/>
-      <point x="316" y="1956" type="line"/>
+      <point x="301" y="1965" type="qcurve"/>
+      <point x="301" y="1934" type="line"/>
       <point x="143" y="1707" type="line"/>
       <point x="188" y="1681"/>
       <point x="256" y="1575"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/registered.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/registered.glif
@@ -60,15 +60,15 @@
       <point x="709" y="961"/>
       <point x="681" y="947" type="qcurve"/>
       <point x="680" y="944" type="line"/>
-      <point x="725" y="878" type="line"/>
-      <point x="727" y="875" type="line" smooth="yes"/>
+      <point x="748" y="843" type="line"/>
+      <point x="748" y="843" type="line"/>
       <point x="781" y="795"/>
       <point x="781" y="795"/>
       <point x="694" y="795" type="qcurve"/>
       <point x="694" y="795" type="line"/>
       <point x="607" y="795"/>
       <point x="607" y="795"/>
-      <point x="593" y="818" type="qcurve"/>
+      <point x="589" y="825" type="qcurve"/>
       <point x="535" y="912" type="line"/>
       <point x="529" y="912" type="line"/>
       <point x="529" y="871" type="line" smooth="yes"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/semicolon.glif
@@ -21,8 +21,8 @@
       <point x="489" y="-131" type="line" smooth="yes"/>
       <point x="350" y="-330" name="inserted"/>
       <point x="350" y="-330"/>
-      <point x="90" y="-168" type="qcurve"/>
-      <point x="90" y="-168" type="line"/>
+      <point x="105" y="-177" type="qcurve"/>
+      <point x="105" y="-148" type="line"/>
       <point x="241" y="36" type="line"/>
       <point x="199" y="63"/>
       <point x="137" y="170"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -5,8 +5,8 @@
   <outline>
     <contour>
       <point x="-13" y="-548" type="line" smooth="yes"/>
-      <point x="-61" y="-620"/>
-      <point x="-61" y="-623"/>
+      <point x="-62" y="-622"/>
+      <point x="-62" y="-622"/>
       <point x="-142" y="-566" type="qcurve"/>
       <point x="-142" y="-553" type="line"/>
       <point x="-34" y="-400" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0.ufo/glyphs/nine.glif
@@ -4,57 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="237" y="991" type="line"/>
-      <point x="237" y="860"/>
-      <point x="409" y="687"/>
-      <point x="541" y="687" type="qcurve"/>
-      <point x="541" y="687" type="line"/>
-      <point x="676" y="687"/>
-      <point x="855" y="860"/>
-      <point x="855" y="993" type="qcurve"/>
-      <point x="855" y="993" type="line"/>
-      <point x="855" y="1125"/>
-      <point x="679" y="1299"/>
-      <point x="539" y="1299" type="qcurve"/>
-      <point x="539" y="1299" type="line"/>
-      <point x="408" y="1299"/>
-      <point x="237" y="1126"/>
-      <point x="237" y="991" type="qcurve"/>
+      <point x="539" y="1461" type="line"/>
+      <point x="749" y="1461"/>
+      <point x="1023" y="1189"/>
+      <point x="1023" y="980" type="qcurve"/>
+      <point x="1023" y="980" type="line"/>
+      <point x="1023" y="791"/>
+      <point x="708" y="529"/>
+      <point x="506" y="529" type="qcurve"/>
+      <point x="506" y="529" type="line"/>
+      <point x="331" y="529"/>
+      <point x="66" y="793"/>
+      <point x="66" y="984" type="qcurve"/>
+      <point x="66" y="984" type="line"/>
+      <point x="66" y="1183"/>
+      <point x="338" y="1461"/>
+      <point x="539" y="1461" type="qcurve"/>
     </contour>
     <contour>
-      <point x="502" y="36" type="line"/>
-      <point x="453" y="-32"/>
-      <point x="453" y="-32"/>
-      <point x="390" y="11" type="qcurve"/>
-      <point x="390" y="11" type="line"/>
-      <point x="317" y="61"/>
-      <point x="317" y="61"/>
-      <point x="364" y="128" type="qcurve"/>
-      <point x="493" y="311" type="line" smooth="yes"/>
-      <point x="539" y="376"/>
-      <point x="627" y="497"/>
-      <point x="657" y="535" type="qcurve"/>
-      <point x="671" y="553" type="line"/>
-      <point x="665" y="561" type="line"/>
-      <point x="646" y="548"/>
-      <point x="563" y="529"/>
-      <point x="507" y="529" type="qcurve"/>
-      <point x="507" y="529" type="line"/>
-      <point x="332" y="529"/>
-      <point x="67" y="793"/>
-      <point x="67" y="985" type="qcurve"/>
-      <point x="67" y="985" type="line"/>
-      <point x="67" y="1183"/>
-      <point x="339" y="1461"/>
-      <point x="541" y="1461" type="qcurve"/>
-      <point x="541" y="1461" type="line"/>
-      <point x="750" y="1461"/>
-      <point x="1025" y="1189"/>
-      <point x="1025" y="985" type="qcurve"/>
-      <point x="1025" y="985" type="line"/>
-      <point x="1025" y="854"/>
-      <point x="901" y="605"/>
-      <point x="795" y="454" type="qcurve"/>
+      <point x="879" y="980" type="line"/>
+      <point x="1023" y="980" type="line"/>
+      <point x="1025" y="806"/>
+      <point x="825" y="495"/>
+      <point x="751" y="390" type="qcurve" smooth="yes"/>
+      <point x="505" y="41" type="line"/>
+      <point x="452" y="-32"/>
+      <point x="452" y="-32"/>
+      <point x="389" y="11" type="qcurve"/>
+      <point x="389" y="11" type="line"/>
+      <point x="316" y="61"/>
+      <point x="316" y="61"/>
+      <point x="362" y="126" type="qcurve"/>
+      <point x="528" y="357" type="line" smooth="yes"/>
+      <point x="583" y="434"/>
+      <point x="670" y="533"/>
+      <point x="734" y="594" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="542" y="1299" type="qcurve"/>
+      <point x="542" y="1299" type="line"/>
+      <point x="407" y="1299"/>
+      <point x="236" y="1126"/>
+      <point x="236" y="990" type="qcurve"/>
+      <point x="236" y="990" type="line"/>
+      <point x="236" y="860"/>
+      <point x="408" y="687"/>
+      <point x="541" y="687" type="qcurve"/>
+      <point x="541" y="687" type="line"/>
+      <point x="675" y="687"/>
+      <point x="854" y="860"/>
+      <point x="854" y="991" type="qcurve"/>
+      <point x="854" y="991" type="line"/>
+      <point x="854" y="1125"/>
+      <point x="678" y="1299"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0.ufo/glyphs/registered.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0.ufo/glyphs/registered.glif
@@ -60,10 +60,10 @@
       <point x="656" y="968"/>
       <point x="614" y="956" type="qcurve"/>
       <point x="610" y="952" type="line"/>
-      <point x="730" y="782" type="line"/>
-      <point x="730" y="778" type="line"/>
-      <point x="713" y="778" name="inserted"/>
-      <point x="696" y="778"/>
+      <point x="706" y="816" type="line"/>
+      <point x="706" y="816" type="line"/>
+      <point x="732" y="778" name="inserted"/>
+      <point x="732" y="778"/>
       <point x="680" y="778" type="qcurve"/>
       <point x="680" y="778" type="line"/>
       <point x="630" y="778"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0.ufo/glyphs/six.glif
@@ -4,9 +4,43 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="260" y="438" type="line"/>
-      <point x="260" y="304"/>
-      <point x="436" y="130"/>
+      <point x="575" y="-32" type="line"/>
+      <point x="365" y="-32"/>
+      <point x="91" y="240"/>
+      <point x="91" y="449" type="qcurve"/>
+      <point x="91" y="449" type="line"/>
+      <point x="91" y="638"/>
+      <point x="406" y="900"/>
+      <point x="608" y="900" type="qcurve"/>
+      <point x="608" y="900" type="line"/>
+      <point x="783" y="900"/>
+      <point x="1048" y="636"/>
+      <point x="1048" y="445" type="qcurve"/>
+      <point x="1048" y="445" type="line"/>
+      <point x="1048" y="246"/>
+      <point x="776" y="-32"/>
+      <point x="575" y="-32" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="235" y="449" type="line"/>
+      <point x="91" y="449" type="line"/>
+      <point x="89" y="623"/>
+      <point x="289" y="934"/>
+      <point x="363" y="1039" type="qcurve" smooth="yes"/>
+      <point x="609" y="1388" type="line"/>
+      <point x="662" y="1461"/>
+      <point x="662" y="1461"/>
+      <point x="725" y="1418" type="qcurve"/>
+      <point x="725" y="1418" type="line"/>
+      <point x="798" y="1368"/>
+      <point x="798" y="1368"/>
+      <point x="752" y="1303" type="qcurve"/>
+      <point x="586" y="1072" type="line" smooth="yes"/>
+      <point x="531" y="995"/>
+      <point x="444" y="896"/>
+      <point x="380" y="835" type="qcurve"/>
+    </contour>
+    <contour>
       <point x="572" y="130" type="qcurve"/>
       <point x="572" y="130" type="line"/>
       <point x="707" y="130"/>
@@ -20,41 +54,9 @@
       <point x="439" y="742"/>
       <point x="260" y="569"/>
       <point x="260" y="438" type="qcurve"/>
-    </contour>
-    <contour>
-      <point x="575" y="-32" type="line"/>
-      <point x="365" y="-32"/>
-      <point x="90" y="240"/>
-      <point x="90" y="449" type="qcurve"/>
-      <point x="90" y="449" type="line"/>
-      <point x="90" y="575"/>
-      <point x="212" y="824"/>
-      <point x="318" y="975" type="qcurve"/>
-      <point x="613" y="1393" type="line"/>
-      <point x="662" y="1461"/>
-      <point x="662" y="1461"/>
-      <point x="725" y="1418" type="qcurve"/>
-      <point x="725" y="1418" type="line"/>
-      <point x="798" y="1368"/>
-      <point x="798" y="1368"/>
-      <point x="751" y="1301" type="qcurve"/>
-      <point x="459" y="894" type="line" smooth="yes"/>
-      <point x="455" y="888"/>
-      <point x="449" y="881"/>
-      <point x="445" y="877" type="qcurve"/>
-      <point x="444" y="876" type="line"/>
-      <point x="450" y="868" type="line"/>
-      <point x="469" y="881"/>
-      <point x="552" y="900"/>
-      <point x="608" y="900" type="qcurve"/>
-      <point x="608" y="900" type="line"/>
-      <point x="783" y="900"/>
-      <point x="1048" y="636"/>
-      <point x="1048" y="445" type="qcurve"/>
-      <point x="1048" y="445" type="line"/>
-      <point x="1048" y="246"/>
-      <point x="776" y="-32"/>
-      <point x="575" y="-32" type="qcurve"/>
+      <point x="260" y="438" type="line"/>
+      <point x="260" y="304"/>
+      <point x="436" y="130"/>
     </contour>
   </outline>
   <lib>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1-ROND0.ufo/glyphs/comma.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1-ROND0.ufo/glyphs/comma.glif
@@ -2,12 +2,13 @@
 <glyph name="comma" format="2">
   <advance width="740"/>
   <unicode hex="002C"/>
+  <guideline x="216" y="-230" angle="90" identifier="lTSkSLlABb"/>
   <outline>
     <contour>
       <point x="295" y="-274" type="line" smooth="yes"/>
-      <point x="277" y="-303" name="inserted"/>
-      <point x="278" y="-304"/>
-      <point x="257" y="-292" type="qcurve"/>
+      <point x="279" y="-299" name="inserted"/>
+      <point x="279" y="-299"/>
+      <point x="257" y="-285" type="qcurve"/>
       <point x="257" y="-272" type="line"/>
       <point x="431" y="4" type="line"/>
       <point x="408" y="0"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -7,8 +7,8 @@
       <point x="-111" y="-547" type="line" smooth="yes"/>
       <point x="-128" y="-575" name="inserted"/>
       <point x="-128" y="-575"/>
-      <point x="-153" y="-558" type="qcurve"/>
-      <point x="-153" y="-558" type="line"/>
+      <point x="-148" y="-562" type="qcurve"/>
+      <point x="-148" y="-550" type="line"/>
       <point x="21" y="-279" type="line"/>
       <point x="-17" y="-286"/>
       <point x="-62" y="-249"/>
@@ -17,9 +17,9 @@
       <point x="-29" y="-159"/>
       <point x="0" y="-159" type="qcurve" smooth="yes"/>
       <point x="28" y="-159"/>
-      <point x="62" y="-196"/>
-      <point x="62" y="-224" type="qcurve" smooth="yes"/>
-      <point x="62" y="-249"/>
+      <point x="63" y="-195"/>
+      <point x="63" y="-223" type="qcurve" smooth="yes"/>
+      <point x="63" y="-246"/>
       <point x="47" y="-289"/>
       <point x="31" y="-315" type="qcurve" smooth="yes"/>
     </contour>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1-ROND0.ufo/glyphs/commaturnedabovecomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1-ROND0.ufo/glyphs/commaturnedabovecomb.glif
@@ -8,8 +8,8 @@
       <point x="111" y="1640" type="line" smooth="yes"/>
       <point x="128" y="1667" name="inserted"/>
       <point x="128" y="1667"/>
-      <point x="153" y="1650" type="qcurve"/>
-      <point x="153" y="1650" type="line"/>
+      <point x="148" y="1654" type="qcurve"/>
+      <point x="148" y="1642" type="line"/>
       <point x="-21" y="1371" type="line"/>
       <point x="17" y="1378"/>
       <point x="62" y="1341"/>
@@ -18,9 +18,9 @@
       <point x="29" y="1251"/>
       <point x="0" y="1251" type="qcurve" smooth="yes"/>
       <point x="-26" y="1251"/>
-      <point x="-65" y="1285"/>
-      <point x="-65" y="1317" type="qcurve"/>
-      <point x="-65" y="1341"/>
+      <point x="-64" y="1285"/>
+      <point x="-64" y="1317" type="qcurve"/>
+      <point x="-64" y="1341"/>
       <point x="-45" y="1384"/>
       <point x="-31" y="1407" type="qcurve" smooth="yes"/>
     </contour>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1-ROND0.ufo/glyphs/semicolon.glif
@@ -19,9 +19,9 @@
     </contour>
     <contour>
       <point x="265" y="-274" type="line" smooth="yes"/>
-      <point x="247" y="-303" name="inserted"/>
-      <point x="248" y="-304"/>
-      <point x="227" y="-292" type="qcurve"/>
+      <point x="249" y="-299" name="inserted"/>
+      <point x="249" y="-299"/>
+      <point x="227" y="-285" type="qcurve"/>
       <point x="227" y="-272" type="line"/>
       <point x="401" y="4" type="line"/>
       <point x="378" y="0"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/comma.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/comma.glif
@@ -7,8 +7,8 @@
       <point x="583" y="-269" type="line" smooth="yes"/>
       <point x="443" y="-476" name="inserted"/>
       <point x="443" y="-476"/>
-      <point x="143" y="-295" type="qcurve"/>
-      <point x="143" y="-295" type="line"/>
+      <point x="158" y="-304" type="qcurve"/>
+      <point x="158" y="-271" type="line"/>
       <point x="382" y="92" type="line"/>
       <point x="359" y="114"/>
       <point x="283" y="229"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -7,8 +7,8 @@
       <point x="-37" y="-892" type="line" smooth="yes"/>
       <point x="-110" y="-1000" name="inserted"/>
       <point x="-110" y="-1000"/>
-      <point x="-350" y="-856" type="qcurve"/>
-      <point x="-350" y="-856" type="line"/>
+      <point x="-337" y="-864" type="qcurve"/>
+      <point x="-337" y="-834" type="line"/>
       <point x="-159" y="-546" type="line"/>
       <point x="-178" y="-528"/>
       <point x="-238" y="-436"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/commaturnedabovecomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/commaturnedabovecomb.glif
@@ -8,8 +8,8 @@
       <point x="37" y="1984" type="line" smooth="yes"/>
       <point x="110" y="2092" name="inserted"/>
       <point x="110" y="2092"/>
-      <point x="350" y="1948" type="qcurve"/>
-      <point x="350" y="1948" type="line"/>
+      <point x="336" y="1956" type="qcurve"/>
+      <point x="336" y="1926" type="line"/>
       <point x="159" y="1638" type="line"/>
       <point x="178" y="1620"/>
       <point x="238" y="1528"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/registered.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/registered.glif
@@ -60,8 +60,8 @@
       <point x="791" y="961"/>
       <point x="751" y="947" type="qcurve"/>
       <point x="750" y="944" type="line"/>
-      <point x="814" y="887" type="line"/>
-      <point x="856" y="848" type="line" smooth="yes"/>
+      <point x="856" y="848" type="line"/>
+      <point x="856" y="848" type="line"/>
       <point x="914" y="794"/>
       <point x="914" y="794"/>
       <point x="814" y="794" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/semicolon.glif
@@ -21,8 +21,8 @@
       <point x="606" y="-250" type="line" smooth="yes"/>
       <point x="472" y="-455" name="inserted"/>
       <point x="472" y="-455"/>
-      <point x="186" y="-270" type="qcurve"/>
-      <point x="186" y="-270" type="line"/>
+      <point x="201" y="-280" type="qcurve"/>
+      <point x="201" y="-247" type="line"/>
       <point x="379" y="40" type="line"/>
       <point x="359" y="63"/>
       <point x="289" y="179"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/comma.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/comma.glif
@@ -2,13 +2,14 @@
 <glyph name="comma" format="2">
   <advance width="720"/>
   <unicode hex="002C"/>
+  <guideline x="124" y="-197" angle="90" identifier="dDkN0MOpG0"/>
   <outline>
     <contour>
       <point x="336" y="-281" type="line" smooth="yes"/>
       <point x="278" y="-371" name="inserted"/>
       <point x="278" y="-371"/>
-      <point x="160" y="-299" type="qcurve"/>
-      <point x="160" y="-299" type="line"/>
+      <point x="169" y="-304" type="qcurve"/>
+      <point x="169" y="-284" type="line"/>
       <point x="348" y="4" type="line"/>
       <point x="310" y="23"/>
       <point x="268" y="91"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -1,14 +1,15 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="commaaccentcomb" format="2">
   <unicode hex="0326"/>
+  <guideline x="-208" y="-594" angle="90" identifier="M3q7hwQa8s"/>
   <anchor x="0" y="0" name="_bottom"/>
   <outline>
     <contour>
       <point x="-61" y="-602" type="line" smooth="yes"/>
       <point x="-108" y="-675" name="inserted"/>
       <point x="-108" y="-675"/>
-      <point x="-203" y="-617" type="qcurve"/>
-      <point x="-203" y="-617" type="line"/>
+      <point x="-195" y="-622" type="qcurve"/>
+      <point x="-195" y="-604" type="line"/>
       <point x="-53" y="-375" type="line"/>
       <point x="-83" y="-360"/>
       <point x="-117" y="-305"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/commaturnedabovecomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/commaturnedabovecomb.glif
@@ -8,8 +8,8 @@
       <point x="54" y="1683" type="line" smooth="yes"/>
       <point x="108" y="1768" name="inserted"/>
       <point x="108" y="1768"/>
-      <point x="203" y="1709" type="qcurve"/>
-      <point x="203" y="1709" type="line"/>
+      <point x="195" y="1714" type="qcurve"/>
+      <point x="195" y="1696" type="line"/>
       <point x="53" y="1467" type="line"/>
       <point x="83" y="1452"/>
       <point x="117" y="1397"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/eight.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/eight.glif
@@ -14,10 +14,10 @@
       <point x="91" y="392" type="qcurve"/>
       <point x="91" y="392" type="line"/>
       <point x="91" y="514"/>
-      <point x="297" y="693"/>
+      <point x="298" y="704"/>
       <point x="459" y="751" type="qcurve"/>
       <point x="459" y="759" type="line"/>
-      <point x="338" y="808"/>
+      <point x="303" y="802"/>
       <point x="166" y="962"/>
       <point x="166" y="1060" type="qcurve"/>
       <point x="166" y="1060" type="line"/>
@@ -30,10 +30,10 @@
       <point x="1520" y="1064" type="qcurve"/>
       <point x="1520" y="1064" type="line"/>
       <point x="1520" y="964"/>
-      <point x="1336" y="799"/>
+      <point x="1370" y="796"/>
       <point x="1226" y="759" type="qcurve"/>
       <point x="1226" y="748" type="line"/>
-      <point x="1394" y="699"/>
+      <point x="1399" y="707"/>
       <point x="1599" y="515"/>
       <point x="1599" y="397" type="qcurve"/>
     </contour>
@@ -48,20 +48,20 @@
       <point x="1353" y="1070" type="qcurve"/>
       <point x="1353" y="1070" type="line"/>
       <point x="1353" y="1176"/>
-      <point x="1077" y="1302"/>
-      <point x="857" y="1302" type="qcurve"/>
-      <point x="857" y="1302" type="line"/>
-      <point x="596" y="1302"/>
+      <point x="1077" y="1306"/>
+      <point x="857" y="1306" type="qcurve"/>
+      <point x="857" y="1306" type="line"/>
+      <point x="596" y="1306"/>
       <point x="333" y="1166"/>
       <point x="333" y="1070" type="qcurve"/>
     </contour>
     <contour>
       <point x="264" y="394" type="line"/>
       <point x="264" y="279"/>
-      <point x="596" y="130"/>
-      <point x="856" y="130" type="qcurve"/>
-      <point x="856" y="130" type="line"/>
-      <point x="1101" y="130"/>
+      <point x="596" y="124"/>
+      <point x="856" y="124" type="qcurve"/>
+      <point x="856" y="124" type="line"/>
+      <point x="1101" y="124"/>
       <point x="1425" y="276"/>
       <point x="1425" y="391" type="qcurve"/>
       <point x="1425" y="391" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/five.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/five.glif
@@ -4,11 +4,11 @@
   <unicode hex="0035"/>
   <outline>
     <contour>
-      <point x="152" y="745" type="qcurve" smooth="yes"/>
-      <point x="269" y="1353" type="line" smooth="yes"/>
-      <point x="284" y="1432"/>
-      <point x="284" y="1432"/>
-      <point x="351" y="1432" type="qcurve" smooth="yes"/>
+      <point x="171" y="745" type="qcurve" smooth="yes"/>
+      <point x="288" y="1353" type="line" smooth="yes"/>
+      <point x="303" y="1432"/>
+      <point x="303" y="1432"/>
+      <point x="370" y="1432" type="qcurve" smooth="yes"/>
       <point x="1452" y="1432" type="line"/>
       <point x="1533" y="1432"/>
       <point x="1533" y="1432"/>
@@ -17,18 +17,18 @@
       <point x="1533" y="1270"/>
       <point x="1533" y="1270" name="inserted"/>
       <point x="1452" y="1270" type="qcurve"/>
-      <point x="417" y="1270" type="line"/>
-      <point x="322" y="813" type="line"/>
-      <point x="331" y="800" type="line"/>
-      <point x="414" y="854"/>
-      <point x="717" y="922"/>
-      <point x="881" y="922" type="qcurve"/>
-      <point x="881" y="922" type="line"/>
-      <point x="1243" y="922"/>
-      <point x="1615" y="669"/>
-      <point x="1615" y="458" type="qcurve"/>
-      <point x="1615" y="458" type="line"/>
-      <point x="1615" y="262"/>
+      <point x="436" y="1270" type="line"/>
+      <point x="341" y="813" type="line"/>
+      <point x="350" y="800" type="line"/>
+      <point x="433" y="854"/>
+      <point x="717" y="932"/>
+      <point x="881" y="932" type="qcurve"/>
+      <point x="881" y="932" type="line"/>
+      <point x="1243" y="932"/>
+      <point x="1615" y="679"/>
+      <point x="1615" y="468" type="qcurve"/>
+      <point x="1615" y="468" type="line"/>
+      <point x="1615" y="272"/>
       <point x="1258" y="-32"/>
       <point x="904" y="-32" type="qcurve"/>
       <point x="904" y="-32" type="line"/>
@@ -45,27 +45,27 @@
       <point x="171" y="335" type="qcurve"/>
       <point x="171" y="335" type="line"/>
       <point x="261" y="249"/>
-      <point x="587" y="138"/>
-      <point x="903" y="138" type="qcurve"/>
-      <point x="903" y="138" type="line"/>
-      <point x="1182" y="138"/>
-      <point x="1441" y="324"/>
-      <point x="1441" y="462" type="qcurve"/>
-      <point x="1441" y="462" type="line"/>
-      <point x="1441" y="595"/>
-      <point x="1175" y="764"/>
-      <point x="888" y="764" type="qcurve"/>
-      <point x="888" y="764" type="line"/>
-      <point x="683" y="764"/>
-      <point x="436" y="718"/>
-      <point x="339" y="655" type="qcurve"/>
-      <point x="339" y="655" type="line"/>
-      <point x="275" y="611"/>
-      <point x="275" y="611"/>
-      <point x="209" y="639" type="qcurve"/>
-      <point x="209" y="639" type="line"/>
-      <point x="137" y="669"/>
-      <point x="137" y="669" name="inserted"/>
+      <point x="587" y="124"/>
+      <point x="903" y="124" type="qcurve"/>
+      <point x="903" y="124" type="line"/>
+      <point x="1182" y="124"/>
+      <point x="1441" y="334"/>
+      <point x="1441" y="472" type="qcurve"/>
+      <point x="1441" y="472" type="line"/>
+      <point x="1441" y="605"/>
+      <point x="1175" y="777"/>
+      <point x="888" y="777" type="qcurve"/>
+      <point x="888" y="777" type="line"/>
+      <point x="683" y="777"/>
+      <point x="456" y="711"/>
+      <point x="358" y="655" type="qcurve"/>
+      <point x="358" y="655" type="line"/>
+      <point x="294" y="611"/>
+      <point x="294" y="611"/>
+      <point x="228" y="639" type="qcurve"/>
+      <point x="228" y="639" type="line"/>
+      <point x="156" y="669"/>
+      <point x="156" y="669" name="inserted"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/nine.glif
@@ -4,57 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="260" y="996" type="line"/>
-      <point x="260" y="857"/>
-      <point x="602" y="673"/>
-      <point x="855" y="673" type="qcurve"/>
-      <point x="855" y="673" type="line"/>
-      <point x="1127" y="673"/>
-      <point x="1462" y="847"/>
-      <point x="1462" y="999" type="qcurve"/>
-      <point x="1462" y="999" type="line"/>
-      <point x="1462" y="1140"/>
-      <point x="1112" y="1325"/>
-      <point x="869" y="1325" type="qcurve"/>
-      <point x="869" y="1325" type="line"/>
-      <point x="600" y="1325"/>
-      <point x="260" y="1140"/>
-      <point x="260" y="996" type="qcurve"/>
+      <point x="866" y="1490" type="line"/>
+      <point x="1176" y="1490"/>
+      <point x="1630" y="1222"/>
+      <point x="1630" y="971" type="qcurve"/>
+      <point x="1630" y="971" type="line"/>
+      <point x="1630" y="778"/>
+      <point x="1123" y="529"/>
+      <point x="858" y="529" type="qcurve"/>
+      <point x="858" y="529" type="line"/>
+      <point x="528" y="529"/>
+      <point x="91" y="780"/>
+      <point x="91" y="988" type="qcurve"/>
+      <point x="91" y="988" type="line"/>
+      <point x="91" y="1201"/>
+      <point x="535" y="1490"/>
+      <point x="866" y="1490" type="qcurve"/>
     </contour>
     <contour>
-      <point x="437" y="-15" type="line"/>
-      <point x="396" y="-32"/>
-      <point x="396" y="-32"/>
-      <point x="364" y="44" type="qcurve"/>
-      <point x="364" y="44" type="line"/>
-      <point x="330" y="122"/>
-      <point x="330" y="122" name="inserted"/>
-      <point x="371" y="138" type="qcurve"/>
-      <point x="976" y="435" type="line" smooth="yes"/>
-      <point x="1109" y="500"/>
-      <point x="1256" y="582"/>
-      <point x="1292" y="612" type="qcurve"/>
-      <point x="1305" y="622" type="line"/>
-      <point x="1300" y="629" type="line"/>
-      <point x="1226" y="586"/>
-      <point x="978" y="534"/>
-      <point x="830" y="532" type="qcurve"/>
-      <point x="830" y="532" type="line"/>
-      <point x="523" y="532"/>
-      <point x="90" y="802"/>
-      <point x="90" y="999" type="qcurve"/>
-      <point x="90" y="999" type="line"/>
-      <point x="90" y="1202"/>
-      <point x="534" y="1487"/>
-      <point x="865" y="1487" type="qcurve"/>
-      <point x="865" y="1487" type="line"/>
-      <point x="1180" y="1487"/>
-      <point x="1629" y="1208"/>
-      <point x="1629" y="998" type="qcurve"/>
-      <point x="1629" y="998" type="line"/>
-      <point x="1629" y="762"/>
-      <point x="1312" y="432"/>
-      <point x="1057" y="302" type="qcurve" smooth="yes"/>
+      <point x="1537" y="971" type="line"/>
+      <point x="1630" y="971" type="line"/>
+      <point x="1630" y="778"/>
+      <point x="1393" y="501"/>
+      <point x="1161" y="363" type="qcurve" smooth="yes"/>
+      <point x="588" y="23" type="line" smooth="yes"/>
+      <point x="514" y="-21"/>
+      <point x="513" y="-22"/>
+      <point x="474" y="50" type="qcurve"/>
+      <point x="474" y="50" type="line"/>
+      <point x="431" y="126"/>
+      <point x="433" y="126"/>
+      <point x="503" y="166" type="qcurve" smooth="yes"/>
+      <point x="1083" y="500" type="line" smooth="yes"/>
+      <point x="1155" y="542"/>
+      <point x="1252" y="598"/>
+      <point x="1323" y="638" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="870" y="1331" type="qcurve"/>
+      <point x="870" y="1331" type="line"/>
+      <point x="601" y="1331"/>
+      <point x="261" y="1139"/>
+      <point x="261" y="985" type="qcurve"/>
+      <point x="261" y="985" type="line"/>
+      <point x="261" y="846"/>
+      <point x="589" y="678"/>
+      <point x="856" y="678" type="qcurve"/>
+      <point x="856" y="678" type="line"/>
+      <point x="1134" y="678"/>
+      <point x="1463" y="843"/>
+      <point x="1463" y="1002" type="qcurve"/>
+      <point x="1463" y="1002" type="line"/>
+      <point x="1463" y="1143"/>
+      <point x="1113" y="1331"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/registered.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/registered.glif
@@ -60,8 +60,8 @@
       <point x="812" y="964"/>
       <point x="744" y="964" type="qcurve"/>
       <point x="751" y="957" type="line"/>
-      <point x="867" y="850" type="line"/>
-      <point x="896" y="824" type="line" smooth="yes"/>
+      <point x="895" y="824" type="line"/>
+      <point x="895" y="824" type="line"/>
       <point x="948" y="776"/>
       <point x="948" y="776"/>
       <point x="890" y="776" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/semicolon.glif
@@ -2,7 +2,7 @@
 <glyph name="semicolon" format="2">
   <advance width="760"/>
   <unicode hex="003B"/>
-  <guideline x="189" y="298" angle="90" identifier="fxvG8gbDj2"/>
+  <guideline x="97" y="-115" angle="90" identifier="fxvG8gbDj2"/>
   <outline>
     <contour>
       <point x="543" y="887" type="qcurve" smooth="yes"/>
@@ -20,10 +20,10 @@
     </contour>
     <contour>
       <point x="340" y="-275" type="line" smooth="yes"/>
-      <point x="281" y="-367" name="inserted"/>
-      <point x="281" y="-367"/>
-      <point x="160" y="-299" type="qcurve"/>
-      <point x="160" y="-299" type="line"/>
+      <point x="279" y="-371" name="inserted"/>
+      <point x="279" y="-371"/>
+      <point x="169" y="-304" type="qcurve"/>
+      <point x="169" y="-284" type="line"/>
       <point x="348" y="4" type="line"/>
       <point x="330" y="8"/>
       <point x="268" y="81"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/six.glif
@@ -4,57 +4,59 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="258" y="457" type="line"/>
-      <point x="258" y="316"/>
-      <point x="608" y="131"/>
-      <point x="851" y="131" type="qcurve"/>
-      <point x="851" y="131" type="line"/>
-      <point x="1120" y="131"/>
-      <point x="1460" y="316"/>
-      <point x="1460" y="460" type="qcurve"/>
-      <point x="1460" y="460" type="line"/>
-      <point x="1460" y="599"/>
-      <point x="1118" y="783"/>
-      <point x="865" y="783" type="qcurve"/>
-      <point x="865" y="783" type="line"/>
-      <point x="593" y="783"/>
-      <point x="258" y="609"/>
-      <point x="258" y="457" type="qcurve"/>
-    </contour>
-    <contour>
       <point x="855" y="-31" type="line"/>
-      <point x="540" y="-31"/>
-      <point x="91" y="248"/>
-      <point x="91" y="458" type="qcurve"/>
-      <point x="91" y="458" type="line"/>
-      <point x="91" y="694"/>
-      <point x="408" y="1024"/>
-      <point x="663" y="1154" type="qcurve" smooth="yes"/>
-      <point x="1283" y="1471" type="line"/>
-      <point x="1324" y="1488"/>
-      <point x="1324" y="1488"/>
-      <point x="1356" y="1412" type="qcurve"/>
-      <point x="1356" y="1412" type="line"/>
-      <point x="1390" y="1334"/>
-      <point x="1390" y="1334" name="inserted"/>
-      <point x="1349" y="1318" type="qcurve"/>
-      <point x="744" y="1021" type="line" smooth="yes"/>
-      <point x="611" y="956"/>
-      <point x="464" y="874"/>
-      <point x="428" y="844" type="qcurve"/>
-      <point x="415" y="834" type="line"/>
-      <point x="420" y="827" type="line"/>
-      <point x="494" y="870"/>
-      <point x="742" y="922"/>
-      <point x="890" y="924" type="qcurve"/>
-      <point x="890" y="924" type="line"/>
-      <point x="1197" y="924"/>
-      <point x="1630" y="654"/>
-      <point x="1630" y="457" type="qcurve"/>
-      <point x="1630" y="457" type="line"/>
-      <point x="1630" y="254"/>
+      <point x="545" y="-31"/>
+      <point x="91" y="237"/>
+      <point x="91" y="488" type="qcurve"/>
+      <point x="91" y="488" type="line"/>
+      <point x="91" y="681"/>
+      <point x="598" y="930"/>
+      <point x="863" y="930" type="qcurve"/>
+      <point x="863" y="930" type="line"/>
+      <point x="1193" y="930"/>
+      <point x="1630" y="679"/>
+      <point x="1630" y="471" type="qcurve"/>
+      <point x="1630" y="471" type="line"/>
+      <point x="1630" y="258"/>
       <point x="1186" y="-31"/>
       <point x="855" y="-31" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="184" y="488" type="line"/>
+      <point x="91" y="488" type="line"/>
+      <point x="91" y="681"/>
+      <point x="328" y="959"/>
+      <point x="560" y="1096" type="qcurve" smooth="yes"/>
+      <point x="1151" y="1445" type="line" smooth="yes"/>
+      <point x="1225" y="1489"/>
+      <point x="1226" y="1490"/>
+      <point x="1265" y="1418" type="qcurve"/>
+      <point x="1265" y="1418" type="line"/>
+      <point x="1308" y="1342"/>
+      <point x="1306" y="1342"/>
+      <point x="1236" y="1302" type="qcurve" smooth="yes"/>
+      <point x="638" y="959" type="line" smooth="yes"/>
+      <point x="566" y="918"/>
+      <point x="471" y="867"/>
+      <point x="398" y="833" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="851" y="128" type="qcurve"/>
+      <point x="851" y="128" type="line"/>
+      <point x="1120" y="128"/>
+      <point x="1460" y="320"/>
+      <point x="1460" y="474" type="qcurve"/>
+      <point x="1460" y="474" type="line"/>
+      <point x="1460" y="613"/>
+      <point x="1132" y="783"/>
+      <point x="865" y="783" type="qcurve"/>
+      <point x="865" y="783" type="line"/>
+      <point x="587" y="783"/>
+      <point x="258" y="616"/>
+      <point x="258" y="457" type="qcurve"/>
+      <point x="258" y="457" type="line"/>
+      <point x="258" y="316"/>
+      <point x="608" y="128"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/three.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/three.glif
@@ -19,26 +19,26 @@
       <point x="1361" y="1066" type="qcurve"/>
       <point x="1361" y="1066" type="line"/>
       <point x="1361" y="1170"/>
-      <point x="1146" y="1304"/>
-      <point x="870" y="1304" type="qcurve"/>
-      <point x="870" y="1304" type="line"/>
-      <point x="696" y="1304"/>
-      <point x="457" y="1260"/>
-      <point x="366" y="1184" type="qcurve"/>
-      <point x="366" y="1184" type="line"/>
-      <point x="326" y="1147"/>
-      <point x="326" y="1147"/>
-      <point x="263" y="1210" type="qcurve"/>
-      <point x="263" y="1210" type="line"/>
-      <point x="208" y="1269"/>
-      <point x="208" y="1269" name="inserted"/>
-      <point x="240" y="1301" type="qcurve"/>
-      <point x="240" y="1301" type="line"/>
-      <point x="337" y="1381"/>
-      <point x="659" y="1465"/>
-      <point x="867" y="1464" type="qcurve"/>
-      <point x="867" y="1464" type="line"/>
-      <point x="1206" y="1466"/>
+      <point x="1160" y="1310"/>
+      <point x="884" y="1310" type="qcurve"/>
+      <point x="884" y="1310" type="line"/>
+      <point x="710" y="1310"/>
+      <point x="449" y="1243"/>
+      <point x="350" y="1179" type="qcurve"/>
+      <point x="350" y="1179" type="line"/>
+      <point x="304" y="1150"/>
+      <point x="304" y="1150"/>
+      <point x="254" y="1224" type="qcurve"/>
+      <point x="254" y="1224" type="line"/>
+      <point x="211" y="1293"/>
+      <point x="211" y="1293" name="inserted"/>
+      <point x="249" y="1318" type="qcurve"/>
+      <point x="249" y="1318" type="line"/>
+      <point x="360" y="1384"/>
+      <point x="673" y="1465"/>
+      <point x="881" y="1464" type="qcurve"/>
+      <point x="881" y="1464" type="line"/>
+      <point x="1220" y="1466"/>
       <point x="1533" y="1255"/>
       <point x="1533" y="1078" type="qcurve"/>
       <point x="1533" y="1078" type="line"/>
@@ -67,10 +67,10 @@
       <point x="254" y="321" type="qcurve"/>
       <point x="254" y="321" type="line"/>
       <point x="344" y="221"/>
-      <point x="664" y="119"/>
-      <point x="879" y="119" type="qcurve"/>
-      <point x="879" y="119" type="line"/>
-      <point x="1173" y="119"/>
+      <point x="664" y="122"/>
+      <point x="879" y="122" type="qcurve"/>
+      <point x="879" y="122" type="line"/>
+      <point x="1173" y="122"/>
       <point x="1407" y="307"/>
       <point x="1407" y="422" type="qcurve"/>
       <point x="1407" y="422" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/two.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/two.glif
@@ -10,43 +10,43 @@
       <point x="95" y="0"/>
       <point x="95" y="91" type="qcurve"/>
       <point x="95" y="91" type="line"/>
-      <point x="94" y="193"/>
-      <point x="94" y="193"/>
-      <point x="202" y="272" type="qcurve" smooth="yes"/>
-      <point x="707" y="638" type="line" smooth="yes"/>
-      <point x="986" y="840"/>
-      <point x="1167" y="1002"/>
-      <point x="1167" y="1096" type="qcurve"/>
-      <point x="1167" y="1096" type="line"/>
-      <point x="1167" y="1198"/>
-      <point x="939" y="1302"/>
-      <point x="736" y="1302" type="qcurve"/>
-      <point x="736" y="1302" type="line"/>
-      <point x="542" y="1300"/>
-      <point x="330" y="1218"/>
-      <point x="284" y="1158" type="qcurve"/>
-      <point x="284" y="1158" type="line"/>
-      <point x="245" y="1110"/>
-      <point x="245" y="1110"/>
+      <point x="94" y="163"/>
+      <point x="89" y="171"/>
+      <point x="199" y="245" type="qcurve" smooth="yes"/>
+      <point x="707" y="588" type="line" smooth="yes"/>
+      <point x="962" y="760"/>
+      <point x="1171" y="937"/>
+      <point x="1171" y="1076" type="qcurve"/>
+      <point x="1171" y="1076" type="line"/>
+      <point x="1171" y="1188"/>
+      <point x="939" y="1308"/>
+      <point x="736" y="1308" type="qcurve"/>
+      <point x="736" y="1308" type="line"/>
+      <point x="542" y="1306"/>
+      <point x="344" y="1210"/>
+      <point x="283" y="1147" type="qcurve"/>
+      <point x="283" y="1147" type="line"/>
+      <point x="240" y="1104"/>
+      <point x="240" y="1104"/>
       <point x="179" y="1161" type="qcurve"/>
       <point x="179" y="1161" type="line"/>
-      <point x="119" y="1212"/>
-      <point x="119" y="1212" name="inserted"/>
-      <point x="143" y="1248" type="qcurve"/>
-      <point x="143" y="1248" type="line"/>
-      <point x="207" y="1329"/>
-      <point x="497" y="1464"/>
-      <point x="725" y="1464" type="qcurve"/>
-      <point x="725" y="1464" type="line"/>
-      <point x="1004" y="1464"/>
-      <point x="1343" y="1266"/>
-      <point x="1343" y="1104" type="qcurve"/>
-      <point x="1343" y="1104" type="line"/>
-      <point x="1343" y="947"/>
-      <point x="1112" y="741"/>
-      <point x="817" y="534" type="qcurve" smooth="yes"/>
-      <point x="291" y="164" type="line"/>
-      <point x="291" y="164" type="line"/>
+      <point x="124" y="1218"/>
+      <point x="124" y="1218" name="inserted"/>
+      <point x="152" y="1251" type="qcurve"/>
+      <point x="152" y="1251" type="line"/>
+      <point x="225" y="1331"/>
+      <point x="508" y="1464"/>
+      <point x="736" y="1464" type="qcurve"/>
+      <point x="736" y="1464" type="line"/>
+      <point x="1015" y="1464"/>
+      <point x="1343" y="1248"/>
+      <point x="1343" y="1076" type="qcurve"/>
+      <point x="1343" y="1076" type="line"/>
+      <point x="1343" y="899"/>
+      <point x="1096" y="664"/>
+      <point x="817" y="484" type="qcurve" smooth="yes"/>
+      <point x="321" y="164" type="line"/>
+      <point x="321" y="164" type="line"/>
       <point x="1318" y="162" type="line"/>
       <point x="1399" y="162"/>
       <point x="1399" y="162"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/zero.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/zero.glif
@@ -7,37 +7,37 @@
       <point x="1041" y="-22" type="qcurve"/>
       <point x="1041" y="-22" type="line"/>
       <point x="638" y="-22"/>
-      <point x="115" y="418"/>
+      <point x="115" y="398"/>
       <point x="115" y="707" type="qcurve"/>
       <point x="115" y="707" type="line"/>
-      <point x="115" y="1015"/>
+      <point x="115" y="1040"/>
       <point x="652" y="1454"/>
       <point x="1034" y="1454" type="qcurve"/>
       <point x="1034" y="1454" type="line"/>
       <point x="1415" y="1454"/>
-      <point x="1957" y="1017"/>
+      <point x="1957" y="1042"/>
       <point x="1957" y="709" type="qcurve"/>
       <point x="1957" y="709" type="line"/>
-      <point x="1957" y="428"/>
+      <point x="1957" y="408"/>
       <point x="1406" y="-22"/>
     </contour>
     <contour>
-      <point x="1036" y="136" type="qcurve"/>
-      <point x="1036" y="136" type="line"/>
-      <point x="1349" y="136"/>
-      <point x="1784" y="489"/>
-      <point x="1784" y="708" type="qcurve"/>
-      <point x="1784" y="708" type="line"/>
-      <point x="1784" y="960"/>
-      <point x="1349" y="1298"/>
-      <point x="1031" y="1298" type="qcurve"/>
-      <point x="1031" y="1298" type="line"/>
-      <point x="721" y="1298"/>
-      <point x="288" y="961"/>
-      <point x="288" y="706" type="qcurve"/>
-      <point x="288" y="706" type="line"/>
-      <point x="288" y="487"/>
-      <point x="695" y="136"/>
+      <point x="1036" y="135" type="qcurve"/>
+      <point x="1036" y="135" type="line"/>
+      <point x="1349" y="135"/>
+      <point x="1784" y="468"/>
+      <point x="1784" y="707" type="qcurve"/>
+      <point x="1784" y="707" type="line"/>
+      <point x="1784" y="984"/>
+      <point x="1349" y="1295"/>
+      <point x="1031" y="1295" type="qcurve"/>
+      <point x="1031" y="1295" type="line"/>
+      <point x="721" y="1295"/>
+      <point x="288" y="985"/>
+      <point x="288" y="705" type="qcurve"/>
+      <point x="288" y="705" type="line"/>
+      <point x="288" y="466"/>
+      <point x="695" y="135"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/comma.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/comma.glif
@@ -2,12 +2,13 @@
 <glyph name="comma" format="2">
   <advance width="464"/>
   <unicode hex="002C"/>
+  <guideline x="123" y="-96" angle="90" identifier="Uh8qpIpqFc"/>
   <outline>
     <contour>
       <point x="197" y="-142" type="line" smooth="yes"/>
-      <point x="177" y="-178" name="inserted"/>
-      <point x="177" y="-178"/>
-      <point x="143" y="-163" type="qcurve"/>
+      <point x="179" y="-174" name="inserted"/>
+      <point x="179" y="-174"/>
+      <point x="143" y="-158" type="qcurve"/>
       <point x="143" y="-145" type="line"/>
       <point x="227" y="-5" type="line"/>
       <point x="203" y="0"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -1,14 +1,15 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="commaaccentcomb" format="2">
   <unicode hex="0326"/>
+  <guideline x="-92" y="-305" angle="90" identifier="CjQZMTHBoC"/>
   <anchor x="0" y="0" name="_bottom"/>
   <outline>
     <contour>
       <point x="-23" y="-384" type="line" smooth="yes"/>
-      <point x="-37" y="-412" name="inserted"/>
-      <point x="-37" y="-412"/>
-      <point x="-65" y="-399" type="qcurve"/>
-      <point x="-65" y="-399" type="line"/>
+      <point x="-35" y="-409" name="inserted"/>
+      <point x="-35" y="-409"/>
+      <point x="-61" y="-398" type="qcurve"/>
+      <point x="-61" y="-391" type="line"/>
       <point x="6" y="-257" type="line"/>
       <point x="-15" y="-255"/>
       <point x="-37" y="-232"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/commaturnedabovecomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/commaturnedabovecomb.glif
@@ -1,15 +1,16 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="commaturnedabovecomb" format="2">
   <unicode hex="0312"/>
+  <guideline x="130" y="1489" angle="0" identifier="4I7fca6EPP"/>
   <anchor x="0" y="1020" name="_top"/>
-  <anchor x="0" y="1492" name="top"/>
+  <anchor x="0" y="1489" name="top"/>
   <outline>
     <contour>
-      <point x="31" y="1467" type="line" smooth="yes"/>
-      <point x="43" y="1492" name="inserted"/>
-      <point x="43" y="1492"/>
-      <point x="71" y="1479" type="qcurve"/>
-      <point x="71" y="1479" type="line"/>
+      <point x="29" y="1464" type="line" smooth="yes"/>
+      <point x="41" y="1489" name="inserted"/>
+      <point x="41" y="1489"/>
+      <point x="67" y="1478" type="qcurve"/>
+      <point x="67" y="1471" type="line"/>
       <point x="0" y="1337" type="line"/>
       <point x="21" y="1335"/>
       <point x="43" y="1312"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/semicolon.glif
@@ -19,9 +19,9 @@
     </contour>
     <contour>
       <point x="209" y="-142" type="line" smooth="yes"/>
-      <point x="189" y="-178" name="inserted"/>
-      <point x="189" y="-178"/>
-      <point x="155" y="-163" type="qcurve"/>
+      <point x="191" y="-174" name="inserted"/>
+      <point x="191" y="-174"/>
+      <point x="155" y="-158" type="qcurve"/>
       <point x="155" y="-145" type="line"/>
       <point x="239" y="-5" type="line"/>
       <point x="215" y="0"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/six.glif
@@ -18,43 +18,45 @@
       <point x="334" y="822" type="qcurve"/>
       <point x="334" y="822" type="line"/>
       <point x="243" y="822"/>
-      <point x="130" y="673"/>
-      <point x="130" y="530" type="qcurve"/>
+      <point x="130" y="688"/>
+      <point x="130" y="560" type="qcurve"/>
     </contour>
     <contour>
-      <point x="336" y="-28" type="line"/>
-      <point x="220" y="-28"/>
-      <point x="99" y="125"/>
-      <point x="99" y="254" type="qcurve"/>
-      <point x="99" y="583" type="line" smooth="yes"/>
-      <point x="99" y="665"/>
-      <point x="118" y="766"/>
-      <point x="160" y="856" type="qcurve" smooth="yes"/>
-      <point x="432" y="1436" type="line"/>
-      <point x="441" y="1453"/>
-      <point x="441" y="1453"/>
-      <point x="456" y="1447" type="qcurve"/>
-      <point x="456" y="1447" type="line"/>
-      <point x="469" y="1439"/>
-      <point x="469" y="1439" name="inserted"/>
-      <point x="460" y="1422" type="qcurve"/>
-      <point x="153" y="762" type="line" smooth="yes"/>
-      <point x="143" y="740"/>
-      <point x="129" y="694"/>
-      <point x="127" y="671" type="qcurve"/>
-      <point x="126" y="662" type="line"/>
-      <point x="129" y="662" type="line"/>
-      <point x="139" y="740"/>
-      <point x="246" y="852"/>
-      <point x="340" y="852" type="qcurve"/>
-      <point x="340" y="852" type="line"/>
-      <point x="440" y="852"/>
+      <point x="334" y="852" type="qcurve"/>
+      <point x="334" y="852" type="line"/>
+      <point x="434" y="852"/>
       <point x="568" y="703"/>
       <point x="568" y="573" type="qcurve"/>
       <point x="568" y="260" type="line"/>
       <point x="568" y="133"/>
       <point x="446" y="-28"/>
       <point x="336" y="-28" type="qcurve"/>
+      <point x="336" y="-28" type="line"/>
+      <point x="220" y="-28"/>
+      <point x="99" y="125"/>
+      <point x="99" y="254" type="qcurve"/>
+      <point x="99" y="551" type="line" smooth="yes"/>
+      <point x="99" y="701"/>
+      <point x="232" y="852"/>
+    </contour>
+    <contour>
+      <point x="106" y="557" type="line"/>
+      <point x="99" y="557" type="line"/>
+      <point x="99" y="707"/>
+      <point x="212" y="894"/>
+      <point x="310" y="1030" type="qcurve" smooth="yes"/>
+      <point x="694" y="1565" type="line"/>
+      <point x="708" y="1584"/>
+      <point x="708" y="1584"/>
+      <point x="720" y="1576" type="qcurve"/>
+      <point x="720" y="1576" type="line"/>
+      <point x="734" y="1567"/>
+      <point x="734" y="1567"/>
+      <point x="722" y="1548" type="qcurve"/>
+      <point x="347" y="1030" type="line"/>
+      <point x="313" y="981"/>
+      <point x="249" y="895"/>
+      <point x="193" y="828" type="qcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/comma.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/comma.glif
@@ -7,8 +7,8 @@
       <point x="427" y="-160" type="line" smooth="yes"/>
       <point x="312" y="-319" name="inserted"/>
       <point x="312" y="-319"/>
-      <point x="51" y="-161" type="qcurve"/>
-      <point x="51" y="-161" type="line"/>
+      <point x="65" y="-170" type="qcurve"/>
+      <point x="65" y="-140" type="line"/>
       <point x="220" y="88" type="line"/>
       <point x="176" y="114"/>
       <point x="110" y="220"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -4,11 +4,11 @@
   <anchor x="0" y="0" name="_bottom"/>
   <outline>
     <contour>
-      <point x="35" y="-721" type="line" smooth="yes"/>
-      <point x="-56" y="-849" name="inserted"/>
-      <point x="-56" y="-849"/>
-      <point x="-266" y="-722" type="qcurve"/>
-      <point x="-266" y="-722" type="line"/>
+      <point x="36" y="-722" type="line" smooth="yes"/>
+      <point x="-54" y="-850" name="inserted"/>
+      <point x="-54" y="-850"/>
+      <point x="-254" y="-729" type="qcurve"/>
+      <point x="-254" y="-705" type="line"/>
       <point x="-131" y="-523" type="line"/>
       <point x="-166" y="-502"/>
       <point x="-219" y="-417"/>
@@ -20,7 +20,7 @@
       <point x="227" y="-281"/>
       <point x="227" y="-369" type="qcurve" smooth="yes"/>
       <point x="227" y="-419"/>
-      <point x="192" y="-503"/>
+      <point x="191" y="-502"/>
       <point x="155" y="-553" type="qcurve" smooth="yes"/>
     </contour>
   </outline>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/commaturnedabovecomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/commaturnedabovecomb.glif
@@ -5,24 +5,24 @@
   <anchor x="0" y="1942" name="top"/>
   <outline>
     <contour>
-      <point x="-35" y="1814" type="line" smooth="yes"/>
-      <point x="56" y="1942" name="inserted"/>
-      <point x="56" y="1942"/>
-      <point x="266" y="1816" type="qcurve"/>
-      <point x="266" y="1816" type="line"/>
-      <point x="131" y="1616" type="line"/>
-      <point x="166" y="1595"/>
-      <point x="219" y="1510"/>
-      <point x="219" y="1451" type="qcurve" smooth="yes"/>
-      <point x="219" y="1368"/>
-      <point x="93" y="1251"/>
-      <point x="0" y="1251" type="qcurve" smooth="yes"/>
-      <point x="-93" y="1251"/>
-      <point x="-227" y="1374"/>
-      <point x="-227" y="1462" type="qcurve" smooth="yes"/>
-      <point x="-227" y="1512"/>
-      <point x="-192" y="1596"/>
-      <point x="-155" y="1646" type="qcurve" smooth="yes"/>
+      <point x="-37" y="1815" type="line" smooth="yes"/>
+      <point x="53" y="1943" name="inserted"/>
+      <point x="53" y="1943"/>
+      <point x="253" y="1823" type="qcurve"/>
+      <point x="253" y="1799" type="line"/>
+      <point x="130" y="1617" type="line"/>
+      <point x="165" y="1596"/>
+      <point x="218" y="1510"/>
+      <point x="218" y="1451" type="qcurve" smooth="yes"/>
+      <point x="218" y="1368"/>
+      <point x="93" y="1252"/>
+      <point x="0" y="1252" type="qcurve" smooth="yes"/>
+      <point x="-93" y="1252"/>
+      <point x="-228" y="1374"/>
+      <point x="-228" y="1462" type="qcurve" smooth="yes"/>
+      <point x="-228" y="1512"/>
+      <point x="-191" y="1597"/>
+      <point x="-155" y="1648" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/registered.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/registered.glif
@@ -61,8 +61,8 @@
       <point x="672" y="972"/>
       <point x="639" y="953" type="qcurve"/>
       <point x="637" y="948" type="line"/>
-      <point x="671" y="888" type="line"/>
-      <point x="671" y="888" type="line"/>
+      <point x="691" y="854" type="line"/>
+      <point x="691" y="854" type="line"/>
       <point x="736" y="778" name="inserted"/>
       <point x="736" y="778"/>
       <point x="660" y="778" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/semicolon.glif
@@ -18,24 +18,24 @@
       <point x="610" y="908"/>
     </contour>
     <contour>
-      <point x="447" y="-160" type="line" smooth="yes"/>
-      <point x="340" y="-322" name="inserted"/>
-      <point x="340" y="-322"/>
-      <point x="112" y="-185" type="qcurve"/>
-      <point x="76" y="-164" type="line"/>
-      <point x="202" y="32" type="line"/>
-      <point x="172" y="52"/>
-      <point x="112" y="146"/>
-      <point x="112" y="228" type="qcurve" smooth="yes"/>
-      <point x="112" y="330"/>
-      <point x="260" y="470"/>
-      <point x="362" y="470" type="qcurve" smooth="yes"/>
-      <point x="466" y="470"/>
-      <point x="618" y="332"/>
-      <point x="618" y="230" type="qcurve" smooth="yes"/>
-      <point x="618" y="174"/>
-      <point x="593" y="61"/>
-      <point x="566" y="20" type="qcurve" smooth="yes"/>
+      <point x="419" y="-168" type="line" smooth="yes"/>
+      <point x="323" y="-315" name="inserted"/>
+      <point x="323" y="-315"/>
+      <point x="79" y="-170" type="qcurve"/>
+      <point x="79" y="-143" type="line"/>
+      <point x="218" y="62" type="line"/>
+      <point x="179" y="84"/>
+      <point x="119" y="180"/>
+      <point x="119" y="245" type="qcurve" smooth="yes"/>
+      <point x="119" y="338"/>
+      <point x="261" y="469"/>
+      <point x="364" y="469" type="qcurve" smooth="yes"/>
+      <point x="468" y="469"/>
+      <point x="619" y="332"/>
+      <point x="619" y="233" type="qcurve" smooth="yes"/>
+      <point x="619" y="178"/>
+      <point x="582" y="82"/>
+      <point x="544" y="24" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/glyphs/comma.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/glyphs/comma.glif
@@ -2,12 +2,13 @@
 <glyph name="comma" format="2">
   <advance width="392"/>
   <unicode hex="002C"/>
+  <guideline x="75" y="-117" angle="90" identifier="cTq8LpGOwl"/>
   <outline>
     <contour>
-      <point x="219" y="-136" type="line" smooth="yes"/>
-      <point x="182" y="-210" name="inserted"/>
-      <point x="182" y="-210"/>
-      <point x="86" y="-160" type="qcurve"/>
+      <point x="225" y="-125" type="line"/>
+      <point x="183" y="-210" name="inserted"/>
+      <point x="183" y="-210"/>
+      <point x="92" y="-163" type="qcurve"/>
       <point x="92" y="-148" type="line"/>
       <point x="162" y="0" type="line"/>
       <point x="128" y="4"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/glyphs/commaaccentcomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/glyphs/commaaccentcomb.glif
@@ -1,16 +1,17 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="commaaccentcomb" format="2">
   <unicode hex="0326"/>
+  <guideline x="-100" y="-431" angle="90" identifier="lv43jgBgWl"/>
   <anchor x="0" y="0" name="_bottom"/>
   <outline>
     <contour>
-      <point x="20" y="-443" type="line" smooth="yes"/>
-      <point x="-10" y="-502" name="inserted"/>
-      <point x="-10" y="-502"/>
-      <point x="-87" y="-462" type="qcurve"/>
+      <point x="25" y="-435" type="line" smooth="yes"/>
+      <point x="-8" y="-502" name="inserted"/>
+      <point x="-8" y="-502"/>
+      <point x="-82" y="-464" type="qcurve"/>
       <point x="-82" y="-452" type="line"/>
       <point x="-26" y="-334" type="line"/>
-      <point x="-53" y="-331"/>
+      <point x="-53" y="-329"/>
       <point x="-90" y="-281"/>
       <point x="-90" y="-246" type="qcurve" smooth="yes"/>
       <point x="-90" y="-209"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/glyphs/commaturnedabovecomb.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/glyphs/commaturnedabovecomb.glif
@@ -1,17 +1,19 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="commaturnedabovecomb" format="2">
   <unicode hex="0312"/>
+  <guideline x="57" y="1595" angle="0" identifier="xEvtKDyZal"/>
+  <guideline x="97" y="1568" angle="90" identifier="E5ZhYwqUsk"/>
   <anchor x="0" y="1020" name="_top"/>
-  <anchor x="0" y="1594" name="top"/>
+  <anchor x="0" y="1595" name="top"/>
   <outline>
     <contour>
-      <point x="-20" y="1535" type="line" smooth="yes"/>
-      <point x="10" y="1594" name="inserted"/>
-      <point x="10" y="1594"/>
-      <point x="87" y="1554" type="qcurve"/>
+      <point x="-25" y="1527" type="line" smooth="yes"/>
+      <point x="8" y="1594" name="inserted"/>
+      <point x="8" y="1594"/>
+      <point x="82" y="1556" type="qcurve"/>
       <point x="82" y="1544" type="line"/>
       <point x="26" y="1426" type="line"/>
-      <point x="54" y="1419"/>
+      <point x="53" y="1421"/>
       <point x="90" y="1373"/>
       <point x="90" y="1338" type="qcurve" smooth="yes"/>
       <point x="90" y="1301"/>
@@ -19,10 +21,10 @@
       <point x="0" y="1250" type="qcurve" smooth="yes"/>
       <point x="-38" y="1250"/>
       <point x="-94" y="1303"/>
-      <point x="-94" y="1342" type="qcurve"/>
-      <point x="-94" y="1365"/>
-      <point x="-81" y="1413"/>
-      <point x="-64" y="1447" type="qcurve" smooth="yes"/>
+      <point x="-94" y="1340" type="qcurve" smooth="yes"/>
+      <point x="-94" y="1364"/>
+      <point x="-81" y="1412"/>
+      <point x="-64" y="1447" type="qcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/glyphs/nine.glif
@@ -4,57 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="204" y="828" type="line" smooth="yes"/>
-      <point x="204" y="776"/>
-      <point x="249" y="718"/>
-      <point x="294" y="718" type="qcurve"/>
-      <point x="294" y="718" type="line"/>
-      <point x="337" y="718"/>
-      <point x="390" y="756"/>
-      <point x="400" y="788" type="qcurve"/>
-      <point x="400" y="1178" type="line" smooth="yes"/>
-      <point x="400" y="1240"/>
-      <point x="350" y="1302"/>
-      <point x="302" y="1302" type="qcurve"/>
-      <point x="302" y="1302" type="line"/>
-      <point x="254" y="1302"/>
-      <point x="204" y="1240"/>
-      <point x="204" y="1180" type="qcurve"/>
-    </contour>
-    <contour>
-      <point x="309" y="30" type="line"/>
-      <point x="287" y="-24" name="inserted"/>
-      <point x="287" y="-24"/>
-      <point x="221" y="0" type="qcurve"/>
-      <point x="221" y="0" type="line"/>
-      <point x="149" y="28"/>
-      <point x="148" y="28"/>
-      <point x="168" y="83" type="qcurve"/>
-      <point x="343" y="484" type="line" smooth="yes"/>
-      <point x="363" y="529"/>
-      <point x="394" y="604"/>
-      <point x="397" y="617" type="qcurve" smooth="yes"/>
-      <point x="404" y="641" type="line"/>
-      <point x="398" y="641" type="line"/>
-      <point x="382" y="607"/>
-      <point x="306" y="561"/>
-      <point x="254" y="561" type="qcurve"/>
-      <point x="254" y="561" type="line"/>
-      <point x="162" y="561"/>
-      <point x="54" y="678"/>
-      <point x="54" y="786" type="qcurve"/>
-      <point x="54" y="1170" type="line" smooth="yes"/>
-      <point x="54" y="1294"/>
-      <point x="184" y="1444"/>
-      <point x="296" y="1444" type="qcurve"/>
-      <point x="296" y="1444" type="line"/>
+      <point x="298" y="1444" type="line"/>
       <point x="422" y="1444"/>
       <point x="552" y="1304"/>
       <point x="552" y="1170" type="qcurve"/>
-      <point x="552" y="823" type="line" smooth="yes"/>
-      <point x="552" y="699"/>
-      <point x="520" y="534"/>
-      <point x="478" y="426" type="qcurve" smooth="yes"/>
+      <point x="552" y="833" type="line" smooth="yes"/>
+      <point x="552" y="729"/>
+      <point x="434" y="590"/>
+      <point x="299" y="570" type="qcurve"/>
+      <point x="299" y="570" type="line"/>
+      <point x="181" y="559"/>
+      <point x="54" y="704"/>
+      <point x="54" y="826" type="qcurve"/>
+      <point x="54" y="1170" type="line" smooth="yes"/>
+      <point x="54" y="1294"/>
+      <point x="183" y="1444"/>
+      <point x="298" y="1444" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="404" y="814" type="line"/>
+      <point x="552" y="814" type="line"/>
+      <point x="552" y="709"/>
+      <point x="515" y="521"/>
+      <point x="474" y="419" type="qcurve" smooth="yes"/>
+      <point x="323" y="46" type="line"/>
+      <point x="289" y="-37"/>
+      <point x="289" y="-37"/>
+      <point x="217" y="-11" type="qcurve"/>
+      <point x="217" y="-11" type="line"/>
+      <point x="148" y="17"/>
+      <point x="148" y="17"/>
+      <point x="178" y="95" type="qcurve"/>
+      <point x="305" y="396" type="line" smooth="yes"/>
+      <point x="342" y="484"/>
+      <point x="375" y="553"/>
+      <point x="395" y="584" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="303" y="1302" type="qcurve"/>
+      <point x="303" y="1302" type="line"/>
+      <point x="254" y="1302"/>
+      <point x="204" y="1240"/>
+      <point x="204" y="1180" type="qcurve"/>
+      <point x="204" y="835" type="line" smooth="yes"/>
+      <point x="204" y="777"/>
+      <point x="255" y="708"/>
+      <point x="304" y="708" type="qcurve"/>
+      <point x="304" y="708" type="line"/>
+      <point x="353" y="708"/>
+      <point x="400" y="777"/>
+      <point x="400" y="835" type="qcurve" smooth="yes"/>
+      <point x="400" y="1178" type="line" smooth="yes"/>
+      <point x="400" y="1240"/>
+      <point x="350" y="1302"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/glyphs/semicolon.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/glyphs/semicolon.glif
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="semicolon" format="2">
-  <advance width="432"/>
+  <advance width="392"/>
   <unicode hex="003B"/>
-  <guideline x="189" y="298" angle="90" identifier="ubx1pSxu9S"/>
+  <guideline x="74" y="-110" angle="90" identifier="ubx1pSxu9S"/>
   <outline>
     <contour>
       <point x="332" y="916" type="qcurve" smooth="yes"/>
@@ -19,11 +19,11 @@
       <point x="332" y="964"/>
     </contour>
     <contour>
-      <point x="236" y="-136" type="line" smooth="yes"/>
-      <point x="200" y="-209" name="inserted"/>
-      <point x="200" y="-209"/>
-      <point x="104" y="-160" type="qcurve"/>
-      <point x="112" y="-144" type="line"/>
+      <point x="242" y="-125" type="line"/>
+      <point x="200" y="-210" name="inserted"/>
+      <point x="200" y="-210"/>
+      <point x="109" y="-163" type="qcurve"/>
+      <point x="109" y="-148" type="line"/>
       <point x="179" y="0" type="line"/>
       <point x="145" y="4"/>
       <point x="99" y="66"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/glyphs/six.glif
@@ -4,57 +4,59 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="206" y="242" type="line" smooth="yes"/>
-      <point x="206" y="180"/>
-      <point x="256" y="118"/>
+      <point x="308" y="-24" type="line"/>
+      <point x="184" y="-24"/>
+      <point x="54" y="116"/>
+      <point x="54" y="250" type="qcurve"/>
+      <point x="54" y="607" type="line" smooth="yes"/>
+      <point x="54" y="711"/>
+      <point x="177" y="870"/>
+      <point x="307" y="870" type="qcurve"/>
+      <point x="307" y="870" type="line"/>
+      <point x="424" y="870"/>
+      <point x="552" y="736"/>
+      <point x="552" y="614" type="qcurve"/>
+      <point x="552" y="250" type="line" smooth="yes"/>
+      <point x="552" y="126"/>
+      <point x="423" y="-24"/>
+      <point x="308" y="-24" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="202" y="606" type="line"/>
+      <point x="54" y="606" type="line"/>
+      <point x="54" y="711"/>
+      <point x="91" y="899"/>
+      <point x="132" y="1001" type="qcurve" smooth="yes"/>
+      <point x="283" y="1374" type="line"/>
+      <point x="317" y="1457"/>
+      <point x="317" y="1457"/>
+      <point x="389" y="1431" type="qcurve"/>
+      <point x="389" y="1431" type="line"/>
+      <point x="458" y="1403"/>
+      <point x="458" y="1403"/>
+      <point x="428" y="1325" type="qcurve"/>
+      <point x="301" y="1024" type="line" smooth="yes"/>
+      <point x="264" y="936"/>
+      <point x="241" y="897"/>
+      <point x="221" y="866" type="qcurve"/>
+    </contour>
+    <contour>
       <point x="303" y="118" type="qcurve"/>
       <point x="303" y="118" type="line"/>
       <point x="352" y="118"/>
       <point x="402" y="180"/>
       <point x="402" y="240" type="qcurve"/>
-      <point x="402" y="592" type="line" smooth="yes"/>
-      <point x="402" y="644"/>
-      <point x="358" y="702"/>
-      <point x="309" y="702" type="qcurve"/>
-      <point x="309" y="702" type="line"/>
-      <point x="270" y="702"/>
-      <point x="216" y="664"/>
-      <point x="206" y="632" type="qcurve"/>
-    </contour>
-    <contour>
-      <point x="308" y="-24" type="line"/>
-      <point x="184" y="-24"/>
-      <point x="54" y="116"/>
-      <point x="54" y="250" type="qcurve"/>
-      <point x="54" y="597" type="line" smooth="yes"/>
-      <point x="54" y="721"/>
-      <point x="86" y="886"/>
-      <point x="128" y="994" type="qcurve" smooth="yes"/>
-      <point x="302" y="1421" type="line"/>
-      <point x="324" y="1475" name="inserted"/>
-      <point x="324" y="1475"/>
-      <point x="396" y="1449" type="qcurve"/>
-      <point x="396" y="1449" type="line"/>
-      <point x="468" y="1421"/>
-      <point x="469" y="1421"/>
-      <point x="449" y="1366" type="qcurve"/>
-      <point x="266" y="936" type="line" smooth="yes"/>
-      <point x="247" y="891"/>
-      <point x="216" y="816"/>
-      <point x="211" y="803" type="qcurve" smooth="yes"/>
-      <point x="206" y="790" type="line"/>
-      <point x="212" y="790" type="line"/>
-      <point x="228" y="824"/>
-      <point x="304" y="870"/>
-      <point x="355" y="870" type="qcurve"/>
-      <point x="355" y="870" type="line"/>
-      <point x="448" y="870"/>
-      <point x="552" y="742"/>
-      <point x="552" y="634" type="qcurve"/>
-      <point x="552" y="250" type="line" smooth="yes"/>
-      <point x="552" y="126"/>
-      <point x="423" y="-24"/>
-      <point x="308" y="-24" type="qcurve"/>
+      <point x="402" y="585" type="line" smooth="yes"/>
+      <point x="402" y="643"/>
+      <point x="351" y="712"/>
+      <point x="302" y="712" type="qcurve"/>
+      <point x="302" y="712" type="line"/>
+      <point x="253" y="712"/>
+      <point x="206" y="643"/>
+      <point x="206" y="585" type="qcurve" smooth="yes"/>
+      <point x="206" y="242" type="line" smooth="yes"/>
+      <point x="206" y="180"/>
+      <point x="256" y="118"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1-ROND0.ufo/glyphs/nine.glif
@@ -4,57 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="159" y="971" type="line"/>
-      <point x="159" y="773"/>
-      <point x="410" y="557"/>
-      <point x="602" y="556" type="qcurve"/>
-      <point x="602" y="556" type="line"/>
-      <point x="779" y="556"/>
-      <point x="1037" y="767"/>
-      <point x="1037" y="965" type="qcurve"/>
-      <point x="1037" y="965" type="line"/>
-      <point x="1037" y="1143"/>
-      <point x="792" y="1397"/>
-      <point x="601" y="1397" type="qcurve"/>
-      <point x="601" y="1397" type="line"/>
-      <point x="412" y="1397"/>
-      <point x="159" y="1151"/>
-      <point x="159" y="971" type="qcurve"/>
+      <point x="597" y="1470" type="line"/>
+      <point x="826" y="1470"/>
+      <point x="1122" y="1194"/>
+      <point x="1122" y="952" type="qcurve"/>
+      <point x="1122" y="952" type="line"/>
+      <point x="1122" y="734"/>
+      <point x="788" y="478"/>
+      <point x="600" y="478" type="qcurve"/>
+      <point x="600" y="478" type="line"/>
+      <point x="338" y="478"/>
+      <point x="70" y="758"/>
+      <point x="70" y="966" type="qcurve"/>
+      <point x="70" y="966" type="line"/>
+      <point x="70" y="1170"/>
+      <point x="362" y="1470"/>
+      <point x="597" y="1470" type="qcurve"/>
     </contour>
     <contour>
-      <point x="446" y="-31" type="line" smooth="yes"/>
-      <point x="409" y="-70"/>
-      <point x="409" y="-70"/>
-      <point x="374" y="-33" type="qcurve"/>
-      <point x="374" y="-33" type="line"/>
-      <point x="345" y="-3"/>
-      <point x="345" y="-3"/>
-      <point x="382" y="34" type="qcurve" smooth="yes"/>
-      <point x="830" y="489" type="line" smooth="yes"/>
-      <point x="867" y="527"/>
-      <point x="925" y="587"/>
-      <point x="949" y="615" type="qcurve"/>
-      <point x="953" y="621" type="line"/>
-      <point x="947" y="624" type="line"/>
-      <point x="905" y="569"/>
-      <point x="725" y="481"/>
-      <point x="580" y="481" type="qcurve"/>
-      <point x="580" y="481" type="line"/>
-      <point x="338" y="481"/>
-      <point x="71" y="761"/>
-      <point x="71" y="969" type="qcurve"/>
-      <point x="71" y="969" type="line"/>
-      <point x="71" y="1173"/>
-      <point x="363" y="1473"/>
-      <point x="598" y="1473" type="qcurve"/>
-      <point x="598" y="1473" type="line"/>
-      <point x="827" y="1473"/>
-      <point x="1123" y="1197"/>
-      <point x="1123" y="955" type="qcurve"/>
-      <point x="1123" y="955" type="line"/>
-      <point x="1123" y="788"/>
-      <point x="995" y="545"/>
-      <point x="884" y="428" type="qcurve" smooth="yes"/>
+      <point x="1086" y="952" type="line"/>
+      <point x="1122" y="952" type="line"/>
+      <point x="1122" y="730"/>
+      <point x="899" y="437"/>
+      <point x="782" y="316" type="qcurve" smooth="yes"/>
+      <point x="437" y="-43" type="line"/>
+      <point x="409" y="-72"/>
+      <point x="409" y="-72"/>
+      <point x="379" y="-43" type="qcurve"/>
+      <point x="379" y="-43" type="line"/>
+      <point x="344" y="-6"/>
+      <point x="344" y="-6"/>
+      <point x="364" y="14" type="qcurve"/>
+      <point x="586" y="240" type="line" smooth="yes"/>
+      <point x="654" y="309"/>
+      <point x="873" y="537"/>
+      <point x="944" y="597" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="600" y="1394" type="qcurve"/>
+      <point x="600" y="1394" type="line"/>
+      <point x="411" y="1394"/>
+      <point x="158" y="1148"/>
+      <point x="158" y="968" type="qcurve"/>
+      <point x="158" y="968" type="line"/>
+      <point x="158" y="770"/>
+      <point x="409" y="557"/>
+      <point x="601" y="556" type="qcurve"/>
+      <point x="601" y="556" type="line"/>
+      <point x="778" y="556"/>
+      <point x="1036" y="764"/>
+      <point x="1036" y="962" type="qcurve"/>
+      <point x="1036" y="962" type="line"/>
+      <point x="1036" y="1140"/>
+      <point x="791" y="1394"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1-ROND0.ufo/glyphs/seven.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1-ROND0.ufo/glyphs/seven.glif
@@ -9,9 +9,9 @@
       <point x="246" y="-19"/>
       <point x="205" y="-1" type="qcurve"/>
       <point x="205" y="-1" type="line"/>
-      <point x="154" y="23"/>
-      <point x="154" y="23"/>
-      <point x="179" y="67" type="qcurve" smooth="yes"/>
+      <point x="166" y="18"/>
+      <point x="166" y="18"/>
+      <point x="191" y="62" type="qcurve" smooth="yes"/>
       <point x="901" y="1340" type="line"/>
       <point x="901" y="1346" type="line"/>
       <point x="59" y="1346" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1-ROND0.ufo/glyphs/six.glif
@@ -4,9 +4,43 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="186" y="476" type="line"/>
-      <point x="186" y="298"/>
-      <point x="431" y="44"/>
+      <point x="625" y="-32" type="line"/>
+      <point x="396" y="-32"/>
+      <point x="100" y="244"/>
+      <point x="100" y="486" type="qcurve"/>
+      <point x="100" y="486" type="line"/>
+      <point x="100" y="694"/>
+      <point x="434" y="963"/>
+      <point x="622" y="963" type="qcurve"/>
+      <point x="622" y="963" type="line"/>
+      <point x="884" y="963"/>
+      <point x="1152" y="680"/>
+      <point x="1152" y="472" type="qcurve"/>
+      <point x="1152" y="472" type="line"/>
+      <point x="1152" y="268"/>
+      <point x="860" y="-32"/>
+      <point x="625" y="-32" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="136" y="486" type="line"/>
+      <point x="100" y="486" type="line"/>
+      <point x="100" y="686"/>
+      <point x="257" y="923"/>
+      <point x="403" y="1078" type="qcurve" smooth="yes"/>
+      <point x="785" y="1481" type="line"/>
+      <point x="813" y="1510"/>
+      <point x="813" y="1510"/>
+      <point x="843" y="1481" type="qcurve"/>
+      <point x="843" y="1481" type="line"/>
+      <point x="878" y="1444"/>
+      <point x="878" y="1444"/>
+      <point x="858" y="1424" type="qcurve"/>
+      <point x="636" y="1198" type="line" smooth="yes"/>
+      <point x="568" y="1129"/>
+      <point x="348" y="904"/>
+      <point x="278" y="843" type="qcurve"/>
+    </contour>
+    <contour>
       <point x="622" y="44" type="qcurve"/>
       <point x="622" y="44" type="line"/>
       <point x="811" y="44"/>
@@ -20,41 +54,9 @@
       <point x="444" y="885"/>
       <point x="186" y="674"/>
       <point x="186" y="476" type="qcurve"/>
-    </contour>
-    <contour>
-      <point x="625" y="-32" type="line"/>
-      <point x="396" y="-32"/>
-      <point x="100" y="244"/>
-      <point x="100" y="486" type="qcurve"/>
-      <point x="100" y="486" type="line"/>
-      <point x="100" y="653"/>
-      <point x="228" y="896"/>
-      <point x="339" y="1013" type="qcurve" smooth="yes"/>
-      <point x="777" y="1472" type="line" smooth="yes"/>
-      <point x="814" y="1511"/>
-      <point x="814" y="1511"/>
-      <point x="849" y="1474" type="qcurve"/>
-      <point x="849" y="1474" type="line"/>
-      <point x="878" y="1444"/>
-      <point x="878" y="1444"/>
-      <point x="841" y="1407" type="qcurve" smooth="yes"/>
-      <point x="393" y="952" type="line" smooth="yes"/>
-      <point x="356" y="914"/>
-      <point x="298" y="854"/>
-      <point x="274" y="826" type="qcurve"/>
-      <point x="270" y="820" type="line"/>
-      <point x="276" y="817" type="line"/>
-      <point x="318" y="872"/>
-      <point x="498" y="960"/>
-      <point x="643" y="960" type="qcurve"/>
-      <point x="643" y="960" type="line"/>
-      <point x="885" y="960"/>
-      <point x="1152" y="680"/>
-      <point x="1152" y="472" type="qcurve"/>
-      <point x="1152" y="472" type="line"/>
-      <point x="1152" y="268"/>
-      <point x="860" y="-32"/>
-      <point x="625" y="-32" type="qcurve"/>
+      <point x="186" y="476" type="line"/>
+      <point x="186" y="298"/>
+      <point x="431" y="44"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/nine.glif
@@ -4,57 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="440" y="893" type="line"/>
-      <point x="440" y="799"/>
-      <point x="549" y="677"/>
-      <point x="634" y="677" type="qcurve"/>
-      <point x="634" y="677" type="line"/>
-      <point x="727" y="677"/>
-      <point x="846" y="799"/>
-      <point x="846" y="893" type="qcurve"/>
-      <point x="846" y="893" type="line"/>
-      <point x="846" y="989"/>
-      <point x="729" y="1113"/>
-      <point x="638" y="1113" type="qcurve"/>
-      <point x="638" y="1113" type="line"/>
-      <point x="552" y="1113"/>
-      <point x="440" y="989"/>
-      <point x="440" y="893" type="qcurve"/>
+      <point x="632" y="1454" type="line"/>
+      <point x="890" y="1457"/>
+      <point x="1229" y="1146"/>
+      <point x="1229" y="890" type="qcurve"/>
+      <point x="1230" y="890" type="line"/>
+      <point x="1230" y="697"/>
+      <point x="949" y="450"/>
+      <point x="636" y="450" type="qcurve"/>
+      <point x="636" y="450" type="line"/>
+      <point x="332" y="427"/>
+      <point x="48" y="680"/>
+      <point x="48" y="904" type="qcurve"/>
+      <point x="48" y="904" type="line"/>
+      <point x="48" y="1134"/>
+      <point x="366" y="1454"/>
+      <point x="632" y="1454" type="qcurve"/>
     </contour>
     <contour>
-      <point x="656" y="49" type="line" smooth="yes"/>
-      <point x="533" y="-55"/>
-      <point x="533" y="-55"/>
-      <point x="412" y="109" type="qcurve"/>
-      <point x="412" y="109" type="line"/>
-      <point x="296" y="267"/>
-      <point x="296" y="266"/>
-      <point x="435" y="355" type="qcurve" smooth="yes"/>
-      <point x="493" y="392" type="line" smooth="yes"/>
-      <point x="552" y="430"/>
-      <point x="588" y="456"/>
-      <point x="598" y="463" type="qcurve"/>
-      <point x="605" y="468" type="line"/>
-      <point x="601" y="474" type="line"/>
-      <point x="594" y="468"/>
-      <point x="564" y="454"/>
-      <point x="541" y="454" type="qcurve"/>
-      <point x="541" y="454" type="line"/>
-      <point x="327" y="454"/>
-      <point x="48" y="697"/>
-      <point x="48" y="915" type="qcurve"/>
-      <point x="48" y="915" type="line"/>
-      <point x="48" y="1145"/>
-      <point x="366" y="1455"/>
-      <point x="622" y="1455" type="qcurve"/>
-      <point x="622" y="1455" type="line"/>
-      <point x="880" y="1455"/>
-      <point x="1230" y="1147"/>
-      <point x="1230" y="891" type="qcurve"/>
-      <point x="1230" y="891" type="line"/>
-      <point x="1230" y="698"/>
-      <point x="1073" y="400"/>
-      <point x="923" y="274" type="qcurve" smooth="yes"/>
+      <point x="951" y="890" type="line"/>
+      <point x="1230" y="890" type="line"/>
+      <point x="1230" y="697"/>
+      <point x="1051" y="378"/>
+      <point x="847" y="209" type="qcurve" smooth="yes"/>
+      <point x="681" y="72" type="line"/>
+      <point x="490" y="-84"/>
+      <point x="491" y="-84"/>
+      <point x="382" y="63" type="qcurve"/>
+      <point x="382" y="63" type="line"/>
+      <point x="248" y="233"/>
+      <point x="248" y="234"/>
+      <point x="414" y="354" type="qcurve"/>
+      <point x="454" y="383" type="line"/>
+      <point x="478" y="401"/>
+      <point x="532" y="433"/>
+      <point x="562" y="449" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="641" y="1113" type="qcurve"/>
+      <point x="642" y="1112" type="line"/>
+      <point x="564" y="1112"/>
+      <point x="463" y="1001"/>
+      <point x="463" y="892" type="qcurve"/>
+      <point x="463" y="892" type="line"/>
+      <point x="463" y="788"/>
+      <point x="561" y="676"/>
+      <point x="638" y="676" type="qcurve"/>
+      <point x="638" y="676" type="line"/>
+      <point x="722" y="676"/>
+      <point x="829" y="788"/>
+      <point x="829" y="892" type="qcurve"/>
+      <point x="828" y="893" type="line"/>
+      <point x="828" y="1002"/>
+      <point x="723" y="1113"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/six.glif
@@ -4,57 +4,59 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="450" y="530" type="line"/>
-      <point x="450" y="434"/>
-      <point x="567" y="310"/>
-      <point x="658" y="310" type="qcurve"/>
-      <point x="658" y="310" type="line"/>
-      <point x="744" y="310"/>
-      <point x="856" y="434"/>
-      <point x="856" y="530" type="qcurve"/>
-      <point x="856" y="530" type="line"/>
-      <point x="856" y="624"/>
-      <point x="747" y="746"/>
-      <point x="662" y="746" type="qcurve"/>
-      <point x="662" y="746" type="line"/>
-      <point x="569" y="746"/>
-      <point x="450" y="624"/>
-      <point x="450" y="530" type="qcurve"/>
-    </contour>
-    <contour>
-      <point x="674" y="-32" type="line"/>
-      <point x="416" y="-32"/>
+      <point x="664" y="-32" type="line"/>
+      <point x="406" y="-35"/>
       <point x="66" y="276"/>
       <point x="66" y="532" type="qcurve"/>
       <point x="66" y="532" type="line"/>
       <point x="66" y="725"/>
-      <point x="223" y="1025"/>
-      <point x="373" y="1149" type="qcurve" smooth="yes"/>
-      <point x="712" y="1429" type="line" smooth="yes"/>
-      <point x="835" y="1531"/>
-      <point x="836" y="1529"/>
-      <point x="956" y="1369" type="qcurve"/>
-      <point x="956" y="1369" type="line"/>
-      <point x="1072" y="1211"/>
-      <point x="1073" y="1210"/>
-      <point x="936" y="1117" type="qcurve" smooth="yes"/>
-      <point x="793" y="1021" type="line" smooth="yes"/>
-      <point x="733" y="980"/>
-      <point x="709" y="964"/>
-      <point x="697" y="958" type="qcurve"/>
-      <point x="691" y="955" type="line"/>
-      <point x="695" y="949" type="line"/>
-      <point x="702" y="955"/>
-      <point x="732" y="969"/>
-      <point x="755" y="969" type="qcurve"/>
-      <point x="755" y="969" type="line"/>
-      <point x="969" y="969"/>
+      <point x="347" y="972"/>
+      <point x="660" y="972" type="qcurve"/>
+      <point x="660" y="972" type="line"/>
+      <point x="978" y="985"/>
       <point x="1248" y="742"/>
       <point x="1248" y="518" type="qcurve"/>
       <point x="1248" y="518" type="line"/>
       <point x="1248" y="288"/>
       <point x="930" y="-32"/>
-      <point x="674" y="-32" type="qcurve"/>
+      <point x="664" y="-32" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="345" y="532" type="line"/>
+      <point x="66" y="532" type="line"/>
+      <point x="66" y="725"/>
+      <point x="245" y="1044"/>
+      <point x="449" y="1213" type="qcurve" smooth="yes"/>
+      <point x="615" y="1350" type="line"/>
+      <point x="806" y="1506"/>
+      <point x="805" y="1506"/>
+      <point x="914" y="1359" type="qcurve"/>
+      <point x="914" y="1359" type="line"/>
+      <point x="1048" y="1189"/>
+      <point x="1048" y="1188"/>
+      <point x="882" y="1068" type="qcurve"/>
+      <point x="842" y="1039" type="line"/>
+      <point x="818" y="1021"/>
+      <point x="764" y="989"/>
+      <point x="734" y="973" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="654" y="310" type="qcurve"/>
+      <point x="654" y="310" type="line"/>
+      <point x="732" y="310"/>
+      <point x="833" y="421"/>
+      <point x="833" y="530" type="qcurve"/>
+      <point x="833" y="530" type="line"/>
+      <point x="833" y="634"/>
+      <point x="735" y="746"/>
+      <point x="658" y="746" type="qcurve"/>
+      <point x="658" y="746" type="line"/>
+      <point x="574" y="746"/>
+      <point x="467" y="634"/>
+      <point x="467" y="530" type="qcurve"/>
+      <point x="467" y="530" type="line"/>
+      <point x="467" y="421"/>
+      <point x="572" y="310"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/zero.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/zero.glif
@@ -22,22 +22,22 @@
       <point x="974" y="-30"/>
     </contour>
     <contour>
-      <point x="712" y="358" type="qcurve"/>
-      <point x="712" y="358" type="line"/>
-      <point x="822" y="358"/>
-      <point x="930" y="548"/>
-      <point x="930" y="722" type="qcurve"/>
-      <point x="930" y="722" type="line"/>
-      <point x="930" y="896"/>
-      <point x="820" y="1066"/>
-      <point x="712" y="1066" type="qcurve"/>
-      <point x="712" y="1066" type="line"/>
-      <point x="604" y="1066"/>
-      <point x="486" y="886"/>
-      <point x="486" y="722" type="qcurve"/>
-      <point x="486" y="722" type="line"/>
-      <point x="486" y="550"/>
-      <point x="602" y="358"/>
+      <point x="716" y="358" type="qcurve"/>
+      <point x="716" y="358" type="line"/>
+      <point x="826" y="358"/>
+      <point x="934" y="548"/>
+      <point x="934" y="722" type="qcurve"/>
+      <point x="934" y="722" type="line"/>
+      <point x="934" y="896"/>
+      <point x="824" y="1066"/>
+      <point x="716" y="1066" type="qcurve"/>
+      <point x="716" y="1066" type="line"/>
+      <point x="608" y="1066"/>
+      <point x="490" y="886"/>
+      <point x="490" y="722" type="qcurve"/>
+      <point x="490" y="722" type="line"/>
+      <point x="490" y="550"/>
+      <point x="606" y="358"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth100-wght400-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth100-wght400-ROND0.ufo/glyphs/nine.glif
@@ -4,57 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="268" y="956" type="line"/>
-      <point x="268" y="802"/>
-      <point x="448" y="608"/>
-      <point x="596" y="608" type="qcurve"/>
-      <point x="596" y="608" type="line"/>
-      <point x="754" y="608"/>
-      <point x="942" y="796"/>
-      <point x="942" y="956" type="qcurve"/>
-      <point x="942" y="956" type="line"/>
-      <point x="942" y="1112"/>
-      <point x="750" y="1308"/>
-      <point x="600" y="1308" type="qcurve"/>
-      <point x="600" y="1308" type="line"/>
-      <point x="462" y="1308"/>
-      <point x="268" y="1102"/>
-      <point x="268" y="956" type="qcurve"/>
+      <point x="585" y="1462" type="line"/>
+      <point x="824" y="1462"/>
+      <point x="1120" y="1174"/>
+      <point x="1120" y="937" type="qcurve"/>
+      <point x="1120" y="937" type="line"/>
+      <point x="1120" y="728"/>
+      <point x="789" y="449"/>
+      <point x="579" y="449" type="qcurve"/>
+      <point x="579" y="449" type="line"/>
+      <point x="330" y="449"/>
+      <point x="50" y="728"/>
+      <point x="50" y="945" type="qcurve"/>
+      <point x="50" y="945" type="line"/>
+      <point x="50" y="1168"/>
+      <point x="362" y="1462"/>
+      <point x="585" y="1462" type="qcurve"/>
     </contour>
     <contour>
-      <point x="525" y="-9" type="line"/>
-      <point x="472" y="-67"/>
-      <point x="471" y="-67"/>
-      <point x="411" y="-16" type="qcurve"/>
-      <point x="411" y="-16" type="line"/>
-      <point x="337" y="45"/>
-      <point x="335" y="44"/>
-      <point x="374" y="86" type="qcurve"/>
-      <point x="581" y="313" type="line" smooth="yes"/>
-      <point x="646" y="384"/>
-      <point x="769" y="520"/>
-      <point x="834" y="579" type="qcurve"/>
-      <point x="843" y="589" type="line"/>
-      <point x="838" y="593" type="line"/>
-      <point x="793" y="539"/>
-      <point x="643" y="466"/>
-      <point x="554" y="466" type="qcurve"/>
-      <point x="554" y="466" type="line"/>
-      <point x="340" y="466"/>
-      <point x="68" y="742"/>
-      <point x="68" y="956" type="qcurve"/>
-      <point x="68" y="956" type="line"/>
-      <point x="68" y="1166"/>
-      <point x="376" y="1466"/>
-      <point x="596" y="1466" type="qcurve"/>
-      <point x="596" y="1466" type="line"/>
-      <point x="832" y="1466"/>
-      <point x="1124" y="1182"/>
-      <point x="1124" y="948" type="qcurve"/>
-      <point x="1124" y="948" type="line"/>
-      <point x="1124" y="778"/>
-      <point x="991" y="519"/>
-      <point x="892" y="407" type="qcurve"/>
+      <point x="970" y="937" type="line"/>
+      <point x="1120" y="937" type="line"/>
+      <point x="1120" y="753"/>
+      <point x="946" y="464"/>
+      <point x="827" y="326" type="qcurve" smooth="yes"/>
+      <point x="550" y="6" type="line" smooth="yes"/>
+      <point x="497" y="-55"/>
+      <point x="498" y="-55"/>
+      <point x="434" y="-1" type="qcurve"/>
+      <point x="434" y="-1" type="line"/>
+      <point x="359" y="61"/>
+      <point x="359" y="61"/>
+      <point x="397" y="103" type="qcurve" smooth="yes"/>
+      <point x="570" y="294" type="line" smooth="yes"/>
+      <point x="637" y="367"/>
+      <point x="817" y="548"/>
+      <point x="888" y="609" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="581" y="1304" type="qcurve"/>
+      <point x="581" y="1304" type="line"/>
+      <point x="437" y="1304"/>
+      <point x="234" y="1089"/>
+      <point x="234" y="936" type="qcurve"/>
+      <point x="234" y="936" type="line"/>
+      <point x="234" y="791"/>
+      <point x="422" y="601"/>
+      <point x="577" y="601" type="qcurve"/>
+      <point x="577" y="601" type="line"/>
+      <point x="742" y="601"/>
+      <point x="938" y="784"/>
+      <point x="938" y="936" type="qcurve"/>
+      <point x="938" y="936" type="line"/>
+      <point x="938" y="1099"/>
+      <point x="738" y="1304"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth100-wght400-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth100-wght400-ROND0.ufo/glyphs/six.glif
@@ -1,60 +1,62 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="six" format="2">
-  <advance width="1220"/>
+  <advance width="1200"/>
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="270" y="494" type="line"/>
-      <point x="270" y="331"/>
-      <point x="470" y="126"/>
-      <point x="627" y="126" type="qcurve"/>
-      <point x="627" y="126" type="line"/>
-      <point x="771" y="126"/>
-      <point x="974" y="341"/>
-      <point x="974" y="494" type="qcurve"/>
-      <point x="974" y="494" type="line"/>
-      <point x="974" y="639"/>
-      <point x="786" y="829"/>
-      <point x="631" y="829" type="qcurve"/>
-      <point x="631" y="829" type="line"/>
-      <point x="466" y="829"/>
-      <point x="270" y="646"/>
-      <point x="270" y="494" type="qcurve"/>
+      <point x="615" y="-32" type="line"/>
+      <point x="376" y="-32"/>
+      <point x="80" y="256"/>
+      <point x="80" y="493" type="qcurve"/>
+      <point x="80" y="493" type="line"/>
+      <point x="80" y="702"/>
+      <point x="411" y="981"/>
+      <point x="621" y="981" type="qcurve"/>
+      <point x="621" y="981" type="line"/>
+      <point x="870" y="981"/>
+      <point x="1150" y="702"/>
+      <point x="1150" y="485" type="qcurve"/>
+      <point x="1150" y="485" type="line"/>
+      <point x="1150" y="262"/>
+      <point x="838" y="-32"/>
+      <point x="615" y="-32" type="qcurve"/>
     </contour>
     <contour>
-      <point x="623" y="-32" type="line"/>
-      <point x="384" y="-32"/>
-      <point x="88" y="256"/>
-      <point x="88" y="493" type="qcurve"/>
-      <point x="88" y="493" type="line"/>
-      <point x="88" y="665"/>
-      <point x="223" y="928"/>
-      <point x="323" y="1041" type="qcurve"/>
-      <point x="678" y="1448" type="line"/>
-      <point x="732" y="1507"/>
-      <point x="733" y="1507"/>
-      <point x="794" y="1455" type="qcurve"/>
-      <point x="794" y="1455" type="line"/>
-      <point x="869" y="1393"/>
-      <point x="871" y="1394"/>
-      <point x="831" y="1351" type="qcurve"/>
-      <point x="638" y="1136" type="line" smooth="yes"/>
-      <point x="572" y="1063"/>
-      <point x="448" y="927"/>
-      <point x="382" y="867" type="qcurve"/>
-      <point x="373" y="857" type="line"/>
-      <point x="378" y="853" type="line"/>
-      <point x="423" y="907"/>
-      <point x="575" y="981"/>
-      <point x="666" y="981" type="qcurve"/>
-      <point x="666" y="981" type="line"/>
-      <point x="882" y="981"/>
-      <point x="1158" y="702"/>
-      <point x="1158" y="485" type="qcurve"/>
-      <point x="1158" y="485" type="line"/>
-      <point x="1158" y="272"/>
-      <point x="846" y="-32"/>
-      <point x="623" y="-32" type="qcurve"/>
+      <point x="230" y="493" type="line"/>
+      <point x="80" y="493" type="line"/>
+      <point x="77" y="667"/>
+      <point x="285" y="1002"/>
+      <point x="373" y="1104" type="qcurve" smooth="yes"/>
+      <point x="669" y="1448" type="line" smooth="yes"/>
+      <point x="721" y="1509"/>
+      <point x="721" y="1509"/>
+      <point x="785" y="1455" type="qcurve"/>
+      <point x="785" y="1455" type="line"/>
+      <point x="860" y="1393"/>
+      <point x="860" y="1393"/>
+      <point x="822" y="1351" type="qcurve" smooth="yes"/>
+      <point x="630" y="1136" type="line" smooth="yes"/>
+      <point x="564" y="1062"/>
+      <point x="383" y="882"/>
+      <point x="312" y="821" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="619" y="126" type="qcurve"/>
+      <point x="619" y="126" type="line"/>
+      <point x="763" y="126"/>
+      <point x="966" y="341"/>
+      <point x="966" y="494" type="qcurve"/>
+      <point x="966" y="494" type="line"/>
+      <point x="966" y="639"/>
+      <point x="778" y="829"/>
+      <point x="623" y="829" type="qcurve"/>
+      <point x="623" y="829" type="line"/>
+      <point x="458" y="829"/>
+      <point x="262" y="646"/>
+      <point x="262" y="494" type="qcurve"/>
+      <point x="262" y="494" type="line"/>
+      <point x="262" y="331"/>
+      <point x="462" y="126"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1-ROND0.ufo/glyphs/four.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1-ROND0.ufo/glyphs/four.glif
@@ -4,7 +4,7 @@
   <unicode hex="0034"/>
   <outline>
     <contour>
-      <point x="1080" y="45" type="qcurve"/>
+      <point x="1080" y="60" type="qcurve"/>
       <point x="1080" y="425" type="line"/>
       <point x="1080" y="432" type="line"/>
       <point x="1080" y="1422" type="line"/>
@@ -15,7 +15,7 @@
       <point x="1172" y="1467"/>
       <point x="1172" y="1467"/>
       <point x="1172" y="1422" type="qcurve"/>
-      <point x="1172" y="45" type="line"/>
+      <point x="1172" y="60" type="line"/>
       <point x="1172" y="0"/>
       <point x="1172" y="0"/>
       <point x="1127" y="0" type="qcurve"/>
@@ -24,9 +24,9 @@
       <point x="1080" y="0"/>
     </contour>
     <contour>
-      <point x="85" y="406" type="line"/>
-      <point x="40" y="406"/>
-      <point x="40" y="406"/>
+      <point x="85" y="399" type="line"/>
+      <point x="40" y="399"/>
+      <point x="40" y="399"/>
       <point x="40" y="447" type="qcurve"/>
       <point x="40" y="447" type="line"/>
       <point x="40" y="490"/>
@@ -41,14 +41,14 @@
       <point x="139" y="480" type="line"/>
       <point x="1114" y="480" type="line"/>
       <point x="1130" y="480" type="line"/>
-      <point x="1502" y="480" type="line"/>
+      <point x="1486" y="480" type="line"/>
       <point x="1538" y="480"/>
       <point x="1538" y="480"/>
       <point x="1538" y="444" type="qcurve"/>
       <point x="1538" y="444" type="line"/>
-      <point x="1538" y="406"/>
-      <point x="1538" y="406"/>
-      <point x="1502" y="406" type="qcurve"/>
+      <point x="1538" y="399"/>
+      <point x="1538" y="399"/>
+      <point x="1486" y="399" type="qcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1-ROND0.ufo/glyphs/nine.glif
@@ -4,57 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="233" y="922" type="line"/>
-      <point x="233" y="720"/>
-      <point x="567" y="459"/>
-      <point x="830" y="459" type="qcurve"/>
-      <point x="830" y="459" type="line"/>
-      <point x="1096" y="459"/>
-      <point x="1427" y="724"/>
-      <point x="1427" y="930" type="qcurve"/>
-      <point x="1427" y="930" type="line"/>
-      <point x="1427" y="1140"/>
-      <point x="1096" y="1412"/>
-      <point x="829" y="1413" type="qcurve"/>
-      <point x="829" y="1413" type="line"/>
-      <point x="567" y="1412"/>
-      <point x="233" y="1135"/>
-      <point x="233" y="922" type="qcurve"/>
+      <point x="827" y="1486" type="line"/>
+      <point x="1129" y="1486"/>
+      <point x="1520" y="1172"/>
+      <point x="1520" y="929" type="qcurve"/>
+      <point x="1520" y="929" type="line"/>
+      <point x="1520" y="697"/>
+      <point x="1116" y="404"/>
+      <point x="821" y="404" type="qcurve"/>
+      <point x="821" y="404" type="line"/>
+      <point x="516" y="404"/>
+      <point x="140" y="708"/>
+      <point x="140" y="941" type="qcurve"/>
+      <point x="140" y="941" type="line"/>
+      <point x="140" y="1178"/>
+      <point x="527" y="1486"/>
+      <point x="827" y="1486" type="qcurve"/>
     </contour>
     <contour>
-      <point x="635" y="-28" type="line" smooth="yes"/>
-      <point x="603" y="-50"/>
-      <point x="604" y="-49"/>
-      <point x="582" y="-9" type="qcurve"/>
-      <point x="582" y="-9" type="line"/>
-      <point x="558" y="36"/>
-      <point x="558" y="35"/>
-      <point x="583" y="52" type="qcurve" smooth="yes"/>
-      <point x="1170" y="443" type="line" smooth="yes"/>
-      <point x="1211" y="470"/>
-      <point x="1234" y="488"/>
-      <point x="1252" y="506" type="qcurve"/>
-      <point x="1257" y="511" type="line"/>
-      <point x="1251" y="517" type="line"/>
-      <point x="1208" y="485"/>
-      <point x="992" y="385"/>
-      <point x="821" y="385" type="qcurve"/>
-      <point x="821" y="385" type="line"/>
-      <point x="516" y="385"/>
-      <point x="140" y="685"/>
-      <point x="140" y="917" type="qcurve"/>
-      <point x="140" y="917" type="line"/>
-      <point x="140" y="1166"/>
-      <point x="527" y="1487"/>
-      <point x="827" y="1487" type="qcurve"/>
-      <point x="827" y="1487" type="line"/>
-      <point x="1129" y="1487"/>
-      <point x="1520" y="1173"/>
-      <point x="1520" y="930" type="qcurve"/>
-      <point x="1520" y="930" type="line"/>
-      <point x="1521" y="745"/>
-      <point x="1346" y="471"/>
-      <point x="1188" y="360" type="qcurve" smooth="yes"/>
+      <point x="1483" y="930" type="line"/>
+      <point x="1519" y="930" type="line"/>
+      <point x="1519" y="750"/>
+      <point x="1339" y="490"/>
+      <point x="1187" y="376" type="qcurve" smooth="yes"/>
+      <point x="630" y="-41" type="line"/>
+      <point x="597" y="-66"/>
+      <point x="597" y="-66"/>
+      <point x="571" y="-31" type="qcurve"/>
+      <point x="571" y="-31" type="line"/>
+      <point x="541" y="12"/>
+      <point x="541" y="12"/>
+      <point x="565" y="30" type="qcurve"/>
+      <point x="1014" y="351" type="line" smooth="yes"/>
+      <point x="1093" y="407"/>
+      <point x="1239" y="502"/>
+      <point x="1318" y="558" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="829" y="1410" type="qcurve"/>
+      <point x="829" y="1410" type="line"/>
+      <point x="567" y="1409"/>
+      <point x="233" y="1144"/>
+      <point x="233" y="940" type="qcurve"/>
+      <point x="234" y="939" type="line"/>
+      <point x="234" y="738"/>
+      <point x="568" y="475"/>
+      <point x="831" y="475" type="qcurve"/>
+      <point x="830" y="476" type="line"/>
+      <point x="1096" y="476"/>
+      <point x="1427" y="721"/>
+      <point x="1427" y="927" type="qcurve"/>
+      <point x="1427" y="927" type="line"/>
+      <point x="1427" y="1137"/>
+      <point x="1096" y="1409"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1-ROND0.ufo/glyphs/six.glif
@@ -4,57 +4,59 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="258" y="505" type="line"/>
-      <point x="258" y="295"/>
-      <point x="589" y="23"/>
-      <point x="856" y="22" type="qcurve"/>
-      <point x="856" y="22" type="line"/>
-      <point x="1118" y="23"/>
-      <point x="1452" y="300"/>
-      <point x="1452" y="513" type="qcurve"/>
-      <point x="1452" y="513" type="line"/>
-      <point x="1452" y="715"/>
-      <point x="1118" y="976"/>
-      <point x="855" y="976" type="qcurve"/>
-      <point x="855" y="976" type="line"/>
-      <point x="589" y="976"/>
-      <point x="258" y="711"/>
-      <point x="258" y="505" type="qcurve"/>
-    </contour>
-    <contour>
       <point x="858" y="-52" type="line"/>
       <point x="556" y="-52"/>
       <point x="165" y="262"/>
       <point x="165" y="505" type="qcurve"/>
       <point x="165" y="505" type="line"/>
-      <point x="164" y="690"/>
-      <point x="339" y="961"/>
-      <point x="497" y="1075" type="qcurve" smooth="yes"/>
-      <point x="1096" y="1505" type="line" smooth="yes"/>
-      <point x="1127" y="1527"/>
-      <point x="1127" y="1526"/>
-      <point x="1149" y="1486" type="qcurve"/>
-      <point x="1149" y="1486" type="line"/>
-      <point x="1173" y="1441"/>
-      <point x="1173" y="1442"/>
-      <point x="1148" y="1425" type="qcurve" smooth="yes"/>
-      <point x="515" y="992" type="line" smooth="yes"/>
-      <point x="475" y="965"/>
-      <point x="454" y="945"/>
-      <point x="433" y="929" type="qcurve"/>
-      <point x="428" y="923" type="line"/>
-      <point x="434" y="918" type="line"/>
-      <point x="477" y="950"/>
-      <point x="693" y="1050"/>
-      <point x="864" y="1050" type="qcurve"/>
-      <point x="864" y="1050" type="line"/>
-      <point x="1169" y="1050"/>
-      <point x="1545" y="750"/>
-      <point x="1545" y="518" type="qcurve"/>
-      <point x="1545" y="518" type="line"/>
-      <point x="1545" y="269"/>
+      <point x="165" y="737"/>
+      <point x="569" y="1030"/>
+      <point x="864" y="1030" type="qcurve"/>
+      <point x="864" y="1030" type="line"/>
+      <point x="1169" y="1030"/>
+      <point x="1545" y="726"/>
+      <point x="1545" y="493" type="qcurve"/>
+      <point x="1545" y="493" type="line"/>
+      <point x="1545" y="256"/>
       <point x="1158" y="-52"/>
       <point x="858" y="-52" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="202" y="504" type="line"/>
+      <point x="166" y="504" type="line"/>
+      <point x="166" y="684"/>
+      <point x="346" y="944"/>
+      <point x="498" y="1058" type="qcurve" smooth="yes"/>
+      <point x="1083" y="1496" type="line"/>
+      <point x="1116" y="1521"/>
+      <point x="1116" y="1521"/>
+      <point x="1142" y="1486" type="qcurve"/>
+      <point x="1142" y="1486" type="line"/>
+      <point x="1172" y="1443"/>
+      <point x="1172" y="1443"/>
+      <point x="1148" y="1425" type="qcurve"/>
+      <point x="671" y="1083" type="line" smooth="yes"/>
+      <point x="593" y="1027"/>
+      <point x="446" y="932"/>
+      <point x="367" y="876" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="856" y="22" type="qcurve"/>
+      <point x="856" y="22" type="line"/>
+      <point x="1118" y="23"/>
+      <point x="1452" y="288"/>
+      <point x="1452" y="492" type="qcurve"/>
+      <point x="1451" y="493" type="line"/>
+      <point x="1451" y="694"/>
+      <point x="1117" y="957"/>
+      <point x="854" y="957" type="qcurve"/>
+      <point x="855" y="956" type="line"/>
+      <point x="589" y="956"/>
+      <point x="258" y="711"/>
+      <point x="258" y="505" type="qcurve"/>
+      <point x="258" y="505" type="line"/>
+      <point x="258" y="295"/>
+      <point x="589" y="23"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1-ROND0.ufo/glyphs/three.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1-ROND0.ufo/glyphs/three.glif
@@ -43,10 +43,10 @@
       <point x="1356" y="1102" type="qcurve"/>
       <point x="1356" y="1102" type="line"/>
       <point x="1355" y="978"/>
-      <point x="1145" y="786"/>
-      <point x="930" y="761" type="qcurve"/>
-      <point x="930" y="758" type="line"/>
-      <point x="1168" y="736"/>
+      <point x="1164" y="793"/>
+      <point x="958" y="761" type="qcurve"/>
+      <point x="958" y="758" type="line"/>
+      <point x="1207" y="745"/>
       <point x="1437" y="541"/>
       <point x="1437" y="404" type="qcurve"/>
       <point x="1437" y="404" type="line"/>
@@ -55,18 +55,18 @@
       <point x="759" y="-52" type="qcurve"/>
       <point x="759" y="-52" type="line"/>
       <point x="496" y="-52"/>
-      <point x="118" y="151"/>
-      <point x="75" y="315" type="qcurve"/>
-      <point x="75" y="315" type="line"/>
-      <point x="64" y="355"/>
-      <point x="64" y="355"/>
-      <point x="108" y="369" type="qcurve"/>
-      <point x="108" y="369" type="line"/>
-      <point x="151" y="382"/>
-      <point x="151" y="382"/>
-      <point x="159" y="352" type="qcurve"/>
-      <point x="159" y="352" type="line"/>
-      <point x="191" y="222"/>
+      <point x="117" y="147"/>
+      <point x="74" y="315" type="qcurve"/>
+      <point x="74" y="315" type="line"/>
+      <point x="63" y="355"/>
+      <point x="63" y="355"/>
+      <point x="105" y="369" type="qcurve"/>
+      <point x="105" y="369" type="line"/>
+      <point x="148" y="382"/>
+      <point x="148" y="382"/>
+      <point x="157" y="351" type="qcurve"/>
+      <point x="157" y="351" type="line"/>
+      <point x="195" y="211"/>
       <point x="498" y="33"/>
       <point x="751" y="32" type="qcurve"/>
       <point x="751" y="32" type="line"/>
@@ -75,7 +75,7 @@
       <point x="1344" y="401" type="qcurve"/>
       <point x="1344" y="401" type="line"/>
       <point x="1345" y="538"/>
-      <point x="1039" y="714"/>
+      <point x="1050" y="714"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/nine.glif
@@ -4,6 +4,48 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
+      <point x="892" y="1485" type="line"/>
+      <point x="1229" y="1485"/>
+      <point x="1664" y="1158"/>
+      <point x="1664" y="897" type="qcurve"/>
+      <point x="1664" y="897" type="line"/>
+      <point x="1664" y="670"/>
+      <point x="1354" y="509"/>
+      <point x="907" y="468" type="qcurve"/>
+      <point x="907" y="468" type="line"/>
+      <point x="489" y="433"/>
+      <point x="130" y="689"/>
+      <point x="130" y="920" type="qcurve"/>
+      <point x="130" y="920" type="line"/>
+      <point x="130" y="1180"/>
+      <point x="559" y="1485"/>
+      <point x="892" y="1485" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="1342" y="896" type="line"/>
+      <point x="1665" y="896" type="line"/>
+      <point x="1665" y="703"/>
+      <point x="1460" y="379"/>
+      <point x="1222" y="215" type="qcurve" smooth="yes"/>
+      <point x="998" y="60" type="line" smooth="yes"/>
+      <point x="777" y="-93"/>
+      <point x="778" y="-89"/>
+      <point x="665" y="78" type="qcurve"/>
+      <point x="665" y="78" type="line"/>
+      <point x="550" y="256"/>
+      <point x="549" y="256"/>
+      <point x="705" y="349" type="qcurve"/>
+      <point x="767" y="382" type="line" smooth="yes"/>
+      <point x="796" y="397"/>
+      <point x="950" y="479"/>
+      <point x="985" y="488" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="910" y="1108" type="qcurve"/>
+      <point x="910" y="1108" type="line"/>
+      <point x="769" y="1108"/>
+      <point x="585" y="995"/>
+      <point x="585" y="905" type="qcurve"/>
       <point x="585" y="905" type="line"/>
       <point x="585" y="805"/>
       <point x="766" y="702"/>
@@ -15,46 +57,6 @@
       <point x="1232" y="905" type="line"/>
       <point x="1232" y="995"/>
       <point x="1050" y="1108"/>
-      <point x="910" y="1108" type="qcurve"/>
-      <point x="910" y="1108" type="line"/>
-      <point x="769" y="1108"/>
-      <point x="585" y="995"/>
-      <point x="585" y="905" type="qcurve"/>
-    </contour>
-    <contour>
-      <point x="784" y="-82" type="line" smooth="yes"/>
-      <point x="676" y="-154"/>
-      <point x="676" y="-152"/>
-      <point x="567" y="8" type="qcurve"/>
-      <point x="567" y="8" type="line"/>
-      <point x="445" y="195"/>
-      <point x="449" y="188"/>
-      <point x="522" y="233" type="qcurve" smooth="yes"/>
-      <point x="807" y="408" type="line" smooth="yes"/>
-      <point x="873" y="449"/>
-      <point x="923" y="474"/>
-      <point x="954" y="489" type="qcurve"/>
-      <point x="974" y="501" type="line"/>
-      <point x="969" y="516" type="line"/>
-      <point x="929" y="493"/>
-      <point x="820" y="468"/>
-      <point x="728" y="468" type="qcurve"/>
-      <point x="728" y="468" type="line"/>
-      <point x="462" y="468"/>
-      <point x="130" y="689"/>
-      <point x="130" y="920" type="qcurve"/>
-      <point x="130" y="920" type="line"/>
-      <point x="130" y="1180"/>
-      <point x="559" y="1485"/>
-      <point x="892" y="1485" type="qcurve"/>
-      <point x="892" y="1485" type="line"/>
-      <point x="1229" y="1485"/>
-      <point x="1665" y="1157"/>
-      <point x="1665" y="896" type="qcurve"/>
-      <point x="1665" y="896" type="line"/>
-      <point x="1665" y="659"/>
-      <point x="1437" y="352"/>
-      <point x="1201" y="195" type="qcurve" smooth="yes"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/six.glif
@@ -4,9 +4,43 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="563" y="523" type="line"/>
-      <point x="563" y="433"/>
-      <point x="745" y="320"/>
+      <point x="903" y="-57" type="line"/>
+      <point x="566" y="-57"/>
+      <point x="131" y="270"/>
+      <point x="131" y="531" type="qcurve"/>
+      <point x="131" y="531" type="line"/>
+      <point x="131" y="758"/>
+      <point x="441" y="919"/>
+      <point x="888" y="960" type="qcurve"/>
+      <point x="888" y="960" type="line"/>
+      <point x="1306" y="995"/>
+      <point x="1665" y="739"/>
+      <point x="1665" y="508" type="qcurve"/>
+      <point x="1665" y="508" type="line"/>
+      <point x="1665" y="248"/>
+      <point x="1236" y="-57"/>
+      <point x="903" y="-57" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="453" y="532" type="line"/>
+      <point x="130" y="532" type="line"/>
+      <point x="130" y="725"/>
+      <point x="334" y="1051"/>
+      <point x="573" y="1213" type="qcurve" smooth="yes"/>
+      <point x="898" y="1433" type="line" smooth="yes"/>
+      <point x="1118" y="1582"/>
+      <point x="1118" y="1582"/>
+      <point x="1231" y="1415" type="qcurve"/>
+      <point x="1231" y="1415" type="line"/>
+      <point x="1346" y="1237"/>
+      <point x="1347" y="1237"/>
+      <point x="1191" y="1144" type="qcurve"/>
+      <point x="1028" y="1046" type="line" smooth="yes"/>
+      <point x="999" y="1029"/>
+      <point x="845" y="949"/>
+      <point x="810" y="940" type="qcurve"/>
+    </contour>
+    <contour>
       <point x="885" y="320" type="qcurve"/>
       <point x="885" y="320" type="line"/>
       <point x="1026" y="320"/>
@@ -20,41 +54,9 @@
       <point x="747" y="726"/>
       <point x="563" y="623"/>
       <point x="563" y="523" type="qcurve"/>
-    </contour>
-    <contour>
-      <point x="903" y="-57" type="line"/>
-      <point x="566" y="-57"/>
-      <point x="130" y="271"/>
-      <point x="130" y="532" type="qcurve"/>
-      <point x="130" y="532" type="line"/>
-      <point x="130" y="769"/>
-      <point x="358" y="1076"/>
-      <point x="594" y="1233" type="qcurve" smooth="yes"/>
-      <point x="1011" y="1510" type="line" smooth="yes"/>
-      <point x="1119" y="1582"/>
-      <point x="1119" y="1580"/>
-      <point x="1228" y="1420" type="qcurve"/>
-      <point x="1228" y="1420" type="line"/>
-      <point x="1350" y="1233"/>
-      <point x="1346" y="1240"/>
-      <point x="1273" y="1195" type="qcurve" smooth="yes"/>
-      <point x="988" y="1020" type="line" smooth="yes"/>
-      <point x="922" y="979"/>
-      <point x="872" y="954"/>
-      <point x="841" y="939" type="qcurve"/>
-      <point x="821" y="927" type="line"/>
-      <point x="826" y="912" type="line"/>
-      <point x="866" y="935"/>
-      <point x="975" y="960"/>
-      <point x="1067" y="960" type="qcurve"/>
-      <point x="1067" y="960" type="line"/>
-      <point x="1333" y="960"/>
-      <point x="1665" y="739"/>
-      <point x="1665" y="508" type="qcurve"/>
-      <point x="1665" y="508" type="line"/>
-      <point x="1665" y="248"/>
-      <point x="1236" y="-57"/>
-      <point x="903" y="-57" type="qcurve"/>
+      <point x="563" y="523" type="line"/>
+      <point x="563" y="433"/>
+      <point x="745" y="320"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth151-wght400-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth151-wght400-ROND0.ufo/glyphs/nine.glif
@@ -4,57 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="291" y="968" type="line"/>
-      <point x="291" y="816"/>
-      <point x="549" y="620"/>
-      <point x="748" y="620" type="qcurve"/>
-      <point x="748" y="620" type="line"/>
-      <point x="947" y="620"/>
-      <point x="1204" y="816"/>
-      <point x="1204" y="968" type="qcurve"/>
-      <point x="1204" y="968" type="line"/>
-      <point x="1204" y="1122"/>
-      <point x="949" y="1320"/>
-      <point x="752" y="1320" type="qcurve"/>
-      <point x="752" y="1320" type="line"/>
-      <point x="551" y="1320"/>
-      <point x="291" y="1122"/>
-      <point x="291" y="968" type="qcurve"/>
+      <point x="747" y="1479" type="line"/>
+      <point x="1034" y="1479"/>
+      <point x="1405" y="1187"/>
+      <point x="1405" y="961" type="qcurve"/>
+      <point x="1405" y="961" type="line"/>
+      <point x="1405" y="761"/>
+      <point x="938" y="484"/>
+      <point x="747" y="484" type="qcurve"/>
+      <point x="747" y="484" type="line"/>
+      <point x="447" y="484"/>
+      <point x="88" y="755"/>
+      <point x="88" y="969" type="qcurve"/>
+      <point x="88" y="969" type="line"/>
+      <point x="88" y="1192"/>
+      <point x="459" y="1479"/>
+      <point x="747" y="1479" type="qcurve"/>
     </contour>
     <contour>
-      <point x="650" y="19" type="line"/>
-      <point x="574" y="-39"/>
-      <point x="574" y="-39"/>
-      <point x="514" y="26" type="qcurve"/>
-      <point x="514" y="26" type="line"/>
-      <point x="446" y="101"/>
-      <point x="446" y="101"/>
-      <point x="516" y="158" type="qcurve"/>
-      <point x="758" y="340" type="line"/>
-      <point x="844" y="408"/>
-      <point x="970" y="500"/>
-      <point x="1050" y="557" type="qcurve" smooth="yes"/>
-      <point x="1057" y="562" type="line"/>
-      <point x="1044" y="572" type="line"/>
-      <point x="985" y="521"/>
-      <point x="805" y="478"/>
-      <point x="695" y="478" type="qcurve"/>
-      <point x="695" y="478" type="line"/>
-      <point x="431" y="478"/>
-      <point x="89" y="754"/>
-      <point x="89" y="968" type="qcurve"/>
-      <point x="89" y="968" type="line"/>
-      <point x="89" y="1191"/>
-      <point x="460" y="1478"/>
-      <point x="748" y="1478" type="qcurve"/>
-      <point x="748" y="1478" type="line"/>
-      <point x="1035" y="1478"/>
-      <point x="1406" y="1186"/>
-      <point x="1406" y="960" type="qcurve"/>
-      <point x="1406" y="960" type="line"/>
-      <point x="1406" y="774"/>
-      <point x="1254" y="520"/>
-      <point x="1076" y="372" type="qcurve" smooth="yes"/>
+      <point x="1256" y="972" type="line"/>
+      <point x="1404" y="961" type="line"/>
+      <point x="1404" y="739"/>
+      <point x="1099" y="394"/>
+      <point x="958" y="276" type="qcurve" smooth="yes"/>
+      <point x="624" y="-4" type="line" smooth="yes"/>
+      <point x="558" y="-59"/>
+      <point x="560" y="-60"/>
+      <point x="498" y="7" type="qcurve"/>
+      <point x="498" y="7" type="line"/>
+      <point x="428" y="86"/>
+      <point x="428" y="86"/>
+      <point x="477" y="124" type="qcurve" smooth="yes"/>
+      <point x="681" y="283" type="line" smooth="yes"/>
+      <point x="759" y="344"/>
+      <point x="1080" y="586"/>
+      <point x="1158" y="636" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="750" y="1321" type="qcurve"/>
+      <point x="750" y="1321" type="line"/>
+      <point x="549" y="1321"/>
+      <point x="289" y="1123"/>
+      <point x="289" y="969" type="qcurve"/>
+      <point x="289" y="969" type="line"/>
+      <point x="289" y="817"/>
+      <point x="547" y="621"/>
+      <point x="746" y="621" type="qcurve"/>
+      <point x="746" y="621" type="line"/>
+      <point x="945" y="621"/>
+      <point x="1202" y="817"/>
+      <point x="1202" y="969" type="qcurve"/>
+      <point x="1202" y="969" type="line"/>
+      <point x="1202" y="1123"/>
+      <point x="947" y="1321"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth151-wght400-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth151-wght400-ROND0.ufo/glyphs/six.glif
@@ -4,9 +4,43 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="351" y="478" type="line"/>
-      <point x="351" y="324"/>
-      <point x="606" y="126"/>
+      <point x="806" y="-32" type="line"/>
+      <point x="519" y="-32"/>
+      <point x="148" y="260"/>
+      <point x="148" y="486" type="qcurve"/>
+      <point x="148" y="486" type="line"/>
+      <point x="148" y="686"/>
+      <point x="615" y="963"/>
+      <point x="806" y="963" type="qcurve"/>
+      <point x="806" y="963" type="line"/>
+      <point x="1106" y="963"/>
+      <point x="1465" y="692"/>
+      <point x="1465" y="478" type="qcurve"/>
+      <point x="1465" y="478" type="line"/>
+      <point x="1465" y="255"/>
+      <point x="1094" y="-32"/>
+      <point x="806" y="-32" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="297" y="475" type="line"/>
+      <point x="149" y="486" type="line"/>
+      <point x="149" y="708"/>
+      <point x="454" y="1054"/>
+      <point x="595" y="1171" type="qcurve" smooth="yes"/>
+      <point x="950" y="1467" type="line" smooth="yes"/>
+      <point x="1016" y="1522"/>
+      <point x="1014" y="1523"/>
+      <point x="1076" y="1456" type="qcurve"/>
+      <point x="1076" y="1456" type="line"/>
+      <point x="1146" y="1377"/>
+      <point x="1146" y="1377"/>
+      <point x="1097" y="1339" type="qcurve" smooth="yes"/>
+      <point x="872" y="1164" type="line" smooth="yes"/>
+      <point x="794" y="1104"/>
+      <point x="473" y="861"/>
+      <point x="395" y="811" type="qcurve"/>
+    </contour>
+    <contour>
       <point x="803" y="126" type="qcurve"/>
       <point x="803" y="126" type="line"/>
       <point x="1004" y="126"/>
@@ -20,41 +54,9 @@
       <point x="608" y="826"/>
       <point x="351" y="630"/>
       <point x="351" y="478" type="qcurve"/>
-    </contour>
-    <contour>
-      <point x="807" y="-32" type="line"/>
-      <point x="520" y="-32"/>
-      <point x="149" y="260"/>
-      <point x="149" y="486" type="qcurve"/>
-      <point x="149" y="486" type="line"/>
-      <point x="149" y="663"/>
-      <point x="289" y="915"/>
-      <point x="417" y="1022" type="qcurve" smooth="yes"/>
-      <point x="941" y="1461" type="line" smooth="yes"/>
-      <point x="1014" y="1522"/>
-      <point x="1014" y="1523"/>
-      <point x="1077" y="1454" type="qcurve"/>
-      <point x="1077" y="1454" type="line"/>
-      <point x="1145" y="1379"/>
-      <point x="1146" y="1377"/>
-      <point x="1075" y="1322" type="qcurve" smooth="yes"/>
-      <point x="797" y="1106" type="line" smooth="yes"/>
-      <point x="710" y="1039"/>
-      <point x="585" y="946"/>
-      <point x="505" y="889" type="qcurve" smooth="yes"/>
-      <point x="498" y="884" type="line"/>
-      <point x="511" y="874" type="line"/>
-      <point x="570" y="925"/>
-      <point x="750" y="968"/>
-      <point x="860" y="968" type="qcurve"/>
-      <point x="860" y="968" type="line"/>
-      <point x="1124" y="968"/>
-      <point x="1466" y="692"/>
-      <point x="1466" y="478" type="qcurve"/>
-      <point x="1466" y="478" type="line"/>
-      <point x="1466" y="255"/>
-      <point x="1095" y="-32"/>
-      <point x="807" y="-32" type="qcurve"/>
+      <point x="351" y="478" type="line"/>
+      <point x="351" y="324"/>
+      <point x="606" y="126"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1-ROND0.ufo/glyphs/eight.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1-ROND0.ufo/glyphs/eight.glif
@@ -18,18 +18,18 @@
       <point x="374" y="770" type="qcurve"/>
       <point x="374" y="770" type="line"/>
       <point x="269" y="778"/>
-      <point x="137" y="970"/>
-      <point x="137" y="1108" type="qcurve"/>
-      <point x="137" y="1108" type="line"/>
-      <point x="137" y="1280"/>
-      <point x="333" y="1458"/>
+      <point x="137" y="962"/>
+      <point x="137" y="1100" type="qcurve"/>
+      <point x="137" y="1100" type="line"/>
+      <point x="137" y="1272"/>
+      <point x="323" y="1458"/>
       <point x="460" y="1458" type="qcurve"/>
       <point x="460" y="1458" type="line"/>
-      <point x="591" y="1458"/>
-      <point x="789" y="1280"/>
-      <point x="789" y="1106" type="qcurve"/>
-      <point x="789" y="1106" type="line"/>
-      <point x="789" y="970"/>
+      <point x="601" y="1458"/>
+      <point x="789" y="1272"/>
+      <point x="789" y="1098" type="qcurve"/>
+      <point x="789" y="1098" type="line"/>
+      <point x="789" y="962"/>
       <point x="651" y="782"/>
       <point x="544" y="768" type="qcurve"/>
       <point x="544" y="768" type="line"/>
@@ -38,22 +38,22 @@
       <point x="843" y="394" type="qcurve"/>
     </contour>
     <contour>
-      <point x="215" y="1106" type="line"/>
-      <point x="215" y="968"/>
+      <point x="215" y="1098" type="line"/>
+      <point x="215" y="960"/>
       <point x="345" y="806"/>
       <point x="462" y="806" type="qcurve"/>
       <point x="462" y="806" type="line"/>
       <point x="578" y="806"/>
-      <point x="710" y="962"/>
-      <point x="710" y="1106" type="qcurve"/>
-      <point x="710" y="1106" type="line"/>
-      <point x="710" y="1262"/>
+      <point x="710" y="954"/>
+      <point x="710" y="1098" type="qcurve"/>
+      <point x="710" y="1098" type="line"/>
+      <point x="710" y="1244"/>
       <point x="570" y="1384"/>
       <point x="462" y="1384" type="qcurve"/>
       <point x="462" y="1384" type="line"/>
       <point x="357" y="1384"/>
-      <point x="215" y="1262"/>
-      <point x="215" y="1106" type="qcurve"/>
+      <point x="215" y="1244"/>
+      <point x="215" y="1098" type="qcurve"/>
     </contour>
     <contour>
       <point x="166" y="394" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1-ROND0.ufo/glyphs/nine.glif
@@ -4,57 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="130" y="950" type="line"/>
-      <point x="130" y="756"/>
-      <point x="280" y="538"/>
-      <point x="418" y="538" type="qcurve"/>
-      <point x="418" y="538" type="line"/>
-      <point x="544" y="538"/>
-      <point x="724" y="724"/>
-      <point x="724" y="950" type="qcurve"/>
-      <point x="724" y="950" type="line"/>
-      <point x="724" y="1164"/>
-      <point x="572" y="1387"/>
+      <point x="431" y="1459" type="line"/>
+      <point x="611" y="1459"/>
+      <point x="808" y="1189"/>
+      <point x="808" y="955" type="qcurve"/>
+      <point x="808" y="955" type="line"/>
+      <point x="808" y="741"/>
+      <point x="578" y="471"/>
+      <point x="418" y="471" type="qcurve"/>
+      <point x="418" y="471" type="line"/>
+      <point x="246" y="471"/>
+      <point x="41" y="719"/>
+      <point x="41" y="955" type="qcurve"/>
+      <point x="41" y="955" type="line"/>
+      <point x="41" y="1181"/>
+      <point x="250" y="1459"/>
+      <point x="431" y="1459" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="772" y="955" type="line"/>
+      <point x="808" y="955" type="line"/>
+      <point x="808" y="794"/>
+      <point x="724" y="519"/>
+      <point x="587" y="337" type="qcurve" smooth="yes"/>
+      <point x="307" y="-37" type="line"/>
+      <point x="283" y="-68"/>
+      <point x="283" y="-68"/>
+      <point x="251" y="-44" type="qcurve"/>
+      <point x="251" y="-44" type="line"/>
+      <point x="213" y="-12"/>
+      <point x="213" y="-12"/>
+      <point x="231" y="10" type="qcurve"/>
+      <point x="467" y="322" type="line" smooth="yes"/>
+      <point x="523" y="395"/>
+      <point x="625" y="525"/>
+      <point x="667" y="579" type="qcurve"/>
+    </contour>
+    <contour>
       <point x="428" y="1387" type="qcurve"/>
       <point x="428" y="1387" type="line"/>
       <point x="302" y="1387"/>
-      <point x="130" y="1170"/>
-      <point x="130" y="950" type="qcurve"/>
-    </contour>
-    <contour>
-      <point x="322" y="-12" type="line"/>
-      <point x="296" y="-46"/>
-      <point x="296" y="-46"/>
-      <point x="263" y="-20" type="qcurve"/>
-      <point x="263" y="-20" type="line"/>
-      <point x="226" y="7"/>
-      <point x="226" y="7"/>
-      <point x="249" y="39" type="qcurve"/>
-      <point x="463" y="317" type="line" smooth="yes"/>
-      <point x="525" y="398"/>
-      <point x="630" y="519"/>
-      <point x="681" y="603" type="qcurve"/>
-      <point x="675" y="606" type="line"/>
-      <point x="675" y="606" type="line"/>
-      <point x="630" y="539"/>
-      <point x="508" y="470"/>
-      <point x="410" y="470" type="qcurve"/>
-      <point x="410" y="470" type="line"/>
-      <point x="238" y="470"/>
-      <point x="40" y="718"/>
-      <point x="40" y="954" type="qcurve"/>
-      <point x="40" y="954" type="line"/>
-      <point x="40" y="1180"/>
-      <point x="256" y="1458"/>
-      <point x="430" y="1458" type="qcurve"/>
-      <point x="430" y="1458" type="line"/>
-      <point x="610" y="1458"/>
-      <point x="808" y="1188"/>
-      <point x="808" y="954" type="qcurve"/>
-      <point x="808" y="954" type="line"/>
-      <point x="808" y="793"/>
-      <point x="740" y="544"/>
-      <point x="656" y="431" type="qcurve"/>
+      <point x="130" y="1171"/>
+      <point x="130" y="959" type="qcurve"/>
+      <point x="130" y="959" type="line"/>
+      <point x="130" y="760"/>
+      <point x="280" y="544"/>
+      <point x="418" y="544" type="qcurve"/>
+      <point x="418" y="544" type="line"/>
+      <point x="544" y="544"/>
+      <point x="724" y="727"/>
+      <point x="724" y="959" type="qcurve"/>
+      <point x="724" y="959" type="line"/>
+      <point x="724" y="1168"/>
+      <point x="572" y="1387"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1-ROND0.ufo/glyphs/six.glif
@@ -4,57 +4,59 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="160" y="480" type="line"/>
-      <point x="160" y="266"/>
-      <point x="312" y="41"/>
-      <point x="456" y="41" type="qcurve"/>
-      <point x="456" y="41" type="line"/>
-      <point x="582" y="41"/>
-      <point x="754" y="260"/>
-      <point x="754" y="480" type="qcurve"/>
-      <point x="754" y="480" type="line"/>
-      <point x="754" y="674"/>
-      <point x="604" y="892"/>
-      <point x="466" y="892" type="qcurve"/>
-      <point x="466" y="892" type="line"/>
-      <point x="340" y="892"/>
-      <point x="160" y="706"/>
-      <point x="160" y="480" type="qcurve"/>
-    </contour>
-    <contour>
       <point x="453" y="-28" type="line"/>
       <point x="273" y="-28"/>
       <point x="76" y="242"/>
       <point x="76" y="476" type="qcurve"/>
       <point x="76" y="476" type="line"/>
-      <point x="76" y="637"/>
-      <point x="154" y="906"/>
-      <point x="279" y="1072" type="qcurve" smooth="yes"/>
-      <point x="575" y="1465" type="line"/>
-      <point x="601" y="1499"/>
-      <point x="601" y="1499"/>
-      <point x="634" y="1473" type="qcurve"/>
-      <point x="634" y="1473" type="line"/>
-      <point x="665" y="1450"/>
-      <point x="671" y="1445"/>
-      <point x="648" y="1413" type="qcurve"/>
-      <point x="419" y="1112" type="line" smooth="yes"/>
-      <point x="357" y="1031"/>
-      <point x="237" y="892"/>
-      <point x="202" y="827" type="qcurve"/>
-      <point x="208" y="824" type="line"/>
-      <point x="208" y="824" type="line"/>
-      <point x="253" y="891"/>
-      <point x="375" y="960"/>
-      <point x="473" y="960" type="qcurve"/>
-      <point x="473" y="960" type="line"/>
-      <point x="645" y="960"/>
+      <point x="76" y="690"/>
+      <point x="306" y="960"/>
+      <point x="466" y="960" type="qcurve"/>
+      <point x="466" y="960" type="line"/>
+      <point x="638" y="960"/>
       <point x="843" y="712"/>
       <point x="843" y="476" type="qcurve"/>
       <point x="843" y="476" type="line"/>
       <point x="843" y="250"/>
       <point x="627" y="-28"/>
       <point x="453" y="-28" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="112" y="476" type="line"/>
+      <point x="76" y="476" type="line"/>
+      <point x="76" y="637"/>
+      <point x="160" y="912"/>
+      <point x="297" y="1094" type="qcurve" smooth="yes"/>
+      <point x="577" y="1468" type="line"/>
+      <point x="601" y="1499"/>
+      <point x="601" y="1499"/>
+      <point x="633" y="1475" type="qcurve"/>
+      <point x="633" y="1475" type="line"/>
+      <point x="671" y="1443"/>
+      <point x="671" y="1443"/>
+      <point x="653" y="1421" type="qcurve"/>
+      <point x="417" y="1109" type="line" smooth="yes"/>
+      <point x="361" y="1036"/>
+      <point x="275" y="921"/>
+      <point x="233" y="867" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="456" y="41" type="qcurve"/>
+      <point x="456" y="41" type="line"/>
+      <point x="582" y="41"/>
+      <point x="754" y="255"/>
+      <point x="754" y="470" type="qcurve"/>
+      <point x="754" y="470" type="line"/>
+      <point x="754" y="669"/>
+      <point x="604" y="892"/>
+      <point x="466" y="892" type="qcurve"/>
+      <point x="466" y="892" type="line"/>
+      <point x="340" y="892"/>
+      <point x="160" y="702"/>
+      <point x="160" y="470" type="qcurve"/>
+      <point x="160" y="470" type="line"/>
+      <point x="160" y="261"/>
+      <point x="312" y="41"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/nine.glif
@@ -4,57 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="414" y="928" type="line"/>
-      <point x="414" y="840"/>
-      <point x="457" y="745"/>
-      <point x="513" y="745" type="qcurve"/>
-      <point x="513" y="745" type="line"/>
-      <point x="566" y="745"/>
-      <point x="613" y="823"/>
-      <point x="613" y="928" type="qcurve"/>
-      <point x="613" y="928" type="line"/>
-      <point x="613" y="1032"/>
-      <point x="561" y="1123"/>
-      <point x="509" y="1123" type="qcurve"/>
-      <point x="509" y="1123" type="line"/>
-      <point x="457" y="1123"/>
-      <point x="414" y="1025"/>
-      <point x="414" y="928" type="qcurve"/>
+      <point x="512" y="1455" type="line"/>
+      <point x="742" y="1455"/>
+      <point x="992" y="1179"/>
+      <point x="992" y="928" type="qcurve"/>
+      <point x="992" y="928" type="line"/>
+      <point x="992" y="767"/>
+      <point x="746" y="559"/>
+      <point x="517" y="535" type="qcurve"/>
+      <point x="517" y="535" type="line"/>
+      <point x="284" y="506"/>
+      <point x="36" y="731"/>
+      <point x="36" y="945" type="qcurve"/>
+      <point x="36" y="945" type="line"/>
+      <point x="36" y="1175"/>
+      <point x="290" y="1455"/>
+      <point x="512" y="1455" type="qcurve"/>
     </contour>
     <contour>
-      <point x="507" y="27" type="line"/>
-      <point x="416" y="-62"/>
-      <point x="417" y="-63"/>
-      <point x="292" y="44" type="qcurve"/>
-      <point x="292" y="44" type="line"/>
-      <point x="162" y="153"/>
-      <point x="162" y="153"/>
-      <point x="227" y="220" type="qcurve"/>
-      <point x="396" y="394" type="line" smooth="yes"/>
-      <point x="466" y="467"/>
-      <point x="537" y="533"/>
-      <point x="578" y="566" type="qcurve" smooth="yes"/>
-      <point x="593" y="577" type="line"/>
-      <point x="581" y="586" type="line"/>
-      <point x="548" y="553"/>
-      <point x="479" y="521"/>
-      <point x="412" y="521" type="qcurve"/>
-      <point x="412" y="521" type="line"/>
-      <point x="259" y="521"/>
-      <point x="31" y="730"/>
-      <point x="31" y="944" type="qcurve"/>
-      <point x="31" y="944" type="line"/>
-      <point x="31" y="1156"/>
-      <point x="285" y="1461"/>
-      <point x="507" y="1461" type="qcurve"/>
-      <point x="507" y="1461" type="line"/>
-      <point x="737" y="1461"/>
-      <point x="987" y="1167"/>
-      <point x="987" y="934" type="qcurve"/>
-      <point x="987" y="934" type="line"/>
-      <point x="987" y="741"/>
-      <point x="848" y="408"/>
-      <point x="742" y="290" type="qcurve" smooth="yes"/>
+      <point x="841" y="927" type="line"/>
+      <point x="992" y="927" type="line"/>
+      <point x="992" y="765"/>
+      <point x="901" y="481"/>
+      <point x="755" y="301" type="qcurve" smooth="yes"/>
+      <point x="596" y="104" type="line" smooth="yes"/>
+      <point x="460" y="-65"/>
+      <point x="460" y="-65"/>
+      <point x="315" y="53" type="qcurve"/>
+      <point x="315" y="53" type="line"/>
+      <point x="177" y="163"/>
+      <point x="177" y="163"/>
+      <point x="297" y="301" type="qcurve"/>
+      <point x="414" y="433" type="line" smooth="yes"/>
+      <point x="439" y="462"/>
+      <point x="514" y="513"/>
+      <point x="546" y="533" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="514" y="1117" type="qcurve"/>
+      <point x="514" y="1117" type="line"/>
+      <point x="462" y="1117"/>
+      <point x="419" y="1025"/>
+      <point x="419" y="928" type="qcurve"/>
+      <point x="419" y="928" type="line"/>
+      <point x="419" y="836"/>
+      <point x="462" y="731"/>
+      <point x="518" y="731" type="qcurve"/>
+      <point x="518" y="731" type="line"/>
+      <point x="571" y="731"/>
+      <point x="618" y="818"/>
+      <point x="618" y="928" type="qcurve"/>
+      <point x="618" y="928" type="line"/>
+      <point x="618" y="1032"/>
+      <point x="566" y="1117"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/six.glif
@@ -4,57 +4,59 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="414" y="503" type="line"/>
-      <point x="414" y="399"/>
-      <point x="466" y="308"/>
+      <point x="520" y="-30" type="line"/>
+      <point x="290" y="-30"/>
+      <point x="40" y="264"/>
+      <point x="40" y="497" type="qcurve"/>
+      <point x="40" y="497" type="line"/>
+      <point x="40" y="658"/>
+      <point x="286" y="866"/>
+      <point x="515" y="890" type="qcurve"/>
+      <point x="515" y="890" type="line"/>
+      <point x="748" y="919"/>
+      <point x="996" y="694"/>
+      <point x="996" y="480" type="qcurve"/>
+      <point x="996" y="480" type="line"/>
+      <point x="996" y="268"/>
+      <point x="742" y="-30"/>
+      <point x="520" y="-30" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="191" y="498" type="line"/>
+      <point x="40" y="498" type="line"/>
+      <point x="40" y="660"/>
+      <point x="131" y="944"/>
+      <point x="277" y="1124" type="qcurve" smooth="yes"/>
+      <point x="436" y="1321" type="line" smooth="yes"/>
+      <point x="572" y="1490"/>
+      <point x="572" y="1490"/>
+      <point x="717" y="1372" type="qcurve"/>
+      <point x="717" y="1372" type="line"/>
+      <point x="855" y="1262"/>
+      <point x="855" y="1262"/>
+      <point x="735" y="1124" type="qcurve"/>
+      <point x="618" y="992" type="line" smooth="yes"/>
+      <point x="593" y="963"/>
+      <point x="518" y="912"/>
+      <point x="486" y="892" type="qcurve"/>
+    </contour>
+    <contour>
       <point x="518" y="308" type="qcurve"/>
       <point x="518" y="308" type="line"/>
       <point x="570" y="308"/>
       <point x="613" y="406"/>
       <point x="613" y="503" type="qcurve"/>
       <point x="613" y="503" type="line"/>
-      <point x="613" y="591"/>
-      <point x="570" y="686"/>
-      <point x="514" y="686" type="qcurve"/>
-      <point x="514" y="686" type="line"/>
-      <point x="461" y="686"/>
-      <point x="414" y="608"/>
+      <point x="613" y="595"/>
+      <point x="570" y="694"/>
+      <point x="514" y="694" type="qcurve"/>
+      <point x="514" y="694" type="line"/>
+      <point x="461" y="694"/>
+      <point x="414" y="613"/>
       <point x="414" y="503" type="qcurve"/>
-    </contour>
-    <contour>
-      <point x="520" y="-30" type="line"/>
-      <point x="290" y="-30"/>
-      <point x="40" y="264"/>
-      <point x="40" y="497" type="qcurve"/>
-      <point x="40" y="497" type="line"/>
-      <point x="40" y="690"/>
-      <point x="179" y="1023"/>
-      <point x="285" y="1141" type="qcurve" smooth="yes"/>
-      <point x="520" y="1404" type="line"/>
-      <point x="611" y="1493"/>
-      <point x="610" y="1494"/>
-      <point x="735" y="1387" type="qcurve"/>
-      <point x="735" y="1387" type="line"/>
-      <point x="865" y="1278"/>
-      <point x="865" y="1278"/>
-      <point x="800" y="1211" type="qcurve"/>
-      <point x="635" y="1034" type="line" smooth="yes"/>
-      <point x="566" y="960"/>
-      <point x="490" y="898"/>
-      <point x="449" y="865" type="qcurve" smooth="yes"/>
-      <point x="434" y="854" type="line"/>
-      <point x="446" y="845" type="line"/>
-      <point x="479" y="878"/>
-      <point x="548" y="910"/>
-      <point x="615" y="910" type="qcurve"/>
-      <point x="615" y="910" type="line"/>
-      <point x="768" y="910"/>
-      <point x="996" y="712"/>
-      <point x="996" y="498" type="qcurve"/>
-      <point x="996" y="498" type="line"/>
-      <point x="996" y="286"/>
-      <point x="742" y="-30"/>
-      <point x="520" y="-30" type="qcurve"/>
+      <point x="414" y="503" type="line"/>
+      <point x="414" y="399"/>
+      <point x="466" y="308"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/zero.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/zero.glif
@@ -22,22 +22,22 @@
       <point x="792" y="-30"/>
     </contour>
     <contour>
-      <point x="584" y="350" type="qcurve"/>
-      <point x="584" y="350" type="line"/>
-      <point x="634" y="350"/>
-      <point x="682" y="474"/>
-      <point x="682" y="722" type="qcurve"/>
-      <point x="682" y="722" type="line"/>
-      <point x="682" y="956"/>
-      <point x="636" y="1062"/>
-      <point x="584" y="1062" type="qcurve"/>
-      <point x="584" y="1062" type="line"/>
-      <point x="532" y="1062"/>
-      <point x="480" y="948"/>
-      <point x="480" y="722" type="qcurve"/>
-      <point x="480" y="722" type="line"/>
-      <point x="480" y="474"/>
-      <point x="534" y="350"/>
+      <point x="587" y="350" type="qcurve"/>
+      <point x="587" y="350" type="line"/>
+      <point x="637" y="350"/>
+      <point x="685" y="474"/>
+      <point x="685" y="722" type="qcurve"/>
+      <point x="685" y="722" type="line"/>
+      <point x="685" y="956"/>
+      <point x="639" y="1062"/>
+      <point x="587" y="1062" type="qcurve"/>
+      <point x="587" y="1062" type="line"/>
+      <point x="535" y="1062"/>
+      <point x="483" y="948"/>
+      <point x="483" y="722" type="qcurve"/>
+      <point x="483" y="722" type="line"/>
+      <point x="483" y="474"/>
+      <point x="537" y="350"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght400-ROND0.ufo/glyphs/five.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght400-ROND0.ufo/glyphs/five.glif
@@ -18,9 +18,9 @@
       <point x="726" y="1246" name="inserted"/>
       <point x="633" y="1246" type="qcurve"/>
       <point x="306" y="1246" type="line"/>
-      <point x="268" y="834" type="line"/>
-      <point x="240" y="832" type="line"/>
-      <point x="284" y="883"/>
+      <point x="268" y="853" type="line"/>
+      <point x="268" y="853" type="line"/>
+      <point x="299" y="893"/>
       <point x="406" y="946"/>
       <point x="464" y="946" type="qcurve"/>
       <point x="464" y="946" type="line"/>
@@ -29,26 +29,26 @@
       <point x="786" y="470" type="qcurve"/>
       <point x="786" y="470" type="line"/>
       <point x="786" y="227"/>
-      <point x="597" y="-30"/>
-      <point x="429" y="-30" type="qcurve"/>
-      <point x="429" y="-30" type="line"/>
-      <point x="261" y="-30"/>
+      <point x="589" y="-30"/>
+      <point x="421" y="-30" type="qcurve"/>
+      <point x="421" y="-30" type="line"/>
+      <point x="253" y="-30"/>
       <point x="71" y="144"/>
       <point x="60" y="295" type="qcurve"/>
       <point x="60" y="295" type="line"/>
-      <point x="52" y="383"/>
-      <point x="52" y="383"/>
-      <point x="140" y="396" type="qcurve"/>
-      <point x="140" y="396" type="line"/>
-      <point x="233" y="410"/>
-      <point x="233" y="410"/>
-      <point x="244" y="316" type="qcurve"/>
-      <point x="244" y="316" type="line"/>
-      <point x="256" y="222"/>
-      <point x="338" y="128"/>
-      <point x="428" y="128" type="qcurve"/>
-      <point x="428" y="128" type="line"/>
-      <point x="519" y="128"/>
+      <point x="53" y="383"/>
+      <point x="53" y="383"/>
+      <point x="141" y="396" type="qcurve"/>
+      <point x="141" y="396" type="line"/>
+      <point x="227" y="410"/>
+      <point x="227" y="410"/>
+      <point x="237" y="316" type="qcurve"/>
+      <point x="237" y="316" type="line"/>
+      <point x="249" y="222"/>
+      <point x="329" y="128"/>
+      <point x="419" y="128" type="qcurve"/>
+      <point x="419" y="128" type="line"/>
+      <point x="510" y="128"/>
       <point x="604" y="308"/>
       <point x="604" y="462" type="qcurve"/>
       <point x="604" y="462" type="line"/>
@@ -56,10 +56,10 @@
       <point x="510" y="776"/>
       <point x="422" y="776" type="qcurve"/>
       <point x="422" y="776" type="line"/>
-      <point x="380" y="776"/>
-      <point x="306" y="728"/>
-      <point x="291" y="699" type="qcurve"/>
-      <point x="291" y="699" type="line"/>
+      <point x="372" y="776"/>
+      <point x="303" y="722"/>
+      <point x="282" y="681" type="qcurve"/>
+      <point x="282" y="681" type="line"/>
       <point x="265" y="648"/>
       <point x="265" y="648"/>
       <point x="178" y="680" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght400-ROND0.ufo/glyphs/four.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght400-ROND0.ufo/glyphs/four.glif
@@ -4,12 +4,12 @@
   <unicode hex="0034"/>
   <outline>
     <contour>
-      <point x="518" y="81" type="qcurve"/>
-      <point x="518" y="414" type="line"/>
-      <point x="524" y="436" type="line"/>
-      <point x="524" y="1385" type="line" smooth="yes"/>
-      <point x="524" y="1452" name="inserted"/>
-      <point x="524" y="1452"/>
+      <point x="508" y="81" type="qcurve"/>
+      <point x="508" y="414" type="line"/>
+      <point x="518" y="436" type="line"/>
+      <point x="518" y="1385" type="line" smooth="yes"/>
+      <point x="518" y="1452" name="inserted"/>
+      <point x="518" y="1452"/>
       <point x="606" y="1452" type="qcurve"/>
       <point x="606" y="1452" type="line"/>
       <point x="686" y="1452"/>
@@ -20,8 +20,8 @@
       <point x="686" y="0"/>
       <point x="603" y="0" type="qcurve"/>
       <point x="603" y="0" type="line"/>
-      <point x="518" y="0"/>
-      <point x="518" y="0" name="inserted"/>
+      <point x="508" y="0"/>
+      <point x="508" y="0" name="inserted"/>
     </contour>
     <contour>
       <point x="91" y="362" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght400-ROND0.ufo/glyphs/nine.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght400-ROND0.ufo/glyphs/nine.glif
@@ -4,57 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="263" y="944" type="line"/>
-      <point x="263" y="789"/>
-      <point x="349" y="634"/>
-      <point x="438" y="634" type="qcurve"/>
-      <point x="438" y="634" type="line"/>
-      <point x="526" y="634"/>
-      <point x="611" y="794"/>
-      <point x="611" y="944" type="qcurve"/>
-      <point x="611" y="944" type="line"/>
-      <point x="611" y="1121"/>
-      <point x="520" y="1304"/>
-      <point x="433" y="1304" type="qcurve"/>
-      <point x="433" y="1304" type="line"/>
-      <point x="351" y="1304"/>
-      <point x="263" y="1120"/>
-      <point x="263" y="944" type="qcurve"/>
+      <point x="437" y="1459" type="line"/>
+      <point x="609" y="1459"/>
+      <point x="801" y="1215"/>
+      <point x="801" y="977" type="qcurve"/>
+      <point x="801" y="977" type="line"/>
+      <point x="801" y="768"/>
+      <point x="609" y="487"/>
+      <point x="437" y="487" type="qcurve"/>
+      <point x="437" y="487" type="line"/>
+      <point x="258" y="487"/>
+      <point x="73" y="704"/>
+      <point x="73" y="945" type="qcurve"/>
+      <point x="73" y="945" type="line"/>
+      <point x="73" y="1196"/>
+      <point x="274" y="1459"/>
+      <point x="437" y="1459" type="qcurve"/>
     </contour>
     <contour>
-      <point x="385" y="-16" type="line" smooth="yes"/>
-      <point x="353" y="-71"/>
-      <point x="353" y="-70"/>
-      <point x="272" y="-20" type="qcurve"/>
-      <point x="272" y="-20" type="line"/>
-      <point x="192" y="28"/>
-      <point x="193" y="28" name="inserted"/>
-      <point x="230" y="89" type="qcurve" smooth="yes"/>
-      <point x="379" y="336" type="line" smooth="yes"/>
-      <point x="428" y="417"/>
-      <point x="486" y="503"/>
-      <point x="531" y="548" type="qcurve"/>
-      <point x="526" y="554" type="line"/>
-      <point x="523" y="551" type="line"/>
-      <point x="504" y="531"/>
-      <point x="424" y="502"/>
-      <point x="377" y="502" type="qcurve"/>
-      <point x="377" y="502" type="line"/>
-      <point x="228" y="502"/>
-      <point x="73" y="768"/>
-      <point x="73" y="962" type="qcurve"/>
-      <point x="73" y="962" type="line"/>
-      <point x="73" y="1194"/>
-      <point x="274" y="1458"/>
-      <point x="437" y="1458" type="qcurve"/>
-      <point x="437" y="1458" type="line"/>
-      <point x="609" y="1458"/>
-      <point x="801" y="1213"/>
-      <point x="801" y="994" type="qcurve"/>
-      <point x="801" y="994" type="line"/>
-      <point x="801" y="837"/>
-      <point x="738" y="592"/>
-      <point x="664" y="465" type="qcurve" smooth="yes"/>
+      <point x="651" y="977" type="line"/>
+      <point x="801" y="977" type="line"/>
+      <point x="801" y="793"/>
+      <point x="723" y="566"/>
+      <point x="632" y="410" type="qcurve" smooth="yes"/>
+      <point x="409" y="26" type="line" smooth="yes"/>
+      <point x="367" y="-46"/>
+      <point x="366" y="-45"/>
+      <point x="291" y="2" type="qcurve"/>
+      <point x="291" y="2" type="line"/>
+      <point x="207" y="51"/>
+      <point x="206" y="51"/>
+      <point x="236" y="100" type="qcurve" smooth="yes"/>
+      <point x="367" y="317" type="line" smooth="yes"/>
+      <point x="420" y="404"/>
+      <point x="627" y="714"/>
+      <point x="635" y="784" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="435" y="1305" type="qcurve"/>
+      <point x="435" y="1305" type="line"/>
+      <point x="350" y="1305"/>
+      <point x="265" y="1133"/>
+      <point x="265" y="967" type="qcurve"/>
+      <point x="265" y="967" type="line"/>
+      <point x="265" y="800"/>
+      <point x="351" y="635"/>
+      <point x="440" y="635" type="qcurve"/>
+      <point x="440" y="635" type="line"/>
+      <point x="530" y="635"/>
+      <point x="613" y="809"/>
+      <point x="613" y="969" type="qcurve"/>
+      <point x="613" y="969" type="line"/>
+      <point x="613" y="1136"/>
+      <point x="527" y="1305"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght400-ROND0.ufo/glyphs/one.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght400-ROND0.ufo/glyphs/one.glif
@@ -12,23 +12,23 @@
       <point x="384" y="0"/>
       <point x="384" y="0"/>
       <point x="384" y="96" type="qcurve"/>
-      <point x="384" y="1206" type="line"/>
-      <point x="187" y="1061" type="line" smooth="yes"/>
-      <point x="103" y="999" name="inserted"/>
-      <point x="103" y="998"/>
-      <point x="52" y="1072" type="qcurve"/>
-      <point x="52" y="1072" type="line"/>
-      <point x="1" y="1146"/>
-      <point x="1" y="1146"/>
-      <point x="87" y="1210" type="qcurve" smooth="yes"/>
-      <point x="341" y="1401" type="line" smooth="yes"/>
-      <point x="433" y="1470"/>
-      <point x="433" y="1470"/>
-      <point x="506" y="1470" type="qcurve"/>
-      <point x="506" y="1470" type="line"/>
-      <point x="572" y="1470"/>
-      <point x="572" y="1470"/>
-      <point x="572" y="1370" type="qcurve"/>
+      <point x="384" y="1186" type="line"/>
+      <point x="187" y="1041" type="line" smooth="yes"/>
+      <point x="103" y="979" name="inserted"/>
+      <point x="103" y="978"/>
+      <point x="52" y="1052" type="qcurve"/>
+      <point x="52" y="1052" type="line"/>
+      <point x="1" y="1126"/>
+      <point x="1" y="1126"/>
+      <point x="87" y="1190" type="qcurve" smooth="yes"/>
+      <point x="341" y="1381" type="line" smooth="yes"/>
+      <point x="433" y="1450"/>
+      <point x="433" y="1450"/>
+      <point x="506" y="1450" type="qcurve"/>
+      <point x="506" y="1450" type="line"/>
+      <point x="572" y="1450"/>
+      <point x="572" y="1450"/>
+      <point x="572" y="1350" type="qcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght400-ROND0.ufo/glyphs/six.glif
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght400-ROND0.ufo/glyphs/six.glif
@@ -4,57 +4,59 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="265" y="485" type="line"/>
-      <point x="265" y="308"/>
-      <point x="356" y="125"/>
-      <point x="443" y="125" type="qcurve"/>
-      <point x="443" y="125" type="line"/>
-      <point x="525" y="125"/>
-      <point x="613" y="309"/>
-      <point x="613" y="485" type="qcurve"/>
-      <point x="613" y="485" type="line"/>
-      <point x="613" y="640"/>
-      <point x="527" y="795"/>
-      <point x="438" y="795" type="qcurve"/>
-      <point x="438" y="795" type="line"/>
-      <point x="350" y="795"/>
-      <point x="265" y="635"/>
-      <point x="265" y="485" type="qcurve"/>
-    </contour>
-    <contour>
       <point x="439" y="-29" type="line"/>
       <point x="267" y="-29"/>
       <point x="75" y="234"/>
       <point x="75" y="453" type="qcurve"/>
       <point x="75" y="453" type="line"/>
-      <point x="75" y="610"/>
-      <point x="138" y="837"/>
-      <point x="212" y="964" type="qcurve" smooth="yes"/>
-      <point x="491" y="1445" type="line" smooth="yes"/>
-      <point x="523" y="1500"/>
-      <point x="523" y="1499"/>
-      <point x="604" y="1449" type="qcurve"/>
-      <point x="604" y="1449" type="line"/>
-      <point x="684" y="1401"/>
-      <point x="683" y="1401" name="inserted"/>
-      <point x="646" y="1340" type="qcurve" smooth="yes"/>
-      <point x="497" y="1093" type="line" smooth="yes"/>
-      <point x="448" y="1012"/>
-      <point x="390" y="926"/>
-      <point x="345" y="881" type="qcurve"/>
-      <point x="350" y="875" type="line"/>
-      <point x="353" y="878" type="line"/>
-      <point x="372" y="898"/>
-      <point x="452" y="927"/>
-      <point x="499" y="927" type="qcurve"/>
-      <point x="499" y="927" type="line"/>
-      <point x="648" y="927"/>
-      <point x="803" y="679"/>
-      <point x="803" y="485" type="qcurve"/>
-      <point x="803" y="485" type="line"/>
-      <point x="803" y="253"/>
+      <point x="75" y="662"/>
+      <point x="267" y="937"/>
+      <point x="439" y="937" type="qcurve"/>
+      <point x="439" y="937" type="line"/>
+      <point x="618" y="947"/>
+      <point x="803" y="699"/>
+      <point x="803" y="465" type="qcurve"/>
+      <point x="803" y="465" type="line"/>
+      <point x="803" y="243"/>
       <point x="602" y="-29"/>
       <point x="439" y="-29" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="225" y="453" type="line"/>
+      <point x="75" y="453" type="line"/>
+      <point x="75" y="637"/>
+      <point x="153" y="864"/>
+      <point x="244" y="1020" type="qcurve" smooth="yes"/>
+      <point x="481" y="1427" type="line" smooth="yes"/>
+      <point x="523" y="1499"/>
+      <point x="524" y="1498"/>
+      <point x="599" y="1451" type="qcurve"/>
+      <point x="599" y="1451" type="line"/>
+      <point x="683" y="1402"/>
+      <point x="683" y="1402"/>
+      <point x="654" y="1353" type="qcurve" smooth="yes"/>
+      <point x="509" y="1113" type="line" smooth="yes"/>
+      <point x="457" y="1026"/>
+      <point x="249" y="716"/>
+      <point x="241" y="646" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="443" y="125" type="qcurve"/>
+      <point x="443" y="125" type="line"/>
+      <point x="528" y="125"/>
+      <point x="613" y="297"/>
+      <point x="613" y="463" type="qcurve"/>
+      <point x="613" y="463" type="line"/>
+      <point x="613" y="630"/>
+      <point x="527" y="795"/>
+      <point x="438" y="795" type="qcurve"/>
+      <point x="438" y="795" type="line"/>
+      <point x="348" y="795"/>
+      <point x="265" y="621"/>
+      <point x="265" y="461" type="qcurve"/>
+      <point x="265" y="461" type="line"/>
+      <point x="265" y="294"/>
+      <point x="351" y="125"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
Imported from fb-wip branch at commit https://github.com/googlefonts/googlesans-flex/commit/05e07338e2d18fc94a20a0deb76ecba831dc2884

Compatibility error at font compile time:

```
Fonts had differing number of contours in glyph nine:
 * 13 fonts had 3
 * 55 fonts had 2
Fonts had differing number of contours in glyph six:
 * 14 fonts had 3
 * 54 fonts had 2
 
fontmake.errors.FontmakeError: In 'regular/GoogleSansFlex.designspace': Compatibility check failed
```

Unable to build font for review.  @dberlow @sannorozco We can re-attempt a build to support your font review as soon as the outline compatibility issue is addressed.  Don't hesitate to reach out when you are prepared to compile fonts. We can trigger the build anytime.

cc @MariannaPaszkowska 