### PR TITLE
Add collidoscope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,19 @@ test: build.stamp
 # -venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-shaping-report.html \
 #	qa/check-shaping.py fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
 
+run-collidoscope: build.stamp
+# Install latest version of fontbakery on every run, isolated from build dependencies
+	test -d venv_bakery || python3 -m venv venv_bakery
+	venv_bakery/bin/pip install -U setuptools wheel pip
+	venv_bakery/bin/pip install -U fontbakery[googlefonts] fonttools[interpolatable]
+
+# Run collidoscope tests
+	mkdir -p out/fontbakery
+	-venv_bakery/bin/fontbakery check-shaping -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-collidoscope-report.html \
+		--configuration qa/fontbakery.config \
+		-c collides \
+		 fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+
 images: venv build.stamp $(DRAWBOT_OUTPUT)
 	git add documentation/*.png && git commit -m "Rebuild images" documentation/*.png
 

--- a/qa/fontbakery.config
+++ b/qa/fontbakery.config
@@ -1,0 +1,2 @@
+com.google.fonts/check/shaping:
+    test_directory: qa/shaping_tests

--- a/qa/shaping_tests/collisions.json
+++ b/qa/shaping_tests/collisions.json
@@ -1,0 +1,16 @@
+{
+    "configuration": {
+        "collidoscope": {
+            "bases": true
+        },
+        "ingredients": {
+            "Character": "[!\"#$%&\\\\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~]"
+        }
+    },
+    "tests": [
+        {
+            "input_type": "pattern",
+            "input": "Character Character"
+        }
+    ]
+}


### PR DESCRIPTION
Add collidoscope testing as separate command: Run `make run-collidoscope` when you need it and have a look at the HTML report in `out/fontbakery`.

The dependencies needed to be updated because collidoscope was outdated and not finding anything. The tool has an `area` parameter that can be used to tweak the threshold of how much overlap is needed to be considered an actual overlap. It might need some fiddling.

@MariannaPaszkowska @chrissimpkins 