### PR TITLE
Add ufo2glyphs2ufo scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,25 @@ A script used to find angles (between the incoming and outgoing handles or point
 5. The script will create a CSV file where it lists glyph points and their locations where the angle of the incoming and outgoing handle or on-curve deviates from other masters. It gives you a link to click, which brings you to the glyph in Fontra and marks the offending point for you. Wiggle the location sliders to see if there is a problem or not.
 
 You can also inspect variable TTFs. Note that the locations might be slightly off then.
+
+### gs-ufo2glyphs.py, gs-glyphs2ufo.py, gs-merge-designspace.py
+
+These work the same as in Google Sans.
+
+This will produce a GoogleSansFlex.glyphs file next to the Designspace:
+
+```sh
+python3 scripts/gs-ufo2glyphs.py sources/regular/GoogleSansFlex.designspace
+```
+
+Going back should be done in a separate directory, because we have an extra merge step, to avoid polluting the sources with leftovers and accidents.
+
+```sh
+python3 scripts/gs-glyphs2ufo.py sources/regular/staging/GoogleSansFlex.glyphs
+```
+
+Merge the two with the following command. You need to have a import_glyphs.txt file describing which glyphs to import:
+
+```sh
+python3 scripts/gs-merge-designspace.py --source source/GoogleSans/staging/GoogleSansSomeScript.designspace --target sources/regular/GoogleSansFlex.designspace --import-glyphs-file sources/regular/staging/import_glyphs.txt
+```

--- a/scripts/gs-glyphs2ufo.py
+++ b/scripts/gs-glyphs2ufo.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google Sans Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Converts incoming Glyphs.app files to Designspace plus UFOs.
+
+Imported files are scrubbed to conform to our source conventions.
+"""
+
+import argparse
+from pathlib import Path
+
+import glyphsLib
+
+from internal import normalize
+
+ROOT_DIR = Path(__file__).parent.parent
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "glyphs_file", nargs="+", type=Path, help="Path to source Glyphs.app file."
+)
+parser.add_argument(
+    "--target-dir",
+    type=Path,
+    help=(
+        "Path to target directory to dump Designspace and UFO into (default: "
+        "same directory)."
+    ),
+)
+parsed_args = parser.parse_args()
+
+
+for glyphs_file_path in parsed_args.glyphs_file:
+    target_dir = parsed_args.target_dir
+    if target_dir is None:
+        target_dir = glyphs_file_path.parent
+
+    # Convert the file to be imported.
+    glyphs_file = glyphsLib.GSFont(glyphs_file_path)
+
+    # Clear out non-foreground layers to reduce noise.
+    for glyph in glyphs_file.glyphs:
+        for layer_id in [
+            layer.layerId
+            for layer in glyph.layers
+            if layer.associatedMasterId != layer.layerId  # Not a master layer
+            and "[" not in layer.name  # and not a bracket layer
+            and "{" not in layer.name  # and not a brace layer
+        ]:
+            del glyph.layers[layer_id]
+        for layer in glyph.layers:
+            layer._background = None
+
+    designspace = glyphsLib.to_designspace(
+        glyphs_file,
+        generate_GDEF=True,
+        instance_dir=str(ROOT_DIR / "build" / "GoogleSans" / "instance_ufo"),
+        minimize_glyphs_diffs=True,  # We need font master IDs for source matching.
+        propagate_anchors=False,  # Not in my sources you don't.
+        write_skipexportglyphs=True,
+    )
+    designspace.findDefault()
+
+    normalize.scrub_designspace(designspace, ROOT_DIR)
+
+    # (Based on glyphsLib.build_masters)
+    # Only write full masters to disk. This assumes that layer sources are always part
+    # of another full master source, which must always be the case in a .glyphs file.
+    ufos = {}
+    for source in designspace.sources:
+        if source.filename in ufos:
+            assert source.font is ufos[source.filename]
+            continue
+
+        ufo_path = target_dir / source.filename
+        source.font.save(ufo_path, overwrite=True)
+
+        ufos[source.filename] = source.font
+
+    designspace.write(target_dir / designspace.filename)
+    ###

--- a/scripts/gs-merge-designspace.py
+++ b/scripts/gs-merge-designspace.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google Sans Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Merge an incoming Designspace into an existing Designspace.
+
+This script will import glyphs amd groups specified in import text files
+(one name per line) and kerning pairs that mention either of them. It will
+also update each UFO's public.glyphOrder and public.postscriptNames lib keys
+with entries for all imported glyphs, as well as public.skipExportGlyphs in
+Designspace and UFOs.
+
+It does not import any font info, global or local guidelines or features.
+Designspace rules are also left untouched. Glyphs.app brace layers are not
+supported.
+"""
+
+import argparse
+import collections
+import copy
+import logging
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+import ufoLib2
+from fontTools.designspaceLib import DesignSpaceDocument
+from ufo2ft.util import makeOfficialGlyphOrder
+
+from internal.normalize import location_to_key
+
+MASTER_ID_KEY = "com.schriftgestaltung.fontMasterID"
+SKIP_EXPORT_GLYPHS_KEY = "public.skipExportGlyphs"
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--source",
+    type=Path,
+    help="Path to source .designspace file.",
+    required=True,
+)
+parser.add_argument(
+    "--target",
+    type=Path,
+    help="Path to target .designspace file.",
+    required=True,
+)
+parser.add_argument(
+    "--import-glyphs-file",
+    type=Path,
+    help=(
+        "Path to text file with glyph names to import (one per line). "
+        "Also imports any kerning pair that mentions them."
+    ),
+)
+parser.add_argument(
+    "--import-groups-file",
+    type=Path,
+    help=(
+        "Path to text file with group names to import (one per line). "
+        "Also imports any kerning pair that mentions them."
+    ),
+)
+parsed_args = parser.parse_args()
+
+
+# Read in stuff to import.
+if parsed_args.import_glyphs_file is not None:
+    import_glyphs = {
+        name.strip()
+        for name in parsed_args.import_glyphs_file.read_text().split("\n")
+        if name
+    }
+else:
+    import_glyphs = set()
+
+if parsed_args.import_groups_file is not None:
+    import_groups = {
+        name.strip()
+        for name in parsed_args.import_groups_file.read_text().split("\n")
+        if name
+    }
+else:
+    import_groups = set()
+
+if not import_glyphs and not import_groups:
+    logging.error("You should provide at least one file with stuff to import.")
+    sys.exit(1)
+
+
+# Load all sources.
+designspace_import = DesignSpaceDocument.fromfile(parsed_args.source)
+designspace_import.loadSourceFonts(ufoLib2.Font.open)
+designspace_target = DesignSpaceDocument.fromfile(parsed_args.target)
+designspace_target.loadSourceFonts(ufoLib2.Font.open)
+
+
+# Update skip export glyphs list.
+skip_export_glyphs_import = set(designspace_import.lib.get(SKIP_EXPORT_GLYPHS_KEY, []))
+skip_export_glyphs_target = set(designspace_target.lib.get(SKIP_EXPORT_GLYPHS_KEY, []))
+skip_export_glyphs_target.update(
+    n for n in skip_export_glyphs_import if n in import_glyphs
+)
+skip_export_glyphs = sorted(skip_export_glyphs_target)
+if skip_export_glyphs_target:
+    designspace_target.lib[SKIP_EXPORT_GLYPHS_KEY] = skip_export_glyphs
+
+# Whether any of the sources to be imported is ungraded.
+import_is_ungraded = False
+
+
+def canonical_location(
+    location: Dict[str, float], designspace: DesignSpaceDocument
+) -> Dict[str, float]:
+    """Returns a canonical location from a raw Designspace location.
+
+    Vendor sources are inconsistent, so using user values and tags to match
+    source axes is hopefully more reliable.
+    """
+    name_to_axis = {a.name: a for a in designspace.axes}
+    name_to_tag = {a.name: a.tag for a in designspace.axes}
+    return {
+        name_to_tag[k]: name_to_axis[k].map_backward(v) for k, v in location.items()
+    }
+
+
+# Actually import now.
+for import_source in designspace_import.sources:
+    if import_source.layerName is not None:
+        logging.error(
+            "Brace layers not supported currently: %s", import_source.asdict()
+        )
+        continue
+
+    if "Grade" not in import_source.location:
+        import_is_ungraded = True
+
+    # Fill in the defaults if the import DS does not have e.g. a GRAD axis.
+    # Match axes by tags because those are more consistent across vendor sources.
+    import_source_location = canonical_location(
+        import_source.location, designspace_import
+    )
+    full_import_source_location = {
+        **canonical_location(designspace_target.default.location, designspace_target),
+        **import_source_location,
+    }
+
+    # Match import to target UFO.
+    try:
+        target_source = next(
+            s
+            for s in designspace_target.sources
+            if (
+                canonical_location(s.location, designspace_target)
+                == full_import_source_location
+            )
+        )
+    except StopIteration:
+        try:
+            target_source = next(
+                s
+                for s in designspace_target.sources
+                if s.font.lib[MASTER_ID_KEY] == import_source.font.lib[MASTER_ID_KEY]
+            )
+        except (StopIteration, KeyError):
+            logging.error(
+                "Cannot find target for source %s because there's no target location %s "
+                "and no target with a matching master ID.",
+                import_source.name,
+                full_import_source_location,
+            )
+            sys.exit(1)
+
+    import_font: ufoLib2.Font = import_source.font
+    target_font: ufoLib2.Font = target_source.font
+
+    # Snatch up any bracket glyphs for glyphs without them being explicitly
+    # listed in the import file. ".BRACKET." is a glyphsLib convention.
+    for name in import_font.keys():
+        if ".BRACKET." not in name:
+            continue
+        base = name.split(".BRACKET.")[0]
+        if base in import_glyphs:
+            import_glyphs.add(name)
+            logging.warning(
+                "Added bracket glyph '%s', manually add to the Designspace rules.", name
+            )
+
+    for glyph_name in import_glyphs:
+        try:
+            target_font[glyph_name] = import_font[glyph_name]
+        except KeyError as e:
+            logging.error(
+                "Glyph %s does not exist in the source UFO %s, aborting.",
+                str(e),
+                str(import_source.filename),
+            )
+            sys.exit(1)
+
+    # If no group import list has been specified, gather all groups that mention
+    # any of the imported glyphs. They can already exist in the target font
+    # (adding new glyphs to existing groups) or not (new script-specific
+    # groups).
+    import_font_groups = set()
+    if not import_groups:
+        for group, glyphs in import_font.groups.items():
+            if any(n in import_glyphs for n in glyphs):
+                import_font_groups.add(group)
+
+    # Use global groups list or, if non passed in, font specific one for checks below.
+    import_groups_to_check = import_groups or import_font_groups
+
+    # Clean glyphs to be imported from the target UFO kerning groups, so
+    # importing the source kerning then does not lead to duplicate group
+    # membership if their memebership changed.
+    kerning_groups_to_be_cleaned = []
+    for group_name in list(target_font.groups.keys()):
+        members = target_font.groups[group_name]
+        new_members = [member for member in members if member not in import_glyphs]
+        if new_members:
+            target_font.groups[group_name] = new_members
+        else:
+            del target_font.groups[group_name]
+            kerning_groups_to_be_cleaned.append(group_name)
+    target_font.kerning = {
+        (f, s): v
+        for (f, s), v in target_font.kerning.items()
+        if f not in kerning_groups_to_be_cleaned
+        and s not in kerning_groups_to_be_cleaned
+    }
+
+    # Importing a group that already exists should extend the existing group with
+    # imported glyphs instead of overwriting the group.
+    target_groups_extended = set()
+    for group_name in import_groups_to_check:
+        try:
+            group_glyphs = import_font.groups[group_name]
+        except KeyError as e:
+            logging.warning(
+                "Kerning group %s does not exist in the source UFO %s, skipping.",
+                str(e),
+                str(import_source.filename),
+            )
+            continue
+        if group_name in target_font.groups:
+            target_groups_extended.add(group_name)
+            existing = set(target_font.groups[group_name])
+            for name in sorted(group_glyphs):
+                if name not in existing and name in import_glyphs:
+                    target_font.groups[group_name].append(name)
+        else:
+            target_font.groups[group_name] = import_font.groups[group_name]
+
+    # Import kerning where either side of a pair is an imported glyph or group.
+    # NOTE: Existing groups extended with new glyphs are a special case, as they
+    #       "contaminate" the below logic and would also let through a pair of
+    #       extended group and completely script-unrelated group. I.e., if
+    #       Armenian extended `public.kern2.dash` with new glyphs and
+    #       accidentally changed the pair `public.kern1.L, public.kern2.dash`,
+    #       The change would be picked up even though it had nothing to do with
+    #       the script in question. This is the more relevant the more out-of-sync
+    #       a source font is relative to the target font. One solution is to
+    #       remove extended groups from the set of groups to check for inclusion.
+    import_groups_to_check = import_groups_to_check - target_groups_extended
+    for key, value in import_font.kerning.items():
+        first, second = key
+        if (first not in import_font and first not in import_font.groups) or (
+            second not in import_font and second not in import_font.groups
+        ):
+            # Skip spurious pairs.
+            continue
+        if (
+            first in import_groups_to_check
+            or first in import_glyphs
+            or second in import_groups_to_check
+            or second in import_glyphs
+        ):
+            target_font.kerning[key] = value
+
+    # Import public.glyphOrder while keeping order:
+    target_glyph_order: List[str] = target_font.lib["public.glyphOrder"]
+    target_glyph_order_set = set(target_glyph_order)
+    for name in makeOfficialGlyphOrder(import_font):
+        if name not in target_glyph_order_set and name in import_glyphs:
+            target_glyph_order.append(name)
+
+    # Import public.postscriptNames for imported glyphs:
+    target_ps_names: Dict[str, str] = target_font.lib["public.postscriptNames"]
+    for key, value in import_font.lib["public.postscriptNames"].items():
+        if key in import_glyphs:
+            target_ps_names[key] = value
+
+    # Write global public.skipExportGlyphs list to all UFOs.
+    target_font.lib[SKIP_EXPORT_GLYPHS_KEY] = skip_export_glyphs
+
+    target_font.save()
+
+
+# If we import sources that don't have a GRAD axis yet, copy all imported glyphs
+# and other data from above over to our existing GRAD sources.
+if import_is_ungraded:
+    default_grades = []
+    grade_mapping = collections.defaultdict(list)
+    for source in designspace_target.sources:
+        if source.location["Grade"]:
+            grade_mapping[location_to_key(source.location)].append(source)
+        else:
+            default_grades.append(source)
+
+    for source in default_grades:
+        for graded_source in grade_mapping[location_to_key(source.location)]:
+            graded_default_layer = graded_source.font.layers.defaultLayer
+            for glyph_name in import_glyphs:
+                graded_default_layer.insertGlyph(
+                    source.font[glyph_name], overwrite=True
+                )
+
+            graded_source.font.groups = source.font.groups
+            graded_source.font.kerning = source.font.kerning
+
+            graded_master_id = graded_source.font.lib.get(MASTER_ID_KEY)
+            graded_source.font.lib = copy.copy(source.font.lib)
+            graded_source.font.lib[MASTER_ID_KEY] = graded_master_id
+
+            graded_source.font.save()
+
+
+designspace_target.write(parsed_args.target)

--- a/scripts/gs-ufo2glyphs.py
+++ b/scripts/gs-ufo2glyphs.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google Sans Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert Designspace to Glyphs.app file.
+
+Saves output to same path as the Designspace with a `.glyphs` suffix. Disables
+the lastChanged marker of glyphs, which we don't need with UFOs.
+"""
+
+import argparse
+from pathlib import Path
+
+import glyphsLib
+from fontTools.designspaceLib import DesignSpaceDocument
+
+ROOT_DIR = Path(__file__).parent.parent
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "designspace", nargs="+", type=Path, help="Path to input Designspace."
+)
+parsed_args = parser.parse_args()
+
+for designspace_path in parsed_args.designspace:
+    designspace = DesignSpaceDocument.fromfile(designspace_path)
+    font = glyphsLib.to_glyphs(designspace, minimize_ufo_diffs=True)
+    font.customParameters["Disable Last Change"] = True
+    font.save(designspace_path.with_suffix(".glyphs"))

--- a/scripts/internal/cut-instances.py
+++ b/scripts/internal/cut-instances.py
@@ -1,0 +1,210 @@
+# Copyright 2022 Google Sans Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import ufoLib2
+from fontTools.designspaceLib import DesignSpaceDocument
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables.O_S_2f_2 import Panose
+from ufo2ft.fontInfoData import (
+    getAttrWithFallback,
+    normalizeStringForPostscript,
+    intListToNum,
+)
+
+
+def cut_instance(
+    variable_font: Path,
+    user_location: dict[str, float],
+    panose_values: list[int],
+    family_name: str | None,
+    style_name: str | None,
+    stylemap_family_name: str | None,
+    stylemap_style_name: str | None,
+    output_file: Path,
+) -> None:
+    user_location_args = [f"{k}={v}" for k, v in user_location.items()]
+
+    # Create output directory in case it doesn't exist yet on CI, when passing
+    # artifacts around.
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"Cutting {user_location_args} from {variable_font}")
+    subprocess.check_call(
+        [
+            "fonttools",
+            "varLib.instancer",
+            "--quiet",
+            "--remove-overlaps",
+            "--update-name-table",
+            "-o",
+            str(output_file),
+            str(variable_font),
+            *user_location_args,
+        ]
+    )
+
+    font = TTFont(output_file)
+
+    font["OS/2"].recalcAvgCharWidth(font)
+
+    panose = Panose()
+    panose.bFamilyType = panose_values[0]
+    panose.bSerifStyle = panose_values[1]
+    panose.bWeight = panose_values[2]
+    panose.bProportion = panose_values[3]
+    panose.bContrast = panose_values[4]
+    panose.bStrokeVariation = panose_values[5]
+    panose.bArmStyle = panose_values[6]
+    panose.bLetterForm = panose_values[7]
+    panose.bMidline = panose_values[8]
+    panose.bXHeight = panose_values[9]
+    font["OS/2"].panose = panose
+
+    info = {
+        "familyName": family_name,
+        "styleName": style_name,
+        "styleMapFamilyName": stylemap_family_name,
+        "styleMapStyleName": stylemap_style_name,
+    }
+    build_name_entries(info, font["name"])
+
+    # style mapping
+    styleMapStyleName = font["name"].getName(2, 3, 1, 0x409).toStr().lower()
+    macStyle = []
+    if styleMapStyleName == "bold":
+        macStyle = [0]
+    elif styleMapStyleName == "bold italic":
+        macStyle = [0, 1]
+    elif styleMapStyleName == "italic":
+        macStyle = [1]
+    font["head"].macStyle = intListToNum(macStyle, 0, 16)
+
+    selection = font["OS/2"].fsSelection
+    selection &= ~(1 << 0)
+    selection &= ~(1 << 5)
+    selection &= ~(1 << 6)
+    if styleMapStyleName == "regular":
+        selection |= 1 << 6
+    elif styleMapStyleName == "bold":
+        selection |= 1 << 5
+    elif styleMapStyleName == "italic":
+        selection |= 1 << 0
+    elif styleMapStyleName == "bold italic":
+        selection |= 1 << 0
+        selection |= 1 << 5
+    font["OS/2"].fsSelection = selection
+
+    font.save(output_file)
+
+
+def build_name_entries(info: dict[str, Any], name: Any) -> None:
+    info = ufoLib2.objects.Info(**info)
+
+    familyName = getAttrWithFallback(info, "styleMapFamilyName")
+    styleName = getAttrWithFallback(info, "styleMapStyleName").title()
+    preferredFamilyName = getAttrWithFallback(info, "openTypeNamePreferredFamilyName")
+    preferredSubfamilyName = getAttrWithFallback(
+        info, "openTypeNamePreferredSubfamilyName"
+    )
+    fullName = f"{preferredFamilyName} {preferredSubfamilyName}"
+
+    nameVals = {
+        1: familyName,
+        2: styleName,
+        4: fullName,
+        6: getAttrWithFallback(info, "postscriptFontName"),
+        16: preferredFamilyName,
+        17: preferredSubfamilyName,
+    }
+
+    # don't add typographic names if they are the same as the legacy ones
+    if nameVals[1] == nameVals[16]:
+        del nameVals[16]
+        name.removeNames(nameID=16, platformID=3, platEncID=1, langID=0x409)
+    if nameVals[2] == nameVals[17]:
+        del nameVals[17]
+        name.removeNames(nameID=17, platformID=3, platEncID=1, langID=0x409)
+    # postscript font name
+    if nameVals[6]:
+        nameVals[6] = normalizeStringForPostscript(nameVals[6])
+
+    for nameId in sorted(nameVals.keys()):
+        nameVal = nameVals[nameId]
+        if not nameVal:
+            continue
+        platformId = 3
+        platEncId = 1
+        langId = 0x409
+        name.setName(nameVal, nameId, platformId, platEncId, langId)
+
+
+def main(args: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "variable_font", type=Path, help="Variable font to cut instances from."
+    )
+    parser.add_argument(
+        "designspace",
+        type=DesignSpaceDocument.fromfile,
+        help="Designspace to take instances from.",
+    )
+    parser.add_argument("output_path", type=Path, help="Output path.")
+    parsed_args = parser.parse_args(args)
+    designspace: DesignSpaceDocument = parsed_args.designspace
+    output_path: Path = parsed_args.output_path
+    variable_font: Path = parsed_args.variable_font
+
+    instance = next(
+        (i for i in designspace.instances if Path(i.filename).stem == output_path.stem),
+        None,
+    )
+    if instance is None:
+        parser.error(f"Cannot find instance with stem '{output_path.stem}'.")
+
+    name2tag = {axis.name: axis.tag for axis in designspace.axes}
+    name2axis = {axis.name: axis for axis in designspace.axes}
+    custom_parameters = dict(instance.lib["com.schriftgestaltung.customParameters"])
+    user_location = {
+        name2tag[k]: name2axis[k].map_backward(v) for k, v in instance.location.items()
+    }
+
+    family_name = custom_parameters.get("preferredFamilyName", instance.familyName)
+    style_name = custom_parameters.get("preferredSubfamilyName", instance.styleName)
+    stylemap_family_name = instance.styleMapFamilyName
+    stylemap_style_name = instance.styleMapStyleName
+
+    cut_instance(
+        variable_font,
+        user_location,
+        custom_parameters["panose"],
+        family_name,
+        style_name,
+        stylemap_family_name,
+        stylemap_style_name,
+        output_path,
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/internal/gdef.py
+++ b/scripts/internal/gdef.py
@@ -1,0 +1,322 @@
+# Copyright 2021 Google Sans Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Update the GDEF definition in the feature file.
+
+We want our own because Glyphs has the habit of propagating anchors on
+_everything_, even symbols that happen to contain components of latin
+glyphs with anchors.
+"""
+
+# pyright: basic
+
+from typing import Dict, Optional
+
+import glyphsLib.builder.constants
+import glyphsLib.glyphdata
+import ufoLib2
+
+KNOWN_BASES = {
+    "k_ssa-deva",
+    "j_nya-deva",
+    "k_ss-deva",
+    "k_ss-deva.alt2",
+    "k_ss-deva.alt3",
+    "k_ss-deva.alt4",
+    "k_ss-deva.alt5",
+    "k_ss-deva.alt6",
+    "k_ss-deva.alt7",
+    "j_ny-deva",
+    "j_ny-deva.alt2",
+    "j_ny-deva.alt3",
+    "j_ny-deva.alt4",
+    "j_ny-deva.alt5",
+    "j_ny-deva.alt6",
+    "j_ny-deva.alt7",
+    "j_ny-deva.alt8",
+    "ng_ya-deva",
+    "ch_ya-deva",
+    "tt_tta-deva",
+    "tt_ttha-deva",
+    "tt_ya-deva",
+    "tth_ttha-deva",
+    "tth_ya-deva",
+    "dd_dda-deva",
+    "dd_ddha-deva",
+    "dd_ya-deva",
+    "ddh_ddha-deva",
+    "ddh_ya-deva",
+    "t_ta-deva",
+    "t_ra-deva",
+    "d_ga-deva",
+    "d_gha-deva",
+    "d_da-deva",
+    "d_dha-deva",
+    "d_dh_ya-deva",
+    "d_ba-deva",
+    "d_bha-deva",
+    "d_ma-deva",
+    "d_ya-deva",
+    "d_ra-deva",
+    "d_va-deva",
+    "p_ta-deva",
+    "sh_ra-deva",
+    "ss_tta-deva",
+    "ss_ttha-deva",
+    "h_nna-deva",
+    "h_na-deva",
+    "h_ma-deva",
+    "h_ya-deva",
+    "h_ra-deva",
+    "h_la-deva",
+    "h_va-deva",
+    "h_ra_uMatra-deva",
+    "h_ra_uuMatra-deva",
+    "ba-khmer",
+    "ba-khmer.post",
+    "ba-khmer.post2",
+    "ba_aaSign-khmer",
+    "ba_aaSign-khmer.post2_",
+    "ba_aaSign-khmer.post_",
+    "ba_auSign-khmer",
+    "ba_auSign-khmer.post2_",
+    "ba_auSign-khmer.post_",
+    "beikoet-khmer",
+    "beiroc-khmer",
+    "buonkoet-khmer",
+    "buonroc-khmer",
+    "ca-khmer",
+    "ca_aaSign-khmer",
+    "ca_auSign-khmer",
+    "cha-khmer",
+    "cha_aaSign-khmer",
+    "cha_auSign-khmer",
+    "cho-khmer",
+    "cho-khmer.post",
+    "cho-khmer.post2",
+    "cho_aaSign-khmer",
+    "cho_aaSign-khmer.post2_",
+    "cho_aaSign-khmer.post_",
+    "cho_auSign-khmer",
+    "cho_auSign-khmer.post2_",
+    "cho_auSign-khmer.post_",
+    "co-khmer",
+    "co_aaSign-khmer",
+    "co_auSign-khmer",
+    "da-khmer",
+    "da_aaSign-khmer",
+    "da_auSign-khmer",
+    "dapBeikoet-khmer",
+    "dapBeiroc-khmer",
+    "dapBuonkoet-khmer",
+    "dapBuonroc-khmer",
+    "dapMuoykoet-khmer",
+    "dapMuoyroc-khmer",
+    "dapPiikoet-khmer",
+    "dapPiiroc-khmer",
+    "dapPramkoet-khmer",
+    "dapPramroc-khmer",
+    "dapkoet-khmer",
+    "daproc-khmer",
+    "do-khmer",
+    "do_aaSign-khmer",
+    "do_auSign-khmer",
+    "dottedCircle",
+    "ha-khmer",
+    "ha_aaSign-khmer",
+    "ha_auSign-khmer",
+    "ka-khmer",
+    "ka_aaSign-khmer",
+    "ka_auSign-khmer",
+    "kha-khmer",
+    "kha_aaSign-khmer",
+    "kha_auSign-khmer",
+    "kho-khmer",
+    "kho-khmer.post",
+    "kho-khmer.post2",
+    "kho_aaSign-khmer",
+    "kho_aaSign-khmer.post2_",
+    "kho_aaSign-khmer.post_",
+    "kho_auSign-khmer",
+    "kho_auSign-khmer.post2_",
+    "kho_auSign-khmer.post_",
+    "ko-khmer",
+    "ko_aaSign-khmer",
+    "ko_auSign-khmer",
+    "la-khmer",
+    "la_aaSign-khmer",
+    "la_auSign-khmer",
+    "lo-khmer",
+    "lo_aaSign-khmer",
+    "lo_auSign-khmer",
+    "mo-khmer",
+    "mo_aaSign-khmer",
+    "mo_auSign-khmer",
+    "muoykoet-khmer",
+    "muoyroc-khmer",
+    "ngo-khmer",
+    "ngo_aaSign-khmer",
+    "ngo_auSign-khmer",
+    "nno-khmer",
+    "nno_aaSign-khmer",
+    "nno_auSign-khmer",
+    "no-khmer",
+    "no_aaSign-khmer",
+    "no_auSign-khmer",
+    "nyo-khmer",
+    "nyo-khmer.less",
+    "nyo_aaSign-khmer",
+    "nyo_aaSign-khmer.less",
+    "nyo_auSign-khmer",
+    "nyo_auSign-khmer.less",
+    "pathamasat-khmer",
+    "pha-khmer",
+    "pha_aaSign-khmer",
+    "pha_auSign-khmer",
+    "pho-khmer",
+    "pho_aaSign-khmer",
+    "pho_auSign-khmer",
+    "piikoet-khmer",
+    "piiroc-khmer",
+    "po-khmer",
+    "po_aaSign-khmer",
+    "po_auSign-khmer",
+    "pramBeikoet-khmer",
+    "pramBeiroc-khmer",
+    "pramBuonkoet-khmer",
+    "pramBuonroc-khmer",
+    "pramMuoykoet-khmer",
+    "pramMuoyroc-khmer",
+    "pramPiikoet-khmer",
+    "pramPiiroc-khmer",
+    "pramkoet-khmer",
+    "pramroc-khmer",
+    "qa-khmer",
+    "qa_aaSign-khmer",
+    "qa_auSign-khmer",
+    "ro-khmer",
+    "ro_aaSign-khmer",
+    "ro_auSign-khmer",
+    "sa-khmer",
+    "sa-khmer.post",
+    "sa_aaSign-khmer",
+    "sa_aaSign-khmer.post_",
+    "sa_auSign-khmer",
+    "sa_auSign-khmer.post_",
+    "sha-khmer",
+    "sha_aaSign-khmer",
+    "sha_auSign-khmer",
+    "sso-khmer",
+    "sso-khmer.post",
+    "sso_aaSign-khmer",
+    "sso_aaSign-khmer.post_",
+    "sso_auSign-khmer",
+    "sso_auSign-khmer.post_",
+    "ta-khmer",
+    "ta_aaSign-khmer",
+    "ta_auSign-khmer",
+    "tha-khmer",
+    "tha_aaSign-khmer",
+    "tha_auSign-khmer",
+    "tho-khmer",
+    "tho_aaSign-khmer",
+    "tho_auSign-khmer",
+    "to-khmer",
+    "to_aaSign-khmer",
+    "to_auSign-khmer",
+    "ttha-khmer",
+    "ttha_aaSign-khmer",
+    "ttha_auSign-khmer",
+    "ttho-khmer",
+    "ttho-khmer.post",
+    "ttho-khmer.post2",
+    "ttho_aaSign-khmer",
+    "ttho_aaSign-khmer.post2_",
+    "ttho_aaSign-khmer.post_",
+    "ttho_auSign-khmer",
+    "ttho_auSign-khmer.post2_",
+    "ttho_auSign-khmer.post_",
+    "tuteyasat-khmer",
+    "vo-khmer",
+    "vo_aaSign-khmer",
+    "vo_auSign-khmer",
+    "yo-khmer",
+    "yo-khmer.post",
+    "yo-khmer.post2",
+    "yo_aaSign-khmer",
+    "yo_aaSign-khmer.post2_",
+    "yo_aaSign-khmer.post_",
+    "yo_auSign-khmer",
+    "yo_auSign-khmer.post2_",
+    "yo_auSign-khmer.post_",
+}
+
+
+def update_opentype_categories(ufo: ufoLib2.Font) -> Dict[str, str]:
+    """Returns a `public.openTypeCategories` dictionary.
+
+    Building it requires anchor propagation or user care to work as
+    expected, as Glyphs.app also looks at anchors for classification:
+
+    * base: any glyph that has an attaching anchor (such as "top"; "_top" does
+      not count) and is neither classified as Ligature nor Mark using the
+      definitions below;
+    * ligature: if subCategory is "Ligature" and the glyph has at least one
+      attaching anchor;
+    * mark: if category is "Mark" and subCategory is either "Nonspacing" or
+      "Spacing Combining";
+    * composite: never assigned by Glyphs.app.
+
+    See:
+
+    * https://github.com/googlefonts/glyphsLib/issues/85
+    * https://github.com/googlefonts/glyphsLib/pull/100#issuecomment-275430289
+    """
+
+    # Drop glyphs that don't exist in font anymore.
+    existing: Dict[str, str] = ufo.lib.get("public.openTypeCategories", {})
+    categories: Dict[str, str] = {k: v for k, v in existing.items() if k in ufo}
+
+    category_key = glyphsLib.builder.constants.GLYPHLIB_PREFIX + "category"
+    subcategory_key = glyphsLib.builder.constants.GLYPHLIB_PREFIX + "subCategory"
+
+    for glyph in ufo:
+        assert glyph.name is not None
+        has_attaching_anchor = False
+        for anchor in glyph.anchors:
+            name = anchor.name
+            if not name:
+                continue
+            if not name.startswith("_"):
+                has_attaching_anchor = True
+
+        # First check glyph.lib for category/subCategory overrides. Otherwise,
+        # use global values from GlyphData.
+        glyphinfo = glyphsLib.glyphdata.get_glyph(glyph.name)
+        category: Optional[str] = glyph.lib.get(category_key, glyphinfo.category)
+        subcategory: Optional[str] = glyph.lib.get(
+            subcategory_key, glyphinfo.subCategory
+        )
+
+        if glyph.name in KNOWN_BASES:
+            categories[glyph.name] = "base"
+        elif subcategory == "Ligature" and has_attaching_anchor:
+            categories[glyph.name] = "ligature"
+        elif category == "Mark" and (
+            subcategory == "Nonspacing" or subcategory == "Spacing Combining"
+        ):
+            categories[glyph.name] = "mark"
+        elif category == "Letter" and has_attaching_anchor:
+            categories[glyph.name] = "base"
+
+    return categories

--- a/scripts/internal/normalize.py
+++ b/scripts/internal/normalize.py
@@ -1,0 +1,316 @@
+# pyright: basic
+# Copyright 2021 Google Sans Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+import copy
+from pathlib import Path
+from typing import Dict, List, Set, Tuple, Union
+
+import ufo2ft
+import ufoLib2
+from fontTools.designspaceLib import (
+    DesignSpaceDocument,
+    InstanceDescriptor,
+    RuleDescriptor,
+    SourceDescriptor,
+)
+from fontTools.misc.transform import Transform
+from glyphsLib.builder.builders import _expand_kerning_to_brackets
+
+from . import gdef
+
+MASTER_ID_KEY = "com.schriftgestaltung.fontMasterID"
+
+
+def scrub_designspace(designspace: DesignSpaceDocument, project_root: Path) -> None:
+    designspace.loadSourceFonts(ufoLib2.Font.open)
+    skip_export_glyphs = set(designspace.lib.get("public.skipExportGlyphs", []))
+    rules = designspace.rules
+    ot_categories = infer_opentype_categories(designspace.default.font)
+
+    for source in designspace.sources:
+        scrub_source(source, skip_export_glyphs, rules, ot_categories)
+
+    scrub_groups(designspace.default, designspace.sources)
+
+    if any(a.tag == "GRAD" for a in designspace.axes):
+        scrub_graded_sources(designspace.sources)
+
+    for instance in designspace.instances:
+        scrub_instance(instance, project_root)
+
+    if skip_export_glyphs:
+        designspace.lib["public.skipExportGlyphs"] = sorted(skip_export_glyphs)
+    designspace.lib = {
+        k: v
+        for k, v in designspace.lib.items()
+        if k.startswith("public.")
+        or k.startswith("com.github.googlei18n.ufo2ft.")
+        or k == "GSDimensionPlugin.Dimensions"
+    }
+
+
+def scrub_instance(instance: InstanceDescriptor, project_root: Path) -> None:
+    lib = instance.lib
+    if not lib:
+        return
+
+    # Custom parameters influence the build.
+    keys_to_keep = {"com.schriftgestaltung.customParameters"}
+
+    # Exporting is the default, only remember if not exporting.
+    if lib.get("com.schriftgestaltung.export") is False:
+        keys_to_keep.add("com.schriftgestaltung.export")
+
+    instance.lib = {
+        k: v for k, v in lib.items() if k.startswith("public.") or k in keys_to_keep
+    }
+
+    # Trick DesignSpaceDocument.updatePaths() into doing the right thing.
+    filename = Path(instance.filename)
+    instance.filename = None
+    instance.path = str(
+        project_root / "build" / "GoogleSans" / "instance_ufo" / filename.name
+    )
+
+
+def scrub_source(
+    source: SourceDescriptor,
+    skip_export_glyphs: Set[str],
+    rules: List[RuleDescriptor],
+    ot_categories: Dict[str, str],
+) -> None:
+    scrub_ufo(source.font, skip_export_glyphs, rules, ot_categories)
+
+
+def scrub_ufo(
+    ufo: ufoLib2.Font,
+    skip_export_glyphs: Set[str],
+    rules: List[RuleDescriptor],
+    ot_categories: Dict[str, str],
+) -> None:
+    # Clean global lib.
+    keys_to_keep = {
+        # UFOs don't need lastChanged because glyphs are separate files, keep it disabled.
+        "com.schriftgestaltung.customParameter.GSFont.disablesLastChange",
+        # May be useful for Glyphs.
+        "com.schriftgestaltung.customParameter.GSFont.Enforce Compatibility Check",
+        # Cuts down on ufo2glyphs Git diffs slightly.
+        MASTER_ID_KEY,
+    }
+    keys_to_remove = {
+        # Using production names is fontmake's default.
+        "com.github.googlei18n.ufo2ft.useProductionNames"
+    }
+    ufo.lib = {
+        k: v
+        for k, v in ufo.lib.items()
+        if (
+            k.startswith("public.")
+            or k.startswith("com.github.googlei18n.ufo2ft.")
+            or k in keys_to_keep
+        )
+        and k not in keys_to_remove
+    }
+
+    ufo.lib["public.skipExportGlyphs"] = sorted(skip_export_glyphs)
+    ufo.lib["public.postscriptNames"] = {
+        k: v for k, v in ufo.lib["public.postscriptNames"].items() if k in ufo
+    }
+
+    # Reset the ufo2ft filters.
+    ufo.lib["com.github.googlei18n.ufo2ft.filters"] = [
+        {"name": "decomposeTransformedComponents", "pre": True},
+        {
+            "name": "propagateAnchors",
+            "pre": True,
+            # Compiling Glyphs files to VFs does not propagate anchors in the following
+            # glyphs:
+            "exclude": [
+                "K.alt",
+                "caroncomb.alt",
+                "caroncomb.alt.cap",
+                "comma.alt",
+                "k.alt",
+                "quoteright.alt",
+                "r.alt",
+            ],
+        },
+        # Uncomment after attaining parity between Glyphs file and DS compilation.
+        {"name": "flattenComponents", "pre": True},
+    ]
+
+    # Delete non-build-relevant layers.
+    layers_to_delete = []
+    for layer in ufo.layers:
+        if layer is ufo.layers.defaultLayer:
+            continue
+        if layer.name.startswith(("[", "{")) and ".background" not in layer.name:
+            continue
+        layers_to_delete.append(layer.name)
+    for layer_name in layers_to_delete:
+        del ufo.layers[layer_name]
+
+    for layer in ufo.layers:
+        layer.lib = {
+            k: v
+            for k, v in layer.lib.items()
+            if k.startswith("public.")
+            or not k.startswith("com.schriftgestaltung.layerOrderInGlyph.")
+        }
+
+    # Clean glifs.
+    for layer in ufo.layers:
+        for glyph in layer:
+            # Turn coordinates like "123.0" into "123".
+            glyph.width = clean_number(glyph.width)
+            for anchor in glyph.anchors:
+                anchor.x = clean_number(anchor.x)
+                anchor.y = clean_number(anchor.y)
+            for guideline in glyph.guidelines:
+                if guideline.x is not None:
+                    guideline.x = clean_number(guideline.x)
+                if guideline.y is not None:
+                    guideline.y = clean_number(guideline.y)
+                if guideline.angle is not None:
+                    guideline.angle = clean_number(guideline.angle)
+            for contour in glyph:
+                for point in contour:
+                    point.x = clean_number(point.x)
+                    point.y = clean_number(point.y)
+            for component in glyph.components:
+                t = component.transformation
+                component.transformation = Transform(
+                    clean_number(t.xx),
+                    clean_number(t.xy),
+                    clean_number(t.yx),
+                    clean_number(t.yy),
+                    clean_number(t.dx),
+                    clean_number(t.dy),
+                )
+
+            if not glyph.lib:
+                continue
+
+            glyph.lib = {
+                k: v
+                for k, v in glyph.lib.items()
+                if (k.startswith("public.") and k != "public.markColor")
+                or (
+                    k.startswith("com.schriftgestaltung.Glyphs.")
+                    and k != "com.schriftgestaltung.Glyphs.lastChange"
+                )
+            }
+
+    # Clean out empty/non-existing groups and kerning pairs.
+    new_groups = {}
+    for key, value in ufo.groups.items():
+        new_value = [v for v in value if v in ufo]
+        if new_value:
+            new_groups[key] = new_value
+    ufo.groups.clear()
+    ufo.groups.update(new_groups)
+
+    new_kerning = {}
+    for key, value in ufo.kerning.items():
+        first, second = key
+        if (first in ufo.groups or first in ufo) and (
+            second in ufo.groups or second in ufo
+        ):
+            new_kerning[key] = value
+    ufo.kerning.clear()
+    ufo.kerning.update(new_kerning)
+
+    # Bracket glyphs are a Glyphs.app construct that inherit the kerning from
+    # their parents.
+    for rule in rules:
+        for name, name_bracket in rule.subs:
+            _expand_kerning_to_brackets(name, name_bracket, ufo)
+
+    # Use OpenType GDEF categories inferred from default source.
+    ufo.lib["public.openTypeCategories"] = ot_categories
+
+
+def clean_number(v: Union[int, float]) -> float:
+    if isinstance(v, int):
+        return v
+    if v.is_integer():
+        return int(v)
+    return v
+
+
+def location_to_key(
+    location: Dict[str, float], skip_axis: str = "Grade"
+) -> Tuple[Tuple[str, float], ...]:
+    return tuple((k, v) for k, v in location.items() if k != skip_axis)
+
+
+def scrub_graded_sources(sources: List[SourceDescriptor]) -> None:
+    default_grades = []
+    grade_mapping = collections.defaultdict(list)
+    for source in sources:
+        if source.location["Grade"]:
+            grade_mapping[location_to_key(source.location)].append(source)
+        else:
+            default_grades.append(source)
+
+    for source in default_grades:
+        all_glyphs = set(source.font.keys())
+        for graded_source in grade_mapping[location_to_key(source.location)]:
+            # NOTE: This copies missing glyphs from the base masters to graded ones.
+            # It only works the first time around!
+            graded_glyphs = set(graded_source.font.keys())
+            graded_default_layer = graded_source.font.layers.defaultLayer
+            for glyph_name in all_glyphs - graded_glyphs:
+                graded_default_layer.insertGlyph(
+                    source.font[glyph_name], overwrite=True
+                )
+
+            graded_source.font.groups = source.font.groups
+            graded_source.font.kerning = source.font.kerning
+
+            graded_master_id = graded_source.font.lib.get(MASTER_ID_KEY)
+            graded_source.font.lib = copy.copy(source.font.lib)
+            graded_source.font.lib[MASTER_ID_KEY] = graded_master_id
+
+
+def scrub_groups(
+    default_source: SourceDescriptor, all_sources: List[SourceDescriptor]
+) -> None:
+    """Remove unused kerning groups."""
+
+    used = set()
+    for source in all_sources:
+        for (first, second) in source.font.kerning:
+            if first.startswith("public.kern1."):
+                used.add(first)
+            if second.startswith("public.kern2."):
+                used.add(second)
+    scrubbed_groups = {k: v for k, v in default_source.font.groups.items() if k in used}
+    for source in all_sources:
+        source.font.groups.clear()
+        source.font.groups.update(scrubbed_groups)
+
+
+def infer_opentype_categories(source: ufoLib2.Font) -> Dict[str, str]:
+    # Update GDEF table. Anchors have to be propagated before we can construct
+    # the GDEF table. Use the UFO copy so we can safely save the original with
+    # just updated features.
+    ufo_copy = copy.deepcopy(source)
+    pre_filter, _ = ufo2ft.filters.loadFilters(ufo_copy)
+    for pf in pre_filter:
+        pf(font=ufo_copy)
+
+    return gdef.update_opentype_categories(ufo_copy)

--- a/scripts/internal/prune_font_binary.py
+++ b/scripts/internal/prune_font_binary.py
@@ -1,0 +1,75 @@
+# Copyright 2020 Google Sans Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import shutil
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from fontTools.subset import main as subset_main
+
+
+def main(args: Optional[List[str]] = None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("fonts", nargs="+", type=Path, help="Fonts to subset in-place.")
+    parsed_args = parser.parse_args(args)
+
+    logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.WARNING)
+    LOGGER = logging.getLogger(__name__)
+
+    for font in parsed_args.fonts:
+        local_filepath = font.resolve()
+        local_filepath_subset = f"{local_filepath}.subset"
+
+        # The subsetter configuration preserves all OT feature support.
+        # It will remove unused, unencoded glyphs.
+        subset_args_expert = [
+            str(local_filepath),
+            "--unicodes=*",
+            "--no-ignore-missing-glyphs",
+            "--notdef-outline",
+            "--layout-features=*",
+            "--name-IDs=*",
+            "--name-languages=*",
+            "--glyph-names",
+            "--no-prune-unicode-ranges",
+            "--recalc-bounds",
+            f"--output-file={local_filepath_subset}",
+        ]
+
+        try:
+            subset_main(subset_args_expert)
+        except Exception as e:
+            LOGGER.error(
+                "ERROR: subsetting error during attempt to subset %s: %s",
+                local_filepath,
+                str(e),
+            )
+            sys.exit(1)
+
+        try:
+            shutil.move(local_filepath_subset, local_filepath)
+        except Exception as e:
+            LOGGER.error(
+                "ERROR: during move of subset file %s: %s",
+                local_filepath,
+                str(e),
+            )
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/internal/reachable_glyphs.py
+++ b/scripts/internal/reachable_glyphs.py
@@ -1,0 +1,52 @@
+# Copyright 2021 Google Sans Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Set
+
+import ufo2ft.featureCompiler
+import ufo2ft.util
+from ufoLib2.objects import Font, Glyph
+
+
+def reachable_glyphs(ufo: Font) -> Set[str]:
+    """Return set of glyph names of glyphs reachable via Unicode value and
+    feature substitutions."""
+
+    features = ufo2ft.featureCompiler.parseLayoutFeatures(ufo)
+    glyph_order = list(ufo.keys())
+    gsub = ufo2ft.util.compileGSUB(features, glyph_order)
+    reachable_glyphs = {g.name for g in ufo if g.unicode is not None}
+    reachable_glyphs.add(".notdef")
+    ufo2ft.util.closeGlyphsOverGSUB(gsub, reachable_glyphs)
+
+    return reachable_glyphs
+
+
+def referenced_as_components(ufo: Font, reachable_glyphs: Set[str]) -> Set[str]:
+    """Return set of glyph names of glyphs used as components by glyphs in
+    reachable_glyphs."""
+
+    def _recurse(glyph: Glyph, seen: Set[str]) -> None:
+        for component in glyph.components:
+            seen.add(component.baseGlyph)
+            _recurse(ufo[component.baseGlyph], seen)
+
+    referenced_components = set()
+    for name in reachable_glyphs:
+        glyph = ufo[name]
+        _recurse(glyph, referenced_components)
+
+    return referenced_components

--- a/scripts/internal/set-overlap-bits.py
+++ b/scripts/internal/set-overlap-bits.py
@@ -1,0 +1,90 @@
+# Copyright 2022 Google Sans Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pathops
+import uharfbuzz as hb
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables import _g_l_y_f
+
+
+def overlapping_glyphs(
+    font: hb.Font, coordinates: list[dict[str, float]], num_glyphs: int
+) -> set[int]:
+    """Return the set of glyph IDs that overlap in any of the user
+    coordinates."""
+    overlapping = set()
+    for gid in range(num_glyphs):
+        for coordinate in coordinates:
+            font.set_variations(coordinate)
+            path = pathops.Path()
+            font.draw_glyph_with_pen(gid, path.getPen())
+            # Remove overlaps (and do some other stuff):
+            path2 = pathops.simplify(path, clockwise=path.clockwise)
+            if path != path2:
+                overlapping.add(gid)
+                break  # If the glyph overlaps in one place, the bit must be set for all.
+    return overlapping
+
+
+def set_overlap_bits_if_overlapping(
+    varfont: TTFont, overlapping_glyphs: set[int]
+) -> tuple[int, int]:
+    name_mapping = varfont.getGlyphNameMany(overlapping_glyphs)
+    glyf_table: _g_l_y_f.table__g_l_y_f = varfont["glyf"]
+
+    overlapping_contours = 0
+    overlapping_components = 0
+    for glyph_name in name_mapping:
+        glyph = glyf_table[glyph_name]
+        # Set OVERLAP_COMPOUND bit for compound glyphs
+        if glyph.isComposite():
+            overlapping_components += 1
+            glyph.components[0].flags |= _g_l_y_f.OVERLAP_COMPOUND
+        # Set OVERLAP_SIMPLE bit for simple glyphs
+        elif glyph.numberOfContours > 0:
+            overlapping_contours += 1
+            glyph.flags[0] |= _g_l_y_f.flagOverlapSimple
+
+    return (overlapping_contours, overlapping_components)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("font", nargs="+", type=Path)
+parsed_args = parser.parse_args()
+fonts: list[Path] = parsed_args.font
+
+for font_path in fonts:
+    font = TTFont(font_path)
+    num_glyphs = font["maxp"].numGlyphs
+    fvar = font["fvar"]
+
+    instance_coordinates = [instance.coordinates for instance in fvar.instances]
+    hbfont = hb.Font(hb.Face(hb.Blob.from_file_path(font_path)))
+    overlapping_glyphs = overlapping_glyphs(hbfont, instance_coordinates, num_glyphs)
+
+    ocont, ocomp = set_overlap_bits_if_overlapping(font, overlapping_glyphs)
+    ocont_p = ocont / num_glyphs
+    ocomp_p = ocomp / num_glyphs
+    print(
+        font.reader.file.name,
+        f"{num_glyphs} glyphs, "
+        f"{ocont} overlapping contours ({ocont_p:.2%}), "
+        f"{ocomp} overlapping components ({ocomp_p:.2%})",
+    )
+    font.save(font_path)


### PR DESCRIPTION
Copy the scripts from GS.

I converted the uprights to .glyphs and loaded them into Glyphs 2.6.x without problems. I had to save the file there before I could open it in Glyphs 3, because the ascender fontinfo value for one of the sources is a floating point value when it shouldn't be, but that can also be fixed by hand.

I suppose we can go with the GS merge workflow, which I can work on when we get to it.