### PR TITLE
Add script to disable glyphs for compilation

### DIFF
--- a/scripts/disable-glyphs.py
+++ b/scripts/disable-glyphs.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from fontTools.designspaceLib import DesignSpaceDocument
+from ufoLib2 import Font
+
+parser = argparse.ArgumentParser()
+parser.add_argument("designspace", type=Path, help="The Designspace to use.")
+parser.add_argument("glyph", nargs="+", help="The glyphs to ignore when compiling.")
+parsed_args = parser.parse_args()
+skip_export_glyphs: list[str] = parsed_args.glyph
+
+designspace = DesignSpaceDocument.fromfile(parsed_args.designspace)
+ufos = designspace.loadSourceFonts(Font.open)
+
+for ufo in ufos:
+    ufo.lib["public.skipExportGlyphs"] = skip_export_glyphs
+    ufo.save()


### PR DESCRIPTION
@MariannaPaszkowska As requested.

To get incompatible sources to build for reviews:

1. If necessary, make a copy of the Designspace under review and comment our or remove the sources (`<source>...</source>` with its content) you don't care about
2. Note which glyphs are incompatible
3. Run the script `scripts/disable-glyphs.py` to update all UFOs with the list of glyphs to ignore, like so, inside the venv: `python scripts/disable-glyphs.py sources/roman/GoogleSansFlexCONTRUCTION.designspace Oslash-bar oslash-bar cent Oslash cent.tf oslash`.
4. If building still complains about incompatibilities, add those glyphs to the list and run the script again.