### PR TITLE
Release workflow: fix bumping version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: [linux, googlefonts-64cores-256GB]
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.x
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.11"
       - name: Install sys tools/deps
         run: |
           sudo apt-get update

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,18 +26,10 @@ jobs:
         shell: bash
         # Set the archive name to repo name + "-assets" e.g "MavenPro-assets"
         run: echo "ZIP_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')-fonts" >> $GITHUB_ENV
-        # If a new release is cut, use the release tag to auto-bump the source files
+      # If a new release is cut, use the release tag to auto-bump the source files
       - name: Bump release
         if: github.event_name == 'release'
-        run: |
-          . venv/bin/activate
-          SRCS=$(yq e ".sources[]" sources/config.yaml)
-          TAG_NAME=${GITHUB_REF/refs\/tags\//}
-          echo "Bumping $SRCS to $TAG_NAME"
-          for src in $SRCS
-          do
-            bumpfontversion sources/$src --new-version $TAG_NAME;
-          done
+        run: make bump-to-tag
       - name: Build font
         run: make build
       - name: Check with fontbakery

--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,6 @@ file-size: build
 
 progress-chart: venv
 	. venv/bin/activate && python scripts/gs-progress-burndown.py
+
+bump-to-tag: venv
+	. venv/bin/activate && python3 scripts/bump-to-tag.py

--- a/scripts/bump-to-tag.py
+++ b/scripts/bump-to-tag.py
@@ -17,6 +17,7 @@ import os
 import yaml
 from pathlib import Path
 
+
 def main():
     try:
         tag_name = os.environ["GITHUB_REF"].replace("refs/tags/", "")
@@ -32,7 +33,7 @@ def main():
     for source in gftools_config["sources"]:
         print(f"Bumping {source} to {tag_name}")
         cmd = subprocess.run(
-            f". venv/bin/activate && bumpfontversion sources/{source} --new-version {tag_name}",
+            f"bumpfontversion sources/{source} --new-version {tag_name}",
             shell=True,
             capture_output=True,
             text=True,

--- a/scripts/bump-to-tag.py
+++ b/scripts/bump-to-tag.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 Google Sans Project Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import os
+import yaml
+from pathlib import Path
+
+def main():
+    try:
+        tag_name = os.environ["GITHUB_REF"].replace("refs/tags/", "")
+        workspace = Path(os.environ["GITHUB_WORKSPACE"])
+        config_path = workspace / "sources" / "config.yaml"
+        file_text = config_path.read_text()
+    except (KeyError, FileNotFoundError) as e:
+        print(e)
+        print("This script is intended to be run by CI during a release. Exiting")
+        exit(2)
+
+    gftools_config = yaml.safe_load(file_text)
+    for source in gftools_config["sources"]:
+        print(f"Bumping {source} to {tag_name}")
+        cmd = subprocess.run(
+            f". venv/bin/activate && bumpfontversion sources/{source} --new-version {tag_name}",
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        if cmd.returncode != 0:
+            print("bumpfontversion failed!")
+            print(cmd.stderr)
+            exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Will close #192 

It's a Python script for bumping the font version. The old bash / in workflow version was unreliable (venv wasn't yet necessarily made) and pulled in a heavy dependecy (`yq`, a snap). This simple script aims to replace both

I've also pinned the Python version of the CI to 3.11 both for consistency and so we don't get thrust into 3.12 without warning, as Nikolaus is concerned with dependencies when that happens

Technical jargon:

I have to `subprocess.run` `bumpfontversion` because it's not designed to be run in a script as far as I can tell

~~Aside: `bumpfontversion` has no license, and is therefore proprietary (though [source available](https://github.com/simoncozens/bumpfontversion))~~ (edit: it's in the README of the repo)