### PR TITLE
Update glyph-list.txt

### DIFF
--- a/.github/actions/import/glyph-list.txt
+++ b/.github/actions/import/glyph-list.txt
@@ -522,3 +522,26 @@ sixsubscript
 sevensubscript
 eightsubscript
 ninesubscript
+
+- flig2
+- flig1
+- tlig
+- gcircumflex.alt
+- zeropercent
+- percentbar
+- exclam-top
+- question-top
+- exclam-bottom
+- question-bottom
+- dot-composite
+- dot-composite-top
+- Eth-bar
+- Oslash-bar
+- oslash-bar
+- diagonalbarl
+- horizontalbarlc
+- H-bar
+- Engeng
+- notequal-slash
+- greaterequal-stroke
+- percentbar.tf


### PR DESCRIPTION
Adding production composites and ligatures. Having those composites reduces the file size of the binaries. 