### PR TITLE
Specify font version in config.yaml

### DIFF
--- a/sources/config.yaml
+++ b/sources/config.yaml
@@ -7,7 +7,7 @@ axisOrder:
   - wght
   - ROND
 familyName: Google Sans Flex
-# TODO: specify version once the option is available
+version: "1.002"
 # The existing UFO sources are quadratics, so it probably does not make sense
 # to build OTFs. Also, Google Sans doesn't build OTFs, so it makes sense to do
 # the same for Flex


### PR DESCRIPTION
Low priority PR, but now that we're using the latest & greatest gftools, we might as well take advantage of being able to specify the font version directly in the config.

~~I've also updated the metadata fixing script to read this version value instead of being hardcoded~~

(Addendum: internal discussion about storing version as string or float [link](https://daltonmaag.slack.com/archives/G010DM236JJ/p1673951030651279))