### PR TITLE
Fix Lithuanian locl

### DIFF
--- a/sources/regular/family.fea
+++ b/sources/regular/family.fea
@@ -281,14 +281,3 @@ feature pnum {
 	sub @FIGURES_TAB by @FIGURES;
     sub @SYMBOLS_TAB by @SYMBOLS;
 } pnum;
-
-feature ccmp {
-	lookup ccmp1 {
-		sub iogonek' @CombiningTopAccents by idotless ogonekcomb;
-		sub iogonek' @CombiningNonTopAccents @CombiningTopAccents by idotless ogonekcomb;
-	} ccmp1;
-	lookup ccmp2 {
-		sub i' @CombiningTopAccents by idotless;
-		sub i' @CombiningNonTopAccents @CombiningTopAccents by idotless;
-	} ccmp2;
-} ccmp;

--- a/sources/regular/family.fea
+++ b/sources/regular/family.fea
@@ -7,8 +7,6 @@ languagesystem latn NLD;
 languagesystem latn LTH;
 
 @CombiningTopAccents = [gravecomb acutecomb tildecomb];
-@CombiningNonTopAccents = [cedillacomb ogonekcomb commaaccentcomb commaaccent];
-
 
 @a_ALT_OFF = [a agrave aacute acircumflex atilde adieresis aring ae aogonek abreve amacron acaron ];
 @a_ALT_ON = [a.alt agrave.alt aacute.alt acircumflex.alt atilde.alt adieresis.alt aring.alt ae.alt aogonek.alt abreve.alt amacron.alt acaron.alt ];

--- a/sources/regular/family.fea
+++ b/sources/regular/family.fea
@@ -6,7 +6,9 @@ languagesystem latn MOL;
 languagesystem latn NLD;
 languagesystem latn LTH;
 
-@CombiningTopAccents = [gravecomb acutecomb circumflexcomb tildecomb macroncomb brevecomb dotaccentcomb dieresiscomb ringcomb hungarumlautcomb caroncomb commaturnedabovecomb];
+@CombiningTopAccents = [gravecomb acutecomb tildecomb];
+@CombiningNonTopAccents = [cedillacomb ogonekcomb commaaccentcomb commaaccent];
+
 
 @a_ALT_OFF = [a agrave aacute acircumflex atilde adieresis aring ae aogonek abreve amacron acaron ];
 @a_ALT_ON = [a.alt agrave.alt aacute.alt acircumflex.alt atilde.alt adieresis.alt aring.alt ae.alt aogonek.alt abreve.alt amacron.alt acaron.alt ];
@@ -33,8 +35,11 @@ feature locl {
 		  sub L' periodcentered' L by Ldot;
 	    } LDOT;
 
-	  language LTH;
-	  sub idotless' @CombiningTopAccents by i;
+	  language LTH exclude_dflt;
+	  	lookup LTH_1 {
+			sub idotless' @CombiningTopAccents by i;
+		} LTH_1;
+	
 	  
 	  language NLD exclude_dflt;
 	    lookup IJ {
@@ -276,3 +281,14 @@ feature pnum {
 	sub @FIGURES_TAB by @FIGURES;
     sub @SYMBOLS_TAB by @SYMBOLS;
 } pnum;
+
+feature ccmp {
+	lookup ccmp1 {
+		sub iogonek' @CombiningTopAccents by idotless ogonekcomb;
+		sub iogonek' @CombiningNonTopAccents @CombiningTopAccents by idotless ogonekcomb;
+	} ccmp1;
+	lookup ccmp2 {
+		sub i' @CombiningTopAccents by idotless;
+		sub i' @CombiningNonTopAccents @CombiningTopAccents by idotless;
+	} ccmp2;
+} ccmp;


### PR DESCRIPTION
Fixing locl OT feature for LTH. CC  @chrissimpkins 

Before and after the change preview in Font Googles (bottom line shows the previous state).
<img width="1236" alt="Screenshot 2023-02-13 at 6 51 12 PM" src="https://user-images.githubusercontent.com/22956348/218520474-fff7d411-a711-42f1-a635-d210c361fe77.png">
