### PR TITLE
Makefile: fix proof cmd

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,9 +35,8 @@ jobs:
         uses: f-actions/opentype-sanitizer@v2
         with:
           path: "fonts/variable/*.ttf"
-      # XXX: Broken with new gftools
-      # - name: proof
-      #   run: make proof
+      - name: proof
+        run: make proof
       - name: Analyze file size
         uses: ./.github/actions/file-size
         continue-on-error: true

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -80,9 +80,8 @@ jobs:
         uses: f-actions/opentype-sanitizer@v2
         with:
           path: "fonts/variable/*.ttf"
-      # XXX: Broken with new gftools
-      # - name: proof
-      #   run: cd "$GITHUB_WORKSPACE/target" && make proof
+      - name: proof
+        run: cd "$GITHUB_WORKSPACE/target" && make proof
       - name: Analyze file size
         uses: ./main/.github/actions/file-size
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,7 @@ dmypy.json
 
 # Project specific
 build*/
+
+# Proof intermediate files
+.ninja_log
+build.ninja

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test: venv build.stamp
 	. venv/bin/activate && fontbakery check-profile -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-shaping-report.html --ghmarkdown out/fontbakery/fontbakery-shaping-report.md qa/check-shaping.py $(shell find fonts/variable -type f)
 
 proof: venv build.stamp
-	. venv/bin/activate; mkdir -p out/ out/proof; gftools gen-html proof $(shell find fonts/variable -type f) -o out/proof
+	. venv/bin/activate; mkdir -p out/ out/proof; diffenator2 proof $(shell find fonts/variable -type f) -o out/proof
 
 images: venv build.stamp $(DRAWBOT_OUTPUT)
 	git add documentation/*.png && git commit -m "Rebuild images" documentation/*.png

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test: venv build.stamp
 	. venv/bin/activate && fontbakery check-profile -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-shaping-report.html --ghmarkdown out/fontbakery/fontbakery-shaping-report.md qa/check-shaping.py $(shell find fonts/variable -type f)
 
 proof: venv build.stamp
-	. venv/bin/activate; mkdir -p out/ out/proof; diffenator2 proof $(shell find fonts/variable -type f) -o out/proof
+	. venv/bin/activate; mkdir -p out/proof; diffenator2 proof $(shell find fonts/variable -type f) -o out/proof
 
 images: venv build.stamp $(DRAWBOT_OUTPUT)
 	git add documentation/*.png && git commit -m "Rebuild images" documentation/*.png


### PR DESCRIPTION
gen-html has been deprecated in favour of diffenator2.

My plan to fix this upstream is the following:

- Fix the ci for packaging gftools.
- add this commit to the original template.

Existing users of the googlefonts-project-template are currently ok since they're using gftools v0.9.21 which doesn't have the diffenator 2 update. It'll be broken for them as well if I fix the ci in gftools and don't update the template. Apologies for these issues. Went on holiday and forgot the state of most things.

fixes https://github.com/googlefonts/googlesans-flex/pull/241#issue-1532724211