### PR TITLE
Update glyph-list - Remove gcircumflex.alt

### DIFF
--- a/.github/actions/import/glyph-list.txt
+++ b/.github/actions/import/glyph-list.txt
@@ -437,7 +437,6 @@ aeacute.alt
 
 g.alt
 gbreve.alt
-gcircumflex.alt
 gcommaaccent.alt
 gdotaccent.alt
 


### PR DESCRIPTION
Removing gcircumflex.alt, because the gcircumflex glyph is not present in the sources and was not a part of the defined character set for this version.