### PR TITLE
Implement optical size axis avar1 map (Black Foundry approach)

### DIFF
--- a/sources/regular/GoogleSansFlex.designspace
+++ b/sources/regular/GoogleSansFlex.designspace
@@ -29,7 +29,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -38,7 +38,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -47,7 +47,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -56,7 +56,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -65,7 +65,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -74,7 +74,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -83,7 +83,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -92,7 +92,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -101,7 +101,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -110,7 +110,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -119,7 +119,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -128,7 +128,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -137,7 +137,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="50"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -146,7 +146,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="50"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -155,7 +155,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="50"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -164,7 +164,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="85"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -173,7 +173,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="85"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -182,7 +182,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="85"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -191,7 +191,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -200,7 +200,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="-50"/>
       </location>
@@ -213,7 +213,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -222,7 +222,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="50"/>
       </location>
@@ -231,7 +231,7 @@
       <location>
         <dimension name="wght" xvalue="579.999"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -240,7 +240,7 @@
       <location>
         <dimension name="wght" xvalue="580"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -249,7 +249,7 @@
       <location>
         <dimension name="wght" xvalue="699.999"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -258,7 +258,7 @@
       <location>
         <dimension name="wght" xvalue="700"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -267,7 +267,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -276,7 +276,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -285,7 +285,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -294,7 +294,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -303,7 +303,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -312,7 +312,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -321,7 +321,7 @@
       <location>
         <dimension name="wght" xvalue="579.999"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -330,7 +330,7 @@
       <location>
         <dimension name="wght" xvalue="580"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -339,7 +339,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -348,7 +348,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="50"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -357,7 +357,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="50"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -366,7 +366,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="50"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -375,7 +375,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="85"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -384,7 +384,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="85"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -393,7 +393,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="85"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -402,7 +402,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -411,7 +411,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -420,7 +420,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -429,7 +429,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -438,7 +438,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -447,7 +447,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -456,7 +456,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -465,7 +465,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -474,7 +474,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -483,7 +483,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -492,7 +492,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -501,7 +501,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -510,7 +510,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -519,7 +519,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -528,7 +528,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="6"/>
+        <dimension name="opsz" xvalue="0"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -537,7 +537,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -546,7 +546,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -555,7 +555,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -564,7 +564,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -573,7 +573,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -582,7 +582,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -591,7 +591,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -600,7 +600,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -609,7 +609,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -618,7 +618,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -627,7 +627,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -636,7 +636,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="25"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -645,7 +645,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -654,7 +654,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -663,7 +663,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -672,7 +672,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -681,7 +681,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -690,7 +690,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="151"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -699,7 +699,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="85"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -708,7 +708,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="85"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -717,7 +717,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="85"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -726,7 +726,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="50"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -735,7 +735,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="50"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -744,7 +744,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="50"/>
-        <dimension name="opsz" xvalue="144"/>
+        <dimension name="opsz" xvalue="100"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -753,7 +753,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="85"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -762,7 +762,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="85"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -771,7 +771,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="85"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -780,7 +780,7 @@
       <location>
         <dimension name="wght" xvalue="1000"/>
         <dimension name="wdth" xvalue="50"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -789,7 +789,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="50"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -798,7 +798,7 @@
       <location>
         <dimension name="wght" xvalue="1"/>
         <dimension name="wdth" xvalue="50"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="100"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -809,7 +809,7 @@
       <location>
         <dimension name="wght" xvalue="100"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -820,7 +820,7 @@
       <location>
         <dimension name="wght" xvalue="200"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -831,7 +831,7 @@
       <location>
         <dimension name="wght" xvalue="300"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -842,7 +842,7 @@
       <location>
         <dimension name="wght" xvalue="400"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -853,7 +853,7 @@
       <location>
         <dimension name="wght" xvalue="500"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -864,7 +864,7 @@
       <location>
         <dimension name="wght" xvalue="600"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -875,7 +875,7 @@
       <location>
         <dimension name="wght" xvalue="700"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -886,7 +886,7 @@
       <location>
         <dimension name="wght" xvalue="800"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>
@@ -897,7 +897,7 @@
       <location>
         <dimension name="wght" xvalue="900"/>
         <dimension name="wdth" xvalue="100"/>
-        <dimension name="opsz" xvalue="18"/>
+        <dimension name="opsz" xvalue="35.2"/>
         <dimension name="ROND" xvalue="0"/>
         <dimension name="GRAD" xvalue="0"/>
       </location>

--- a/sources/regular/GoogleSansFlex.designspace
+++ b/sources/regular/GoogleSansFlex.designspace
@@ -8,7 +8,14 @@
       <labelname xml:lang="en">width</labelname>
     </axis>
     <axis tag="opsz" name="opsz" minimum="6" maximum="144" default="18">
-      <labelname xml:lang="en">optical size</labelname>
+      <map input="6" output="0"/>
+      <map input="8" output="0.004"/>
+      <map input="14" output="10"/>
+      <map input="18" output="35.2"/>
+      <map input="24" output="73"/>
+      <map input="92" output="93"/>
+      <map input="144" output="100"/>
+      <labelname xml:lang="en">Optical size</labelname>
     </axis>
     <axis tag="ROND" name="ROND" minimum="0" maximum="100" default="0">
       <labelname xml:lang="en">ROUNDED</labelname>


### PR DESCRIPTION
For comparison with #335 

This PR adds the Black Foundry optical size axis avar1 map that is defined as follows:

```xml
<map input="6" output="0"/>
<map input="8" output="0.004"/>
<map input="14" output="10"/>
<map input="18" output="35.2"/>
<map input="24" output="73"/>
<map input="92" output="93"/>
<map input="144" output="100"/>
```

avar table data:

<img width="403" alt="2023-02-03_17-48-51" src="https://user-images.githubusercontent.com/4249591/216725647-08fa8566-4842-4b76-9c68-26f0542d3bfc.png">

Stepwise non-linear interpolation (user values on the x-axis):

![chart (1)](https://user-images.githubusercontent.com/4249591/216725796-dd696344-756c-41d7-b7aa-55c3250f9166.png)


This is meant to support builds for review of this issue in the Latin glyph set and is not necessarily the decided approach to opsz avar.  Opened as a draft PR while we discuss this.