### PR TITLE
Workflow tweaks

### DIFF
--- a/.github/actions/import/scripts/fix-metadata-in-sources.py
+++ b/.github/actions/import/scripts/fix-metadata-in-sources.py
@@ -64,4 +64,8 @@ for source in designspace.sources:
     # TODO: get version from config.yaml once supported
     ufo.info.versionMajor = 1
     ufo.info.versionMinor = 0
+
+    # Clear out export bans to avoid confusion.
+    ufo.lib["public.skipExportGlyphs"] = []
+
     ufo.save()

--- a/.github/actions/ufodiff/Dockerfile
+++ b/.github/actions/ufodiff/Dockerfile
@@ -5,5 +5,6 @@ RUN apt update && apt install git -y --no-install-recommends
 RUN pip install ufodiff
 
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Minor tweaks:

1. Make ufodiff run again
2. Clear out glyph export bans to avoid confusion, they seem to be remnants of GS.

@MariannaPaszkowska we can make a test import after this merge :)