### PR TITLE
Fix vertical metrics on import

### DIFF
--- a/.github/actions/import/scripts/fix_metadata_in_sources.py
+++ b/.github/actions/import/scripts/fix_metadata_in_sources.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 from fontTools.designspaceLib import DesignSpaceDocument
 from fontTools.misc.fixedTools import otRound
+from fontTools.pens.boundsPen import BoundsPen
 from ufoLib2 import Font
 
 # Defined in USER coordinates.
@@ -94,6 +95,37 @@ def main(designspace_path: Path) -> None:
         ufo.info.openTypeNameDesigner = "Google Sans Authors"
         ufo.info.openTypeNameDesignerURL = "https://design.google"
         ufo.info.openTypeNameLicense = "Google offers many fonts on open source terms. Google Sans Flex is not one of them. Please see google.com/fonts for alternatives."
+
+        # Use vertical metrics from Google Sans, times two.
+        ufo.info.openTypeHheaAscender = 1932
+        ufo.info.openTypeHheaDescender = -572
+        ufo.info.openTypeHheaLineGap = 0
+        ufo.info.openTypeOS2StrikeoutPosition = 612
+        ufo.info.openTypeOS2StrikeoutSize = 168
+        ufo.info.openTypeOS2SubscriptXOffset = 0
+        ufo.info.openTypeOS2SubscriptXSize = 1300
+        ufo.info.openTypeOS2SubscriptYOffset = 150
+        ufo.info.openTypeOS2SubscriptYSize = 1200
+        ufo.info.openTypeOS2SuperscriptXOffset = 0
+        ufo.info.openTypeOS2SuperscriptXSize = 1300
+        ufo.info.openTypeOS2SuperscriptYOffset = 700
+        ufo.info.openTypeOS2SuperscriptYSize = 1200
+        ufo.info.openTypeOS2TypoAscender = 1932
+        ufo.info.openTypeOS2TypoDescender = -572
+        ufo.info.openTypeOS2TypoLineGap = 0
+        ufo.info.postscriptUnderlinePosition = -320
+        ufo.info.postscriptUnderlineThickness = 168
+
+        # TODO: Adapt once the italic is being imported
+        ufo.info.openTypeHheaCaretSlopeRise = 1
+        ufo.info.openTypeHheaCaretSlopeRun = 0
+
+        # Use the xHeight from the "z" if not a sparse UFO:
+        if (glyph_z := ufo.get("z")) is not None:
+            bp = BoundsPen(ufo)
+            glyph_z.draw(bp)
+            ufo.info.xHeight = otRound(bp.bounds[3])
+
         # TODO: get version from config.yaml once supported
         ufo.info.versionMajor = 1
         ufo.info.versionMinor = 0

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1-ROND0.ufo/fontinfo.plist
@@ -106,6 +106,10 @@
     <string>2017/07/06 05:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -128,6 +132,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -196,6 +216,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1020.0</real>
+    <integer>1020</integer>
   </dict>
 </plist>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght1000-ROND0.ufo/fontinfo.plist
@@ -120,19 +120,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>650</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>75</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>600</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>650</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>350</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>600</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>
@@ -176,6 +176,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1020.0</real>
+    <integer>1020</integer>
   </dict>
 </plist>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth100-wght400-ROND0.ufo/fontinfo.plist
@@ -25,7 +25,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -53,19 +53,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1-ROND0.ufo/fontinfo.plist
@@ -80,7 +80,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -106,19 +106,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght1000-ROND0.ufo/fontinfo.plist
@@ -94,7 +94,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -120,19 +120,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth151-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth151-wght400-ROND0.ufo/fontinfo.plist
@@ -82,7 +82,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -110,19 +110,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1-ROND0.ufo/fontinfo.plist
@@ -96,7 +96,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -124,19 +124,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght1000-ROND0.ufo/fontinfo.plist
@@ -96,7 +96,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -124,19 +124,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -196,6 +196,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1020.0</real>
+    <integer>1020</integer>
   </dict>
 </plist>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth25-wght400-ROND0.ufo/fontinfo.plist
@@ -92,6 +92,10 @@
     <string>2017/07/06 05:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -114,6 +118,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth50-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth50-wght1-ROND0.ufo/fontinfo.plist
@@ -23,7 +23,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -49,19 +49,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth50-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth50-wght1000-ROND0.ufo/fontinfo.plist
@@ -23,7 +23,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -49,19 +49,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>217</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>25</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>200</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>217</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>117</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>200</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth50-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth50-wght400-ROND0.ufo/fontinfo.plist
@@ -23,7 +23,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -49,19 +49,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth85-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth85-wght1-ROND0.ufo/fontinfo.plist
@@ -23,7 +23,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -49,19 +49,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth85-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth85-wght1000-ROND0.ufo/fontinfo.plist
@@ -49,19 +49,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>520</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>60</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>480</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>520</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>280</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>480</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz144-wdth85-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz144-wdth85-wght400-ROND0.ufo/fontinfo.plist
@@ -23,7 +23,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -49,19 +49,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1-ROND0.ufo/fontinfo.plist
@@ -61,6 +61,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -83,6 +87,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -142,6 +162,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1020.0</real>
+    <integer>1020</integer>
   </dict>
 </plist>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght1000-ROND0.ufo/fontinfo.plist
@@ -76,19 +76,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>650</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>75</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>600</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>650</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>350</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>600</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0-GRAD-50.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0-GRAD-50.ufo/fontinfo.plist
@@ -41,6 +41,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -63,6 +67,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0-GRAD50.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0-GRAD50.ufo/fontinfo.plist
@@ -41,6 +41,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -63,6 +67,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght400-ROND0.ufo/fontinfo.plist
@@ -41,6 +41,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -76,6 +80,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght699-ROND0-SPARSE.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght699-ROND0-SPARSE.ufo/fontinfo.plist
@@ -25,7 +25,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -53,19 +53,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth100-wght700-ROND0-SPARSE.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth100-wght700-ROND0-SPARSE.ufo/fontinfo.plist
@@ -25,7 +25,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -53,19 +53,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1-ROND0.ufo/fontinfo.plist
@@ -51,6 +51,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -73,6 +77,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght1000-ROND0.ufo/fontinfo.plist
@@ -56,7 +56,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -84,19 +84,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/fontinfo.plist
@@ -51,6 +51,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -73,6 +77,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/fontinfo.plist
@@ -49,6 +49,14 @@
     <integer>0</integer>
     <key>openTypeHeadCreated</key>
     <string>2017/07/06 09:41:44</string>
+    <key>openTypeHheaAscender</key>
+    <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
+    <key>openTypeHheaDescender</key>
+    <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
     <integer>0</integer>
     <key>openTypeNameDesigner</key>
@@ -66,11 +74,31 @@
       <integer>7</integer>
     </array>
     <key>openTypeOS2StrikeoutPosition</key>
-    <integer>306</integer>
+    <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
-    <integer>84</integer>
+    <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
+    <key>openTypeOS2TypoAscender</key>
+    <integer>1932</integer>
+    <key>openTypeOS2TypoDescender</key>
+    <integer>-572</integer>
     <key>openTypeOS2TypoLineGap</key>
     <integer>0</integer>
     <key>openTypeOS2VendorID</key>
@@ -108,9 +136,9 @@
     <key>postscriptStemSnapV</key>
     <array/>
     <key>postscriptUnderlinePosition</key>
-    <integer>-160</integer>
+    <integer>-320</integer>
     <key>postscriptUnderlineThickness</key>
-    <integer>84</integer>
+    <integer>168</integer>
     <key>postscriptWeightName</key>
     <string>Thin</string>
     <key>styleName</key>
@@ -124,6 +152,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1020.0</real>
+    <integer>1020</integer>
   </dict>
 </plist>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1000-ROND0.ufo/fontinfo.plist
@@ -56,7 +56,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -84,19 +84,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -156,6 +156,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1020.0</real>
+    <integer>1020</integer>
   </dict>
 </plist>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght400-ROND0.ufo/fontinfo.plist
@@ -78,6 +78,10 @@
     <string>2017/07/06 05:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -96,6 +100,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth50-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth50-wght1-ROND0.ufo/fontinfo.plist
@@ -18,6 +18,10 @@
     <integer>0</integer>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -31,9 +35,25 @@
     <key>openTypeNameManufacturer</key>
     <string>Google LLC</string>
     <key>openTypeOS2StrikeoutPosition</key>
-    <integer>408</integer>
+    <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
-    <integer>112</integer>
+    <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>
@@ -73,9 +93,9 @@
     <key>postscriptStemSnapV</key>
     <array/>
     <key>postscriptUnderlinePosition</key>
-    <real>-213.33333333333337</real>
+    <integer>-320</integer>
     <key>postscriptUnderlineThickness</key>
-    <integer>112</integer>
+    <integer>168</integer>
     <key>postscriptWeightName</key>
     <string>Thin</string>
     <key>styleName</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth50-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth50-wght1000-ROND0.ufo/fontinfo.plist
@@ -23,7 +23,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -49,19 +49,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>217</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>25</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>200</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>217</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>117</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>200</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth50-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth50-wght400-ROND0.ufo/fontinfo.plist
@@ -18,6 +18,10 @@
     <integer>0</integer>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -38,6 +42,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth85-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth85-wght1-ROND0.ufo/fontinfo.plist
@@ -20,6 +20,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -39,9 +43,25 @@
       <integer>7</integer>
     </array>
     <key>openTypeOS2StrikeoutPosition</key>
-    <integer>551</integer>
+    <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
-    <integer>151</integer>
+    <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -85,9 +105,9 @@
     <key>postscriptStemSnapV</key>
     <array/>
     <key>postscriptUnderlinePosition</key>
-    <integer>-288</integer>
+    <integer>-320</integer>
     <key>postscriptUnderlineThickness</key>
-    <real>151.2</real>
+    <integer>168</integer>
     <key>postscriptWeightName</key>
     <string>Thin</string>
     <key>styleName</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth85-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth85-wght1000-ROND0.ufo/fontinfo.plist
@@ -49,19 +49,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>520</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>60</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>480</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>520</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>280</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>480</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth85-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth85-wght400-ROND0.ufo/fontinfo.plist
@@ -20,6 +20,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -42,6 +46,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1-ROND0.ufo/fontinfo.plist
@@ -107,6 +107,10 @@
     <integer>0</integer>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -127,6 +131,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth100-wght1000-ROND0.ufo/fontinfo.plist
@@ -80,7 +80,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -106,19 +106,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth100-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth100-wght400-ROND0.ufo/fontinfo.plist
@@ -125,6 +125,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -147,6 +151,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1-ROND0.ufo/fontinfo.plist
@@ -77,6 +77,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -99,6 +103,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -158,6 +178,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1086.0</real>
+    <integer>1086</integer>
   </dict>
 </plist>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth151-wght1000-ROND0.ufo/fontinfo.plist
@@ -80,7 +80,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -106,19 +106,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth151-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth151-wght400-ROND0.ufo/fontinfo.plist
@@ -81,6 +81,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -103,6 +107,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1-ROND0.ufo/fontinfo.plist
@@ -57,6 +57,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -79,6 +83,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -138,6 +158,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1086.0</real>
+    <integer>1086</integer>
   </dict>
 </plist>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght1000-ROND0.ufo/fontinfo.plist
@@ -92,7 +92,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -120,19 +120,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -192,6 +192,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1086.0</real>
+    <integer>1086</integer>
   </dict>
 </plist>

--- a/sources/regular/GoogleSansFlex-opsz6-wdth25-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/regular/GoogleSansFlex-opsz6-wdth25-wght400-ROND0.ufo/fontinfo.plist
@@ -20,6 +20,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -42,6 +46,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth100-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth100-wght1-ROND100.ufo/fontinfo.plist
@@ -33,6 +33,14 @@
 </string>
     <key>openTypeHeadCreated</key>
     <string>2017/07/06 05:41:44</string>
+    <key>openTypeHheaAscender</key>
+    <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
+    <key>openTypeHheaDescender</key>
+    <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
     <integer>0</integer>
     <key>openTypeNameDesigner</key>
@@ -45,8 +53,32 @@
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
     <string>https://design.google</string>
+    <key>openTypeOS2StrikeoutPosition</key>
+    <integer>612</integer>
+    <key>openTypeOS2StrikeoutSize</key>
+    <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
+    <key>openTypeOS2TypoAscender</key>
+    <integer>1932</integer>
+    <key>openTypeOS2TypoDescender</key>
+    <integer>-572</integer>
     <key>openTypeOS2TypoLineGap</key>
     <integer>0</integer>
     <key>openTypeOS2UnicodeRanges</key>
@@ -92,6 +124,10 @@
     <array/>
     <key>postscriptStemSnapV</key>
     <array/>
+    <key>postscriptUnderlinePosition</key>
+    <integer>-320</integer>
+    <key>postscriptUnderlineThickness</key>
+    <integer>168</integer>
     <key>styleMapStyleName</key>
     <string>regular</string>
     <key>styleName</key>
@@ -105,6 +141,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1020.0</real>
+    <integer>1020</integer>
   </dict>
 </plist>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth100-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth100-wght1000-ROND100.ufo/fontinfo.plist
@@ -156,19 +156,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>650</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>75</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>600</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>650</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>350</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>600</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>
@@ -212,6 +212,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1020.0</real>
+    <integer>1020</integer>
   </dict>
 </plist>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth100-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth100-wght400-ROND100.ufo/fontinfo.plist
@@ -86,7 +86,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -114,19 +114,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth151-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth151-wght1-ROND100.ufo/fontinfo.plist
@@ -23,7 +23,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -49,19 +49,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth151-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth151-wght1000-ROND100.ufo/fontinfo.plist
@@ -52,7 +52,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -78,19 +78,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth151-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth151-wght400-ROND100.ufo/fontinfo.plist
@@ -72,7 +72,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -100,19 +100,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth25-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth25-wght1-ROND100.ufo/fontinfo.plist
@@ -25,7 +25,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -53,19 +53,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth25-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth25-wght1000-ROND100.ufo/fontinfo.plist
@@ -62,7 +62,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -90,19 +90,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -162,6 +162,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1020.0</real>
+    <integer>1020</integer>
   </dict>
 </plist>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth25-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz144-wdth25-wght400-ROND100.ufo/fontinfo.plist
@@ -76,6 +76,14 @@
 </string>
     <key>openTypeHeadCreated</key>
     <string>2017/07/06 05:41:44</string>
+    <key>openTypeHheaAscender</key>
+    <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
+    <key>openTypeHheaDescender</key>
+    <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
     <integer>0</integer>
     <key>openTypeNameDesigner</key>
@@ -88,8 +96,32 @@
     <string>Google LLC</string>
     <key>openTypeNameManufacturerURL</key>
     <string>https://design.google</string>
+    <key>openTypeOS2StrikeoutPosition</key>
+    <integer>612</integer>
+    <key>openTypeOS2StrikeoutSize</key>
+    <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
+    <key>openTypeOS2TypoAscender</key>
+    <integer>1932</integer>
+    <key>openTypeOS2TypoDescender</key>
+    <integer>-572</integer>
     <key>openTypeOS2TypoLineGap</key>
     <integer>0</integer>
     <key>openTypeOS2UnicodeRanges</key>
@@ -135,6 +167,10 @@
     <array/>
     <key>postscriptStemSnapV</key>
     <array/>
+    <key>postscriptUnderlinePosition</key>
+    <integer>-320</integer>
+    <key>postscriptUnderlineThickness</key>
+    <integer>168</integer>
     <key>styleMapStyleName</key>
     <string>regular</string>
     <key>styleName</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth100-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth100-wght1-ROND100.ufo/fontinfo.plist
@@ -73,6 +73,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -95,6 +99,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -154,6 +174,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1020.0</real>
+    <integer>1020</integer>
   </dict>
 </plist>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth100-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth100-wght1000-ROND100.ufo/fontinfo.plist
@@ -122,19 +122,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>650</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>75</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>600</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>650</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>350</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>600</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth100-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth100-wght400-ROND100.ufo/fontinfo.plist
@@ -63,6 +63,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -85,6 +89,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth151-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth151-wght1-ROND100.ufo/fontinfo.plist
@@ -75,6 +75,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -97,6 +101,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth151-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth151-wght1000-ROND100.ufo/fontinfo.plist
@@ -68,7 +68,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -96,19 +96,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth151-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth151-wght400-ROND100.ufo/fontinfo.plist
@@ -53,6 +53,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -75,6 +79,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth25-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth25-wght1-ROND100.ufo/fontinfo.plist
@@ -69,6 +69,14 @@
     <integer>0</integer>
     <key>openTypeHeadCreated</key>
     <string>2017/07/06 09:41:44</string>
+    <key>openTypeHheaAscender</key>
+    <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
+    <key>openTypeHheaDescender</key>
+    <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
     <integer>0</integer>
     <key>openTypeNameDesigner</key>
@@ -86,11 +94,31 @@
       <integer>7</integer>
     </array>
     <key>openTypeOS2StrikeoutPosition</key>
-    <integer>306</integer>
+    <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
-    <integer>84</integer>
+    <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
+    <key>openTypeOS2TypoAscender</key>
+    <integer>1932</integer>
+    <key>openTypeOS2TypoDescender</key>
+    <integer>-572</integer>
     <key>openTypeOS2TypoLineGap</key>
     <integer>0</integer>
     <key>openTypeOS2VendorID</key>
@@ -128,9 +156,9 @@
     <key>postscriptStemSnapV</key>
     <array/>
     <key>postscriptUnderlinePosition</key>
-    <integer>-160</integer>
+    <integer>-320</integer>
     <key>postscriptUnderlineThickness</key>
-    <integer>84</integer>
+    <integer>168</integer>
     <key>postscriptWeightName</key>
     <string>Thin</string>
     <key>styleName</key>
@@ -144,6 +172,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1020.0</real>
+    <integer>1020</integer>
   </dict>
 </plist>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth25-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth25-wght1000-ROND100.ufo/fontinfo.plist
@@ -78,7 +78,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -106,19 +106,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -178,6 +178,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1020.0</real>
+    <integer>1020</integer>
   </dict>
 </plist>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth25-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz18-wdth25-wght400-ROND100.ufo/fontinfo.plist
@@ -78,6 +78,10 @@
     <string>2017/07/06 05:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -100,6 +104,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth100-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth100-wght1-ROND100.ufo/fontinfo.plist
@@ -107,6 +107,10 @@
     <integer>0</integer>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -127,6 +131,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth100-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth100-wght1000-ROND100.ufo/fontinfo.plist
@@ -80,7 +80,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -106,19 +106,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth100-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth100-wght400-ROND100.ufo/fontinfo.plist
@@ -125,6 +125,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -147,6 +151,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth151-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth151-wght1-ROND100.ufo/fontinfo.plist
@@ -77,6 +77,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -99,6 +103,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -158,6 +178,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1086.0</real>
+    <integer>1086</integer>
   </dict>
 </plist>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth151-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth151-wght1000-ROND100.ufo/fontinfo.plist
@@ -80,7 +80,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -106,19 +106,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2TypoAscender</key>
     <integer>1932</integer>
     <key>openTypeOS2TypoDescender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth151-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth151-wght400-ROND100.ufo/fontinfo.plist
@@ -81,6 +81,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -103,6 +107,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth25-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth25-wght1-ROND100.ufo/fontinfo.plist
@@ -57,6 +57,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -79,6 +83,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -138,6 +158,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1086.0</real>
+    <integer>1086</integer>
   </dict>
 </plist>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth25-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth25-wght1000-ROND100.ufo/fontinfo.plist
@@ -92,7 +92,7 @@
     <key>openTypeHheaCaretOffset</key>
     <integer>0</integer>
     <key>openTypeHheaCaretSlopeRise</key>
-    <integer>0</integer>
+    <integer>1</integer>
     <key>openTypeHheaCaretSlopeRun</key>
     <integer>0</integer>
     <key>openTypeHheaDescender</key>
@@ -120,19 +120,19 @@
     <key>openTypeOS2SubscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
-    <integer>0</integer>
+    <integer>150</integer>
     <key>openTypeOS2SubscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
     <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
-    <integer>0</integer>
+    <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
-    <integer>0</integer>
+    <integer>700</integer>
     <key>openTypeOS2SuperscriptYSize</key>
-    <integer>0</integer>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>
@@ -192,6 +192,6 @@
     <key>versionMinor</key>
     <integer>0</integer>
     <key>xHeight</key>
-    <real>1086.0</real>
+    <integer>1086</integer>
   </dict>
 </plist>

--- a/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth25-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/regular/ROND100/GoogleSansFlex-opsz6-wdth25-wght400-ROND100.ufo/fontinfo.plist
@@ -101,6 +101,10 @@
     <string>2017/07/06 09:41:44</string>
     <key>openTypeHheaAscender</key>
     <integer>1932</integer>
+    <key>openTypeHheaCaretSlopeRise</key>
+    <integer>1</integer>
+    <key>openTypeHheaCaretSlopeRun</key>
+    <integer>0</integer>
     <key>openTypeHheaDescender</key>
     <integer>-572</integer>
     <key>openTypeHheaLineGap</key>
@@ -123,6 +127,22 @@
     <integer>612</integer>
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
+    <key>openTypeOS2SubscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SubscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SubscriptYOffset</key>
+    <integer>150</integer>
+    <key>openTypeOS2SubscriptYSize</key>
+    <integer>1200</integer>
+    <key>openTypeOS2SuperscriptXOffset</key>
+    <integer>0</integer>
+    <key>openTypeOS2SuperscriptXSize</key>
+    <integer>1300</integer>
+    <key>openTypeOS2SuperscriptYOffset</key>
+    <integer>700</integer>
+    <key>openTypeOS2SuperscriptYSize</key>
+    <integer>1200</integer>
     <key>openTypeOS2Type</key>
     <array/>
     <key>openTypeOS2TypoAscender</key>


### PR DESCRIPTION
This reduces the MVAR table to containing just xHeight changes. The rest of the values are taken from GS.

@MariannaPaszkowska 