### PR TITLE
Skip font-v on import

### DIFF
--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -68,6 +68,8 @@ jobs:
         run: echo "ZIP_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')-fonts" >> $GITHUB_ENV
       - name: Build font
         run: cd "$GITHUB_WORKSPACE/target" && make build
+        env:
+          SKIP_FONTV: true
       - name: Check with fontbakery
         # Copy current QA files (and Makefile to drive them) from main so we
         # have up to date tests.

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ venv: venv/touchfile
 build.stamp: venv sources/config.yaml $(SOURCES)
 	rm -rf fonts/
 	venv/bin/gftools builder sources/config.yaml
-	venv/bin/font-v write --sha1 fonts/variable/*.ttf
+	# Font-v cannot deal with worktrees, which we use for imports. See
+	# https://github.com/source-foundry/font-v/issues/169. Just skip it.
+	if [ -z "${SKIP_FONTV}" ]; then venv/bin/font-v write --sha1 fonts/variable/*.ttf; fi
 	venv/bin/python scripts/sanitize-name-table.py fonts/variable/*.ttf
 	touch build.stamp
 


### PR DESCRIPTION
It cannot deal with worktrees, which we use on import.