### PR TITLE
Make burndown generator more robust

### DIFF
--- a/.github/workflows/burndown.yaml
+++ b/.github/workflows/burndown.yaml
@@ -1,5 +1,9 @@
 name: Progress chart
-on: [push]
+on:
+  push:
+    branches:
+      - fb-wip
+      - import-fb-wip
 
 jobs:
   burndown:

--- a/scripts/gs-progress-burndown.py
+++ b/scripts/gs-progress-burndown.py
@@ -667,9 +667,22 @@ def main() -> None:
     ):
         print("Opening UFOs", end="")
         for ufo_path in config.ufo_finder(tmpdir):
-            ufo = Font.open(ufo_path)
+            try:
+                ufo = Font.open(ufo_path)
+            except Exception as e:
+                relative_path = ufo_path.relative_to(tmpdir)
+                print(f"\nReading UFO '{relative_path}' failed, skipping: {e}")
+                continue
             print(".", end="", flush=True)
-            for glyph in ufo:
+            for glyph_name in ufo.keys():
+                try:
+                    glyph = ufo[glyph_name]
+                except Exception as e:
+                    relative_path = ufo_path.relative_to(tmpdir)
+                    print(
+                        f"\nReading glyph '{glyph_name}' from UFO '{relative_path}' failed, skipping: {e}"
+                    )
+                    continue
                 counts = counts_by_date[date]
                 for i, status in enumerate(config.statuses):
                     if glyph_matches_status(glyph, status):


### PR DESCRIPTION
Hello @MariannaPaszkowska @chrissimpkins! I hope you are having a nice break, and am happy to share my first PR for the Flex project, which is ready for review/merging when you are back :tada:

---

Previously, if the generator could not read a config or designspace file, it would skip over them, but where it could not parse a UFO or glif file [it would crash](https://github.com/googlefonts/googlesans-flex/actions/runs/3787094936/jobs/6438579220).

This commit extends the same skipping behaviour to UFOs and glif files, as the burndown generator should be flexible enough to encounter git histories with WIP commits and still produce a graph for them.

For each day, the current behaviour is to [print a warning](https://github.com/googlefonts/googlesans-flex/actions/runs/3787766380/jobs/6439865506#step:4:482) and implicitly show no status for affected glyphs, which is visible as a dip on the graph. This could be adjusted if unhelpful: for example, we could use a different commit to represent the day, or skip adding the day's datapoint to the chart entirely. Is there a particular behaviour you would prefer?