### PR TITLE
Add Google logo ligatures feature support

### DIFF
--- a/sources/regular/family.fea
+++ b/sources/regular/family.fea
@@ -215,14 +215,18 @@ feature liga {
     sub f t by f_t;
     sub t f by t_f;
     sub t t by t_t;
-#     sub [G g] o o g l e underscore l o g o by Google.logo;
-#     sub [G g] o o g l e l o g o l i g a t u r e by Google.logo;
-#     sub G l o g o l i g a t u r e by G.logo;
-#     sub o l o g o l i g a t u r e by o.logo;
-#     sub g l o g o l i g a t u r e by g.logo;
-#     sub l l o g o l i g a t u r e by l.logo;
-#     sub e l o g o l i g a t u r e by e.logo;
 } liga;
+
+feature calt {
+	# Google logo ligatures
+	sub colon [G g] o o g l e underscore l o g o underscore l i g a t u r e colon by Google.logo;
+    sub colon [G g] o o g l e underscore G underscore l o g o underscore l i g a t u r e colon by G.logo;
+    sub colon [G g] o o g l e underscore o underscore l o g o underscore l i g a t u r e colon by o.logo;
+    sub colon [G g] o o g l e underscore g underscore l o g o underscore l i g a t u r e colon by g.logo;
+    sub colon [G g] o o g l e underscore l underscore l o g o underscore l i g a t u r e colon by l.logo;
+    sub colon [G g] o o g l e underscore e underscore l o g o underscore l i g a t u r e colon by e.logo;
+    sub colon [G g] o o g l e underscore s u p e r underscore [G g] underscore l o g o underscore l i g a t u r e colon by G.super;
+} calt;
 
 feature ss01 {
 	featureNames {

--- a/sources/regular/family.fea
+++ b/sources/regular/family.fea
@@ -219,13 +219,13 @@ feature liga {
 
 feature calt {
 	# Google logo ligatures
-	sub colon [G g] o o g l e underscore l o g o underscore l i g a t u r e colon by Google.logo;
-    sub colon [G g] o o g l e underscore G underscore l o g o underscore l i g a t u r e colon by G.logo;
-    sub colon [G g] o o g l e underscore o underscore l o g o underscore l i g a t u r e colon by o.logo;
-    sub colon [G g] o o g l e underscore g underscore l o g o underscore l i g a t u r e colon by g.logo;
-    sub colon [G g] o o g l e underscore l underscore l o g o underscore l i g a t u r e colon by l.logo;
-    sub colon [G g] o o g l e underscore e underscore l o g o underscore l i g a t u r e colon by e.logo;
-    sub colon [G g] o o g l e underscore s u p e r underscore [G g] underscore l o g o underscore l i g a t u r e colon by G.super;
+	sub colon [G g] o o g l e underscore l o g o by Google.logo;
+    sub colon [G g] o o g l e underscore G underscore l o g o by G.logo;
+    sub colon [G g] o o g l e underscore o underscore l o g o by o.logo;
+    sub colon [G g] o o g l e underscore g underscore l o g o by g.logo;
+    sub colon [G g] o o g l e underscore l underscore l o g o by l.logo;
+    sub colon [G g] o o g l e underscore e underscore l o g o by e.logo;
+    sub colon [G g] o o g l e underscore s u p e r underscore [G g] underscore l o g o by G.super;
 } calt;
 
 feature ss01 {


### PR DESCRIPTION
Added to calt feature with input strings defined by @davelab6 in https://github.com/googlefonts/googlesans-flex/issues/260#issuecomment-1416220736

related https://github.com/googlefonts/googlesans-flex/pull/304
