### PR TITLE
Import scripts: make code more testable

### DIFF
--- a/.github/actions/import/entrypoint.py
+++ b/.github/actions/import/entrypoint.py
@@ -15,12 +15,11 @@
 
 import logging
 from pathlib import Path
-import shutil
 import yaml
 
-from scripts.gs_merge_designspace import main as merge
-from scripts.gs_normalize_designspace import main as normalize
-from scripts.fix_metadata_in_sources import main as fix_metadata
+from scripts.gs_merge_designspace import merge_designspace
+from scripts.gs_normalize_designspace import normalize
+from scripts.fix_metadata_in_sources import fix_metadata
 
 REPLACE_TARGET_DESIGNSPACE = False
 FOLLOW_GLYPHS = True  # while sources are in flux
@@ -39,7 +38,7 @@ gftools_config = yaml.safe_load(file_text)
 for designspace_path in gftools_config["sources"]:
     logging.info(f"Merging {designspace_path}")
     designspace_path_target = designspace_path.replace("roman/", "regular/", 1)
-    merge(
+    merge_designspace(
         SOURCE_DIR / "sources" / designspace_path,
         TARGET_DIR / "sources" / designspace_path_target,
         GLYPH_LIST,

--- a/.github/actions/import/scripts/fix_metadata_in_sources.py
+++ b/.github/actions/import/scripts/fix_metadata_in_sources.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from typing import Optional, Sequence
 
 from fontTools.designspaceLib import DesignSpaceDocument
 from fontTools.misc.fixedTools import otRound
@@ -39,7 +40,14 @@ INSTANCE_LOCATIONS = {
 POSTSCRIPT_NAMES = "public.postscriptNames"
 
 
-def main(designspace_path: Path) -> None:
+def main(args: Optional[Sequence[str]] = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("designspace", type=Path)
+    parsed_args = parser.parse_args(args=args)
+    fix_metadata(parsed_args.designspace_path)
+
+
+def fix_metadata(designspace_path: Path) -> None:
     designspace = DesignSpaceDocument.fromfile(designspace_path)
     designspace.loadSourceFonts(Font.open)
     designspace.instances.clear()
@@ -189,7 +197,4 @@ def recompute_win_metrics(fonts: list[Font]) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("designspace", type=Path)
-    parsed_args = parser.parse_args()
-    main(parsed_args.designspace)
+    main()

--- a/.github/actions/import/scripts/gs_merge_designspace.py
+++ b/.github/actions/import/scripts/gs_merge_designspace.py
@@ -34,7 +34,7 @@ import shutil
 import sys
 import os.path
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Sequence, Optional
 
 from fontTools.designspaceLib import DesignSpaceDocument, SourceDescriptor
 from .internal.reachable_glyphs import referenced_as_components
@@ -47,7 +47,56 @@ SKIP_EXPORT_GLYPHS_KEY = "public.skipExportGlyphs"
 logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 
 
-def main(
+def main(args: Optional[Sequence[str]] = None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source",
+        type=Path,
+        help="Path to source .designspace file.",
+        required=True,
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        help="Path to target .designspace file.",
+        required=True,
+    )
+    parser.add_argument(
+        "--import-glyphs-file",
+        type=Path,
+        help=(
+            "Path to text file with glyph names to import (one per line). "
+            "Also imports any kerning pair that mentions them."
+        ),
+        required=True,
+    )
+    parser.add_argument(
+        "--replace-target-designspace",
+        action="store_true",
+        help=(
+            "Import the source Designspace verbatim, for when it is in flux and "
+            "matching sources makes little sense."
+        ),
+    )
+    parser.add_argument(
+        "--follow-glyphs",
+        action="store_true",
+        help=(
+            "Also import glyphs that are referenced but not explicitly listed in "
+            "the import list."
+        ),
+    )
+    parsed_args = parser.parse_args(args=args)
+    merge_designspace(
+        parsed_args.source,
+        parsed_args.target,
+        parsed_args.import_glyphs_file,
+        parsed_args.replace_target_designspace,
+        parsed_args.follow_glyphs,
+    )
+
+
+def merge_designspace(
     source_path: Path,
     target_path: Path,
     import_glyphs_file: Path,
@@ -59,9 +108,6 @@ def main(
         name.strip() for name in import_glyphs_file.read_text().split("\n") if name
     ]
     import_glyphs = set(import_glyphs_verbatim)
-
-    replace_target_designspace: bool = replace_target_designspace
-    follow_glyphs: bool = follow_glyphs
 
     # The path to the shared feature file that all UFOs should point to:
     family_fea_path = target_path.parent / "family.fea"
@@ -408,49 +454,4 @@ def find_matching_source(
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--source",
-        type=Path,
-        help="Path to source .designspace file.",
-        required=True,
-    )
-    parser.add_argument(
-        "--target",
-        type=Path,
-        help="Path to target .designspace file.",
-        required=True,
-    )
-    parser.add_argument(
-        "--import-glyphs-file",
-        type=Path,
-        help=(
-            "Path to text file with glyph names to import (one per line). "
-            "Also imports any kerning pair that mentions them."
-        ),
-        required=True,
-    )
-    parser.add_argument(
-        "--replace-target-designspace",
-        action="store_true",
-        help=(
-            "Import the source Designspace verbatim, for when it is in flux and "
-            "matching sources makes little sense."
-        ),
-    )
-    parser.add_argument(
-        "--follow-glyphs",
-        action="store_true",
-        help=(
-            "Also import glyphs that are referenced but not explicitly listed in "
-            "the import list."
-        ),
-    )
-    parsed_args = parser.parse_args()
-    main(
-        parsed_args.source,
-        parsed_args.target,
-        parsed_args.import_glyphs_file,
-        parsed_args.replace_target_designspace,
-        parsed_args.follow_glyphs,
-    )
+    main()

--- a/.github/actions/import/scripts/gs_normalize_designspace.py
+++ b/.github/actions/import/scripts/gs_normalize_designspace.py
@@ -18,6 +18,7 @@ source conventions."""
 
 import argparse
 from pathlib import Path
+from typing import Sequence, Optional
 
 from fontTools.designspaceLib import DesignSpaceDocument
 
@@ -26,7 +27,19 @@ from .internal import normalize
 ROOT_DIR = Path(__file__).parent.parent
 
 
-def main(source_dir: Path) -> None:
+def main(args: Optional[Sequence[str]] = None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        default=ROOT_DIR / "sources",
+        help="Path to source directory.",
+    )
+    parsed_args = parser.parse_args(args=args)
+    normalize(parsed_args.source_dir)
+
+
+def normalize(source_dir: Path) -> None:
     for designspace_path in source_dir.glob("*.designspace"):
         designspace = DesignSpaceDocument.fromfile(designspace_path)
 
@@ -38,12 +51,4 @@ def main(source_dir: Path) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--source-dir",
-        type=Path,
-        default=ROOT_DIR / "sources",
-        help="Path to source directory.",
-    )
-    parsed_args = parser.parse_args()
-    main(parsed_args.source_dir)
+    main()


### PR DESCRIPTION
Very low priority PR, simply addressing the code review comments Jany had [here](https://github.com/googlefonts/googlesans-flex/pull/104#pullrequestreview-1237177662)

Technical jargon:

Moves argument parsing into a main function and the formerly-main function into a function describing what it does. This makes imports more readable. Further, the main function is able to access a sequence of strings, which are parsed as though they were commandline arguments, making the code more testable.

I'm hoping the the type hints are what's expected, not worked much with Python type hints