### PR TITLE
Fix file size analysis on import

### DIFF
--- a/.github/actions/file-size/action.yml
+++ b/.github/actions/file-size/action.yml
@@ -1,5 +1,12 @@
 name: file-size
 description: Analyzes TTFs to give a breakdown of their size
+inputs:
+  path:
+    description: the path that maps to the repository root
+    required: true
+    default: /github/workspace
 runs:
   using: docker
   image: Dockerfile
+  args:
+    - ${{ inputs.path }}

--- a/.github/actions/file-size/entrypoint.sh
+++ b/.github/actions/file-size/entrypoint.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 
-if [ ! -e /github/workspace/fonts ] ; then
-    echo "ERROR: built fonts not found at /github/workspace/fonts"
+# If $1 is specified, use that as the path
+if [ -n "$1" ] ; then
+    REPO_PATH=$1
+else
+    REPO_PATH="/github/workspace"
+fi
+
+if [ ! -d "$REPO_PATH/fonts" ] ; then
+    echo "ERROR: built fonts not found at $REPO_PATH/fonts"
     exit 1
 fi
 
-# shellcheck disable=SC2038
-find /github/workspace/fonts -name '*.ttf' -type f | xargs python3 /report-filesize.py
+find "$REPO_PATH/fonts" -name '*.ttf' -type f -print0 | xargs -0 python3 /report-filesize.py

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "The name of the branch to import from"
+        description: The name of the branch to import from
         required: true
       email:
         description: Your GitHub email address (CLA approved)
@@ -34,7 +34,7 @@ jobs:
             echo "The target branch '$TARGET_BRANCH' already exists, updating."
             git worktree add --quiet ../target "$TARGET_BRANCH"
           else
-          echo "The target branch '$TARGET_BRANCH' doesn't exist, creating."
+            echo "The target branch '$TARGET_BRANCH' doesn't exist, creating."
             git fetch origin main # because shallow
             git worktree add --quiet ../target -b "$TARGET_BRANCH" origin/main
           fi
@@ -81,8 +81,10 @@ jobs:
         continue-on-error: true
       - name: proof
         run: cd "$GITHUB_WORKSPACE/target" && make proof
-      - name: Analyze file size # FIXME: currently can't find font files
+      - name: Analyze file size
         uses: ./main/.github/actions/file-size
+        with:
+          path: /github/workspace/target
         continue-on-error: true
       - name: Archive artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
I believe these are the necessary changes needed to have file size analysis running on the import workflow. It would be good to test this and make sure before merging, however because currently imports from `fb-wip` don't build, I don't know if the action will work as intended because it's not run

Essentially what I've done is allowed for configuring the path that the size analysis GitHub action looks at, and configured it correctly for the import workflow. I also made the font discovery slightly more robust and fixed an instance of incorrect indentation I noticed