### PR TITLE
Remove config file copying during import

### DIFF
--- a/.github/actions/import/entrypoint.py
+++ b/.github/actions/import/entrypoint.py
@@ -58,5 +58,4 @@ for designspace_path in gftools_config["sources"]:
         TARGET_DIR / "sources" / designspace_path,
     )
 
-shutil.copy2(SOURCE_DIR / CONFIG_FILE, TARGET_DIR / CONFIG_FILE)
 logging.info("Done!")


### PR DESCRIPTION
We should assume that the target (main) has a better config as it's unlikely to be directly updated by Font Bureau

Thanks to @madig for spotting this flaw in #158