### PR TITLE
Limit the trigger for releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,9 @@
 name: Build font and specimen
 
-on: [push, release]
+on:
+  push:
+  release:
+    types: [published] # A release, pre-release, or draft of a release was published.
 
 jobs:
   build:


### PR DESCRIPTION
Closes https://github.com/googlefonts/googlesans-flex/issues/253.

Going from the documentation at https://docs.github.com/de/developers/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=published#release, this will now trigger a release job only when you click the publish button when making a GitHub release over at https://github.com/googlefonts/googlesans-flex/releases/new.