### PR TITLE
Implement optical size axis avar1 map (Font Bureau approach)

### DIFF
--- a/sources/regular/GoogleSansFlex.designspace
+++ b/sources/regular/GoogleSansFlex.designspace
@@ -8,7 +8,11 @@
       <labelname xml:lang="en">width</labelname>
     </axis>
     <axis tag="opsz" name="opsz" minimum="6" maximum="144" default="18">
-      <labelname xml:lang="en">optical size</labelname>
+      <map input="6" output="6"/>
+      <map input="18" output="18"/>
+      <map input="92" output="120"/>
+      <map input="144" output="144"/>
+      <labelname xml:lang="en">Optical size</labelname>
     </axis>
     <axis tag="ROND" name="ROND" minimum="0" maximum="100" default="0">
       <labelname xml:lang="en">ROUNDED</labelname>


### PR DESCRIPTION
For comparison with #320

The avar1 map is defined as follows:

```
<map input="6" output="6"/>
<map input="18" output="18"/>
<map input="92" output="120"/>
<map input="144" output="144"/>
```

avar table definition:

<img width="396" alt="2023-02-06_15-03-38" src="https://user-images.githubusercontent.com/4249591/217073522-5416bf8f-3ff8-4cf8-895a-4ef94c8d77eb.png">

Stepwise non-linear interpolation (user values on the x-axis):

![chart (2)](https://user-images.githubusercontent.com/4249591/217074091-6c4626f2-e8af-4151-941c-d6b3f66b2ed2.png)



cc @dberlow @sannorozco @MariannaPaszkowska 




