### PR TITLE
Import workflow: support importing commits

### DIFF
--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: The name of the branch to import from
+        description: The Git reference to import from (branch name or 7 character commit reference)
         required: true
       email:
         description: Your GitHub email address (CLA approved)

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -17,17 +17,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: main
+          fetch-depth: 0
       - name: Prepare environment
         env:
-          SOURCE_BRANCH: ${{ github.event.inputs.branch }}
+          SOURCE_REF: ${{ github.event.inputs.branch }}
           TARGET_BRANCH: ${{ format('import-{0}', github.event.inputs.branch) }}
         run: |
           cd "$GITHUB_WORKSPACE/main"
-
-          # The clone is shallow, need to fetch other branches
-          git fetch origin "$SOURCE_BRANCH"
-          git branch "$SOURCE_BRANCH" "origin/$SOURCE_BRANCH"
-          git worktree add --quiet ../source "$SOURCE_BRANCH"
+          git worktree add --quiet ../source "$SOURCE_REF"
 
           # Try to fetch, OK if it doesn't exist (we'll create it)
           if git fetch origin "$TARGET_BRANCH" &>/dev/null ; then
@@ -35,14 +32,13 @@ jobs:
             git worktree add --quiet ../target "$TARGET_BRANCH"
           else
             echo "The target branch '$TARGET_BRANCH' doesn't exist, creating."
-            git fetch origin main # because shallow
             git worktree add --quiet ../target -b "$TARGET_BRANCH" origin/main
           fi
       - name: Run import scripts
         uses: ./main/.github/actions/import
       - name: Commit & push changes
         env:
-          SOURCE_BRANCH: ${{ github.event.inputs.branch }}
+          SOURCE_REF: ${{ github.event.inputs.branch }}
           TARGET_BRANCH: ${{ format('import-{0}', github.event.inputs.branch) }}
           GIT_EMAIL: ${{ github.event.inputs.email }}
         run: |
@@ -51,7 +47,7 @@ jobs:
           git config user.name "Import Script"
           git config user.email "$GIT_EMAIL"
           git add sources
-          git commit --quiet -m "Import from $SOURCE_BRANCH
+          git commit --quiet -m "Import from $SOURCE_REF
             
           This commit was creating automatically using the GitHub workflow"
           git push -u origin "$TARGET_BRANCH"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The "Use workflow from" determines which version of the import script will be us
 * As a developer of the import script, you can select a branch on which you're
   implementing fixes to the workflow, e.g. `fix-import-crash`.
 
-"The name of the branch to import from" is where the updated UFOs will be taken
+"The Git reference to import from" is where the updated UFOs will be taken
 from, e.g. `fb-wip`. The name of the target branch will be derived from that by
 prepending `import-`, e.g. `import-fb-wip`. The target branch will be created
 if it does not exist, or updated with a new commit otherwise.


### PR DESCRIPTION
@MariannaPaszkowska as requested in #117! Note that I would recommend you use the commit 594f926 as that's the one on fb-wip, whereas the one you linked me earlier was the merge commit from the import.

Technical jargon:

This actually simplifies the import workflow, just at the cost on giving up on shallow cloning the repo, since you can't `git fetch` a specific commit