### PR TITLE
Build & import workflows: remove installation of yq, pin Python

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,10 +11,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - name: Install sys tools/deps
-        run: |
-          sudo apt-get update
-          sudo snap install yq
       - uses: actions/cache@v3
         with:
           path: ./venv/

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -55,10 +55,10 @@ jobs:
             
           This commit was creating automatically using the GitHub workflow"
           git push -u origin "$TARGET_BRANCH"
-      - name: Set up Python 3.x
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.11"
       - uses: actions/cache@v3
         with:
           path: ./venv/

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -59,10 +59,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-      - name: Install yq
-        run: |
-          sudo apt-get update
-          sudo snap install yq
       - uses: actions/cache@v3
         with:
           path: ./venv/


### PR DESCRIPTION
Unused as of #201 in build, never needed in import

Will save a bit of time & money

Did mean to do this in #201 but lose track of the removal in a rebase

Also pinned Python version in import, the same as for build

Safe and easy to merge @MariannaPaszkowska, although low priority