### PR TITLE
Remove commit-level burndown chart generation

### DIFF
--- a/.github/workflows/burndown.yaml
+++ b/.github/workflows/burndown.yaml
@@ -1,24 +1,24 @@
-name: Progress chart
-on:
-  push:
-    branches:
-      - fb-wip
-      - import-fb-wip
+# name: Progress chart
+# on:
+#   push:
+#     branches:
+#       - fb-wip
+#       - import-fb-wip
 
-jobs:
-  burndown:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # Fetch all so we get access to all tags, etc.
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.x"
-      - name: Generate chart
-        run: make progress-chart
-      - name: Upload chart
-        uses: actions/upload-artifact@v3
-        with:
-          path: gs-flex-progress.png
+# jobs:
+#   burndown:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+#         with:
+#           fetch-depth: 0 # Fetch all so we get access to all tags, etc.
+#       - name: Set up Python 3.x
+#         uses: actions/setup-python@v4
+#         with:
+#           python-version: "3.x"
+#       - name: Generate chart
+#         run: make progress-chart
+#       - name: Upload chart
+#         uses: actions/upload-artifact@v3
+#         with:
+#           path: gs-flex-progress.png


### PR DESCRIPTION
D/W Marianna. We are not actively using it.  It runs on every fb-wip and import-fb-wip commit, currently takes > 10 mins to complete + is storing assets.  Let's avoid those runner computation and GH storage charges for now if we don't need it.  Commented out so that we can add it back in the future if it becomes required again.
