### PR TITLE
Fix some roundtripping attempts

### DIFF
--- a/scripts/gs-merge-designspace.py
+++ b/scripts/gs-merge-designspace.py
@@ -312,7 +312,7 @@ for import_source in designspace_import.sources:
 
 # If we import sources that don't have a GRAD axis yet, copy all imported glyphs
 # and other data from above over to our existing GRAD sources.
-if import_is_ungraded:
+if import_is_ungraded and any(a.name == "Grade" for a in designspace_target.axes):
     default_grades = []
     grade_mapping = collections.defaultdict(list)
     for source in designspace_target.sources:

--- a/scripts/gs-normalize-designspace.py
+++ b/scripts/gs-normalize-designspace.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright 2020 Google Sans Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Normalize all Designspaces and attached UFOs in a directory to match the
+source conventions."""
+
+import argparse
+from pathlib import Path
+
+from fontTools.designspaceLib import DesignSpaceDocument
+
+from internal import normalize
+
+ROOT_DIR = Path(__file__).parent.parent
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "source_dir",
+    type=Path,
+    help="Path to source directory.",
+)
+parsed_args = parser.parse_args()
+
+for designspace_path in parsed_args.source_dir.glob("*.designspace"):
+    designspace = DesignSpaceDocument.fromfile(designspace_path)
+
+    normalize.scrub_designspace(designspace, ROOT_DIR)
+
+    for source in designspace.sources:
+        source.font.save()
+    designspace.write(designspace_path)

--- a/scripts/internal/normalize.py
+++ b/scripts/internal/normalize.py
@@ -207,7 +207,10 @@ def scrub_ufo(
             glyph.lib = {
                 k: v
                 for k, v in glyph.lib.items()
-                if (k.startswith("public.") and k != "public.markColor")
+                if (
+                    k.startswith("public.")
+                    and k not in {"public.markColor", "public.verticalOrigin"}
+                )
                 or (
                     k.startswith("com.schriftgestaltung.Glyphs.")
                     and k != "com.schriftgestaltung.Glyphs.lastChange"


### PR DESCRIPTION
* Don't crash when no Grade axis is found
* Normalize glyph's verticalOrigins away, a side effect of newer glyphsLibs