### PR TITLE
Import from it-ad-wip-italic-v1.002

### DIFF
--- a/sources/italic/GoogleSansFlex-Italic.designspace
+++ b/sources/italic/GoogleSansFlex-Italic.designspace
@@ -1037,7 +1037,7 @@
     </source>
   </sources>
   <instances>
-    <instance stylename="Thin Italic">
+    <instance stylename="Thin">
       <location>
         <dimension name="Weight" xvalue="100"/>
         <dimension name="Width" xvalue="100"/>
@@ -1047,7 +1047,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance stylename="ExtraLight Italic">
+    <instance stylename="ExtraLight">
       <location>
         <dimension name="Weight" xvalue="200"/>
         <dimension name="Width" xvalue="100"/>
@@ -1057,7 +1057,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance stylename="Light Italic">
+    <instance stylename="Light">
       <location>
         <dimension name="Weight" xvalue="300"/>
         <dimension name="Width" xvalue="100"/>
@@ -1067,7 +1067,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance stylename="Italic">
+    <instance stylename="Regular">
       <location>
         <dimension name="Weight" xvalue="400"/>
         <dimension name="Width" xvalue="100"/>
@@ -1077,7 +1077,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance stylename="Medium Italic">
+    <instance stylename="Medium">
       <location>
         <dimension name="Weight" xvalue="500"/>
         <dimension name="Width" xvalue="100"/>
@@ -1087,7 +1087,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance stylename="SemiBold Italic">
+    <instance stylename="SemiBold">
       <location>
         <dimension name="Weight" xvalue="600"/>
         <dimension name="Width" xvalue="100"/>
@@ -1097,7 +1097,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance stylename="Bold Italic">
+    <instance stylename="Bold">
       <location>
         <dimension name="Weight" xvalue="700"/>
         <dimension name="Width" xvalue="100"/>
@@ -1107,7 +1107,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance stylename="ExtraBold Italic">
+    <instance stylename="ExtraBold">
       <location>
         <dimension name="Weight" xvalue="800"/>
         <dimension name="Width" xvalue="100"/>
@@ -1117,7 +1117,7 @@
       <kerning/>
       <info/>
     </instance>
-    <instance stylename="Black Italic">
+    <instance stylename="Black">
       <location>
         <dimension name="Weight" xvalue="900"/>
         <dimension name="Width" xvalue="100"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/fontinfo.plist
@@ -133,7 +133,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -141,7 +141,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1712"/>
   <unicode hex="004F"/>
-  <guideline x="856" y="0" angle="90" identifier="f2nbMxCHci"/>
-  <anchor x="856" y="0" name="bottom"/>
-  <anchor x="856" y="716" name="center"/>
-  <anchor x="1088" y="0" name="ogonek"/>
-  <anchor x="856" y="1432" name="top"/>
-  <anchor x="1076" y="1432" name="topright"/>
+  <guideline x="855.9264451679694" y="0" angle="90" identifier="f2nbMxCHci"/>
+  <anchor x="765.9264451679694" y="0" name="bottom"/>
+  <anchor x="891.9264451679694" y="716" name="center"/>
+  <anchor x="997.9264451679694" y="0" name="ogonek"/>
+  <anchor x="1018.9264451679694" y="1432" name="top"/>
+  <anchor x="1238.9264451679694" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="856" y="-32" type="qcurve" smooth="yes"/>
-      <point x="535" y="-32" name="inserted"/>
-      <point x="120" y="390"/>
-      <point x="120" y="716" type="qcurve"/>
-      <point x="120" y="716" type="line"/>
-      <point x="120" y="1042" name="inserted"/>
-      <point x="535" y="1464"/>
-      <point x="856" y="1464" type="qcurve" smooth="yes"/>
-      <point x="1177" y="1464" name="inserted"/>
-      <point x="1592" y="1042"/>
-      <point x="1592" y="716" type="qcurve"/>
-      <point x="1592" y="716" type="line"/>
-      <point x="1592" y="390" name="inserted"/>
-      <point x="1177" y="-32"/>
+      <point x="761" y="-32" type="qcurve" smooth="yes"/>
+      <point x="440" y="-32" name="inserted"/>
+      <point x="99" y="390"/>
+      <point x="156" y="716" type="qcurve"/>
+      <point x="156" y="716" type="line"/>
+      <point x="214" y="1042" name="inserted"/>
+      <point x="703" y="1464"/>
+      <point x="1024" y="1464" type="qcurve" smooth="yes"/>
+      <point x="1345" y="1464" name="inserted"/>
+      <point x="1686" y="1042"/>
+      <point x="1628" y="716" type="qcurve"/>
+      <point x="1628" y="716" type="line"/>
+      <point x="1571" y="390" name="inserted"/>
+      <point x="1082" y="-32"/>
     </contour>
     <contour>
-      <point x="856" y="-28" type="qcurve" smooth="yes"/>
-      <point x="1175" y="-28" name="inserted"/>
-      <point x="1588" y="391"/>
-      <point x="1588" y="716" type="qcurve"/>
-      <point x="1588" y="716" type="line"/>
-      <point x="1588" y="1041" name="inserted"/>
-      <point x="1175" y="1460"/>
-      <point x="856" y="1460" type="qcurve" smooth="yes"/>
-      <point x="537" y="1460" name="inserted"/>
-      <point x="124" y="1041"/>
-      <point x="124" y="716" type="qcurve"/>
-      <point x="124" y="716" type="line"/>
-      <point x="124" y="391" name="inserted"/>
-      <point x="537" y="-28"/>
+      <point x="761" y="-28" type="qcurve" smooth="yes"/>
+      <point x="1080" y="-28" name="inserted"/>
+      <point x="1567" y="391"/>
+      <point x="1624" y="716" type="qcurve"/>
+      <point x="1624" y="716" type="line"/>
+      <point x="1682" y="1041" name="inserted"/>
+      <point x="1343" y="1460"/>
+      <point x="1024" y="1460" type="qcurve" smooth="yes"/>
+      <point x="705" y="1460" name="inserted"/>
+      <point x="218" y="1041"/>
+      <point x="160" y="716" type="qcurve"/>
+      <point x="160" y="716" type="line"/>
+      <point x="103" y="391" name="inserted"/>
+      <point x="442" y="-28"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/O_slash-bar.glif
@@ -3,28 +3,28 @@
   <advance width="1351"/>
   <outline>
     <contour>
-      <point x="670" y="757" type="line"/>
-      <point x="1273" y="1515" type="line"/>
-      <point x="1277" y="1520"/>
-      <point x="1277" y="1520"/>
-      <point x="1278" y="1519" type="qcurve"/>
-      <point x="1278" y="1519" type="line"/>
-      <point x="1280" y="1517"/>
-      <point x="1280" y="1517" name="inserted"/>
-      <point x="1276" y="1512" type="qcurve" smooth="yes"/>
-      <point x="674" y="754" type="line"/>
+      <point x="669.9264451679694" y="757" type="line"/>
+      <point x="1272.9264451679694" y="1515" type="line"/>
+      <point x="1276.9264451679694" y="1520"/>
+      <point x="1276.9264451679694" y="1520"/>
+      <point x="1277.9264451679694" y="1519" type="qcurve"/>
+      <point x="1277.9264451679694" y="1519" type="line"/>
+      <point x="1279.9264451679694" y="1517"/>
+      <point x="1279.9264451679694" y="1517" name="inserted"/>
+      <point x="1275.9264451679694" y="1512" type="qcurve" smooth="yes"/>
+      <point x="673.9264451679694" y="754" type="line"/>
     </contour>
     <contour>
-      <point x="86" y="21" type="qcurve"/>
-      <point x="670" y="757" type="line"/>
-      <point x="674" y="754" type="line"/>
-      <point x="89" y="18" type="line"/>
-      <point x="85" y="13"/>
-      <point x="85" y="13"/>
-      <point x="84" y="14" type="qcurve"/>
-      <point x="84" y="14" type="line"/>
-      <point x="82" y="16"/>
-      <point x="82" y="16" name="inserted"/>
+      <point x="85.92644516796938" y="21" type="qcurve"/>
+      <point x="669.9264451679694" y="757" type="line"/>
+      <point x="673.9264451679694" y="754" type="line"/>
+      <point x="88.92644516796938" y="18" type="line"/>
+      <point x="84.92644516796938" y="13"/>
+      <point x="84.92644516796938" y="13"/>
+      <point x="83.92644516796938" y="14" type="qcurve"/>
+      <point x="83.92644516796938" y="14" type="line"/>
+      <point x="81.92644516796938" y="16"/>
+      <point x="81.92644516796938" y="16" name="inserted"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="1712"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="175" yOffset="-50"/>
+    <component base="O" identifier="8EEF40A4"/>
+    <component base="Oslash-bar" xOffset="175" yOffset="-50" identifier="0A2E7F32"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>0A2E7F32</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>8EEF40A4</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/nine.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/nine.glif
@@ -4,59 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="498" y="1448" type="line"/>
-      <point x="710" y="1448"/>
-      <point x="974" y="1172"/>
-      <point x="974" y="982" type="qcurve"/>
-      <point x="974" y="982" type="line"/>
-      <point x="974" y="762" name="inserted"/>
-      <point x="667" y="528"/>
-      <point x="496" y="528" type="qcurve"/>
-      <point x="496" y="528" type="line"/>
-      <point x="294" y="528" name="inserted"/>
-      <point x="22" y="777"/>
-      <point x="22" y="982" type="qcurve"/>
-      <point x="22" y="982" type="line"/>
-      <point x="22" y="1185" name="inserted"/>
-      <point x="288" y="1448"/>
-      <point x="498" y="1448" type="qcurve"/>
+      <point x="497.9264451679694" y="1448" type="line"/>
+      <point x="709.9264451679694" y="1448"/>
+      <point x="973.9264451679694" y="1172"/>
+      <point x="973.9264451679694" y="982" type="qcurve"/>
+      <point x="973.9264451679694" y="982" type="line"/>
+      <point x="973.9264451679694" y="762" name="inserted"/>
+      <point x="666.9264451679694" y="528"/>
+      <point x="495.9264451679694" y="528" type="qcurve"/>
+      <point x="495.9264451679694" y="528" type="line"/>
+      <point x="293.9264451679694" y="528" name="inserted"/>
+      <point x="21.926445167969376" y="777"/>
+      <point x="21.926445167969376" y="982" type="qcurve"/>
+      <point x="21.926445167969376" y="982" type="line"/>
+      <point x="21.926445167969376" y="1185" name="inserted"/>
+      <point x="287.9264451679694" y="1448"/>
+      <point x="497.9264451679694" y="1448" type="qcurve"/>
     </contour>
     <contour>
-      <point x="972" y="982" type="line"/>
-      <point x="974" y="982" type="line"/>
-      <point x="974" y="853"/>
-      <point x="869" y="671"/>
-      <point x="730" y="485" type="qcurve" smooth="yes"/>
-      <point x="347" y="-29" type="line"/>
-      <point x="345" y="-32"/>
-      <point x="345" y="-32"/>
-      <point x="343" y="-31" type="qcurve"/>
-      <point x="343" y="-31" type="line"/>
-      <point x="341" y="-30"/>
-      <point x="341" y="-30"/>
-      <point x="344" y="-26" type="qcurve"/>
-      <point x="727" y="488" type="line" smooth="yes"/>
-      <point x="840" y="640"/>
-      <point x="957" y="825"/>
-      <point x="967" y="906" type="qcurve"/>
+      <point x="971.9264451679694" y="982" type="line"/>
+      <point x="973.9264451679694" y="982" type="line"/>
+      <point x="973.9264451679694" y="853"/>
+      <point x="868.9264451679694" y="671"/>
+      <point x="729.9264451679694" y="485" type="qcurve" smooth="yes"/>
+      <point x="346.9264451679694" y="-29" type="line"/>
+      <point x="344.9264451679694" y="-32"/>
+      <point x="344.9264451679694" y="-32"/>
+      <point x="342.9264451679694" y="-31" type="qcurve"/>
+      <point x="342.9264451679694" y="-31" type="line"/>
+      <point x="340.9264451679694" y="-30"/>
+      <point x="340.9264451679694" y="-30"/>
+      <point x="343.9264451679694" y="-26" type="qcurve"/>
+      <point x="726.9264451679694" y="488" type="line" smooth="yes"/>
+      <point x="839.9264451679694" y="640"/>
+      <point x="956.9264451679694" y="825"/>
+      <point x="966.9264451679694" y="906" type="qcurve"/>
     </contour>
     <contour>
-      <point x="498" y="1444" type="qcurve"/>
-      <point x="498" y="1444" type="line"/>
-      <point x="290" y="1444" name="inserted"/>
-      <point x="26" y="1183"/>
-      <point x="26" y="982" type="qcurve"/>
-      <point x="26" y="982" type="line"/>
-      <point x="26" y="779" name="inserted"/>
-      <point x="296" y="532"/>
-      <point x="496" y="532" type="qcurve"/>
-      <point x="496" y="532" type="line"/>
-      <point x="664" y="532" name="inserted"/>
-      <point x="970" y="766"/>
-      <point x="970" y="982" type="qcurve"/>
-      <point x="970" y="982" type="line"/>
-      <point x="970" y="1170" name="inserted"/>
-      <point x="708" y="1444"/>
+      <point x="497.9264451679694" y="1444" type="qcurve"/>
+      <point x="497.9264451679694" y="1444" type="line"/>
+      <point x="289.9264451679694" y="1444" name="inserted"/>
+      <point x="25.926445167969376" y="1183"/>
+      <point x="25.926445167969376" y="982" type="qcurve"/>
+      <point x="25.926445167969376" y="982" type="line"/>
+      <point x="25.926445167969376" y="779" name="inserted"/>
+      <point x="295.9264451679694" y="532"/>
+      <point x="495.9264451679694" y="532" type="qcurve"/>
+      <point x="495.9264451679694" y="532" type="line"/>
+      <point x="663.9264451679694" y="532" name="inserted"/>
+      <point x="969.9264451679694" y="766"/>
+      <point x="969.9264451679694" y="982" type="qcurve"/>
+      <point x="969.9264451679694" y="982" type="line"/>
+      <point x="969.9264451679694" y="1170" name="inserted"/>
+      <point x="707.9264451679694" y="1444"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1260"/>
   <outline>
-    <component base="nine" xOffset="126"/>
+    <component base="nine" xOffset="126" identifier="1DB27195"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>1DB27195</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1208"/>
   <unicode hex="006F"/>
-  <guideline x="604" y="785" angle="90" identifier="mQmnUpoLMh"/>
-  <anchor x="606" y="0" name="bottom"/>
-  <anchor x="604" y="510" name="center"/>
-  <anchor x="761" y="0" name="ogonek"/>
-  <anchor x="604" y="1020" name="top"/>
-  <anchor x="770" y="1020" name="topright"/>
+  <guideline x="603.9264451679694" y="785" angle="90" identifier="mQmnUpoLMh"/>
+  <anchor x="515.9264451679694" y="0" name="bottom"/>
+  <anchor x="603.9264451679694" y="510" name="center"/>
+  <anchor x="670.9264451679694" y="0" name="ogonek"/>
+  <anchor x="693.9264451679694" y="1020" name="top"/>
+  <anchor x="859.9264451679694" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="604" y="-22" type="qcurve" smooth="yes"/>
-      <point x="384" y="-22" name="inserted"/>
-      <point x="100" y="279"/>
-      <point x="100" y="512" type="qcurve"/>
-      <point x="100" y="512" type="line"/>
-      <point x="100" y="745" name="inserted"/>
-      <point x="384" y="1046"/>
-      <point x="604" y="1046" type="qcurve" smooth="yes"/>
-      <point x="824" y="1046" name="inserted"/>
-      <point x="1108" y="745"/>
-      <point x="1108" y="512" type="qcurve"/>
-      <point x="1108" y="512" type="line"/>
-      <point x="1108" y="279" name="inserted"/>
-      <point x="824" y="-22"/>
+      <point x="509.9264451679694" y="-22" type="qcurve" smooth="yes"/>
+      <point x="289.9264451679694" y="-22" name="inserted"/>
+      <point x="58.926445167969376" y="279"/>
+      <point x="99.92644516796938" y="512" type="qcurve"/>
+      <point x="99.92644516796938" y="512" type="line"/>
+      <point x="141.92644516796938" y="745" name="inserted"/>
+      <point x="478.9264451679694" y="1046"/>
+      <point x="698.9264451679694" y="1046" type="qcurve" smooth="yes"/>
+      <point x="918.9264451679694" y="1046" name="inserted"/>
+      <point x="1149.9264451679694" y="745"/>
+      <point x="1107.9264451679694" y="512" type="qcurve"/>
+      <point x="1107.9264451679694" y="512" type="line"/>
+      <point x="1066.9264451679694" y="279" name="inserted"/>
+      <point x="729.9264451679694" y="-22"/>
     </contour>
     <contour>
-      <point x="604" y="-18" type="qcurve" smooth="yes"/>
-      <point x="822" y="-18" name="inserted"/>
-      <point x="1104" y="281"/>
-      <point x="1104" y="512" type="qcurve"/>
-      <point x="1104" y="512" type="line"/>
-      <point x="1104" y="743" name="inserted"/>
-      <point x="822" y="1042"/>
-      <point x="604" y="1042" type="qcurve" smooth="yes"/>
-      <point x="386" y="1042" name="inserted"/>
-      <point x="104" y="743"/>
-      <point x="104" y="512" type="qcurve"/>
-      <point x="104" y="512" type="line"/>
-      <point x="104" y="281" name="inserted"/>
-      <point x="386" y="-18"/>
+      <point x="510.9264451679694" y="-18" type="qcurve" smooth="yes"/>
+      <point x="728.9264451679694" y="-18" name="inserted"/>
+      <point x="1063.9264451679694" y="281"/>
+      <point x="1103.9264451679694" y="512" type="qcurve"/>
+      <point x="1103.9264451679694" y="512" type="line"/>
+      <point x="1144.9264451679694" y="743" name="inserted"/>
+      <point x="915.9264451679694" y="1042"/>
+      <point x="697.9264451679694" y="1042" type="qcurve" smooth="yes"/>
+      <point x="479.9264451679694" y="1042" name="inserted"/>
+      <point x="144.92644516796938" y="743"/>
+      <point x="103.92644516796938" y="512" type="qcurve"/>
+      <point x="103.92644516796938" y="512" type="line"/>
+      <point x="63.926445167969376" y="281" name="inserted"/>
+      <point x="292.9264451679694" y="-18"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/oslash-bar.glif
@@ -3,28 +3,28 @@
   <advance width="1046"/>
   <outline>
     <contour>
-      <point x="519" y="513" type="line"/>
-      <point x="912" y="1046" type="line"/>
-      <point x="918" y="1054"/>
-      <point x="918" y="1054"/>
-      <point x="920" y="1052" type="qcurve"/>
-      <point x="920" y="1052" type="line"/>
-      <point x="922" y="1051"/>
-      <point x="922" y="1051" name="inserted"/>
-      <point x="916" y="1043" type="qcurve"/>
-      <point x="523" y="510" type="line"/>
+      <point x="518.9264451679694" y="513" type="line"/>
+      <point x="911.9264451679694" y="1046" type="line"/>
+      <point x="917.9264451679694" y="1054"/>
+      <point x="917.9264451679694" y="1054"/>
+      <point x="919.9264451679694" y="1052" type="qcurve"/>
+      <point x="919.9264451679694" y="1052" type="line"/>
+      <point x="921.9264451679694" y="1051"/>
+      <point x="921.9264451679694" y="1051" name="inserted"/>
+      <point x="915.9264451679694" y="1043" type="qcurve"/>
+      <point x="522.9264451679694" y="510" type="line"/>
     </contour>
     <contour>
-      <point x="137" y="-5" type="qcurve"/>
-      <point x="519" y="513" type="line"/>
-      <point x="523" y="510" type="line"/>
-      <point x="141" y="-8" type="line"/>
-      <point x="135" y="-16"/>
-      <point x="135" y="-16"/>
-      <point x="133" y="-14" type="qcurve"/>
-      <point x="133" y="-14" type="line"/>
-      <point x="131" y="-13"/>
-      <point x="131" y="-13" name="inserted"/>
+      <point x="136.92644516796938" y="-5" type="qcurve"/>
+      <point x="518.9264451679694" y="513" type="line"/>
+      <point x="522.9264451679694" y="510" type="line"/>
+      <point x="140.92644516796938" y="-8" type="line"/>
+      <point x="134.92644516796938" y="-16"/>
+      <point x="134.92644516796938" y="-16"/>
+      <point x="132.92644516796938" y="-14" type="qcurve"/>
+      <point x="132.92644516796938" y="-14" type="line"/>
+      <point x="130.92644516796938" y="-13"/>
+      <point x="130.92644516796938" y="-13" name="inserted"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1208"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="78" yOffset="-9"/>
+    <component base="o" identifier="F80C822D"/>
+    <component base="oslash-bar" xOffset="78" yOffset="-9" identifier="600D75B8"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>600D75B8</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>F80C822D</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/six.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/six.glif
@@ -4,59 +4,59 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="518" y="-32" type="line"/>
-      <point x="306" y="-32"/>
-      <point x="42" y="244"/>
-      <point x="42" y="434" type="qcurve"/>
-      <point x="42" y="434" type="line"/>
-      <point x="42" y="649" name="inserted"/>
-      <point x="349" y="888"/>
-      <point x="520" y="888" type="qcurve"/>
-      <point x="520" y="888" type="line"/>
-      <point x="722" y="888" name="inserted"/>
-      <point x="994" y="639"/>
-      <point x="994" y="434" type="qcurve"/>
-      <point x="994" y="434" type="line"/>
-      <point x="994" y="231" name="inserted"/>
-      <point x="728" y="-32"/>
-      <point x="518" y="-32" type="qcurve"/>
+      <point x="517.9264451679694" y="-32" type="line"/>
+      <point x="305.9264451679694" y="-32"/>
+      <point x="41.926445167969376" y="244"/>
+      <point x="41.926445167969376" y="434" type="qcurve"/>
+      <point x="41.926445167969376" y="434" type="line"/>
+      <point x="41.926445167969376" y="649" name="inserted"/>
+      <point x="348.9264451679694" y="888"/>
+      <point x="519.9264451679694" y="888" type="qcurve"/>
+      <point x="519.9264451679694" y="888" type="line"/>
+      <point x="721.9264451679694" y="888" name="inserted"/>
+      <point x="993.9264451679694" y="639"/>
+      <point x="993.9264451679694" y="434" type="qcurve"/>
+      <point x="993.9264451679694" y="434" type="line"/>
+      <point x="993.9264451679694" y="231" name="inserted"/>
+      <point x="727.9264451679694" y="-32"/>
+      <point x="517.9264451679694" y="-32" type="qcurve"/>
     </contour>
     <contour>
-      <point x="44" y="434" type="line"/>
-      <point x="42" y="434" type="line"/>
-      <point x="42" y="563"/>
-      <point x="147" y="745"/>
-      <point x="286" y="931" type="qcurve" smooth="yes"/>
-      <point x="669" y="1445" type="line"/>
-      <point x="671" y="1448"/>
-      <point x="671" y="1448"/>
-      <point x="673" y="1447" type="qcurve"/>
-      <point x="673" y="1447" type="line"/>
-      <point x="675" y="1446"/>
-      <point x="675" y="1446"/>
-      <point x="672" y="1442" type="qcurve"/>
-      <point x="289" y="928" type="line" smooth="yes"/>
-      <point x="176" y="776"/>
-      <point x="70" y="618"/>
-      <point x="49" y="511" type="qcurve"/>
+      <point x="43.926445167969376" y="434" type="line"/>
+      <point x="41.926445167969376" y="434" type="line"/>
+      <point x="41.926445167969376" y="563"/>
+      <point x="146.92644516796938" y="745"/>
+      <point x="285.9264451679694" y="931" type="qcurve" smooth="yes"/>
+      <point x="668.9264451679694" y="1445" type="line"/>
+      <point x="670.9264451679694" y="1448"/>
+      <point x="670.9264451679694" y="1448"/>
+      <point x="672.9264451679694" y="1447" type="qcurve"/>
+      <point x="672.9264451679694" y="1447" type="line"/>
+      <point x="674.9264451679694" y="1446"/>
+      <point x="674.9264451679694" y="1446"/>
+      <point x="671.9264451679694" y="1442" type="qcurve"/>
+      <point x="288.9264451679694" y="928" type="line" smooth="yes"/>
+      <point x="175.92644516796938" y="776"/>
+      <point x="69.92644516796938" y="618"/>
+      <point x="48.926445167969376" y="511" type="qcurve"/>
     </contour>
     <contour>
-      <point x="518" y="-28" type="qcurve"/>
-      <point x="518" y="-28" type="line"/>
-      <point x="726" y="-28" name="inserted"/>
-      <point x="990" y="233"/>
-      <point x="990" y="434" type="qcurve"/>
-      <point x="990" y="434" type="line"/>
-      <point x="990" y="637" name="inserted"/>
-      <point x="720" y="884"/>
-      <point x="520" y="884" type="qcurve"/>
-      <point x="520" y="884" type="line"/>
-      <point x="352" y="884" name="inserted"/>
-      <point x="46" y="650"/>
-      <point x="46" y="434" type="qcurve"/>
-      <point x="46" y="434" type="line"/>
-      <point x="46" y="246" name="inserted"/>
-      <point x="308" y="-28"/>
+      <point x="517.9264451679694" y="-28" type="qcurve"/>
+      <point x="517.9264451679694" y="-28" type="line"/>
+      <point x="725.9264451679694" y="-28" name="inserted"/>
+      <point x="989.9264451679694" y="233"/>
+      <point x="989.9264451679694" y="434" type="qcurve"/>
+      <point x="989.9264451679694" y="434" type="line"/>
+      <point x="989.9264451679694" y="637" name="inserted"/>
+      <point x="719.9264451679694" y="884"/>
+      <point x="519.9264451679694" y="884" type="qcurve"/>
+      <point x="519.9264451679694" y="884" type="line"/>
+      <point x="351.9264451679694" y="884" name="inserted"/>
+      <point x="45.926445167969376" y="650"/>
+      <point x="45.926445167969376" y="434" type="qcurve"/>
+      <point x="45.926445167969376" y="434" type="line"/>
+      <point x="45.926445167969376" y="246" name="inserted"/>
+      <point x="307.9264451679694" y="-28"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1260"/>
   <outline>
-    <component base="six" xOffset="118"/>
+    <component base="six" xOffset="118" identifier="E6038B1B"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>E6038B1B</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND0.ufo/fontinfo.plist
@@ -118,7 +118,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -126,7 +126,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1592"/>
   <unicode hex="004F"/>
-  <guideline x="796" y="821" angle="90" identifier="6YPqKXjABP"/>
-  <anchor x="791" y="0" name="bottom"/>
-  <anchor x="794" y="716" name="center"/>
-  <anchor x="1019" y="0" name="ogonek"/>
-  <anchor x="791" y="1432" name="top"/>
-  <anchor x="1011" y="1432" name="topright"/>
+  <guideline x="850.7644511616" y="821" angle="100" identifier="6YPqKXjABP"/>
+  <anchor x="701" y="0" name="bottom"/>
+  <anchor x="830.2501181873" y="716" name="center"/>
+  <anchor x="929" y="0" name="ogonek"/>
+  <anchor x="953.5002363745" y="1432" name="top"/>
+  <anchor x="1173.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="796" y="-32" type="qcurve" smooth="yes"/>
-      <point x="494" y="-32" name="inserted"/>
-      <point x="40" y="382"/>
-      <point x="40" y="716" type="qcurve"/>
-      <point x="40" y="716" type="line"/>
-      <point x="40" y="1050" name="inserted"/>
-      <point x="484" y="1464"/>
-      <point x="796" y="1464" type="qcurve" smooth="yes"/>
-      <point x="1108" y="1464" name="inserted"/>
-      <point x="1552" y="1038"/>
-      <point x="1552" y="716" type="qcurve"/>
-      <point x="1552" y="716" type="line"/>
-      <point x="1552" y="394" name="inserted"/>
-      <point x="1099" y="-32"/>
+      <point x="722" y="-32" type="qcurve" smooth="yes"/>
+      <point x="420" y="-32" name="inserted"/>
+      <point x="20" y="396"/>
+      <point x="79" y="730" type="qcurve"/>
+      <point x="79" y="730" type="line"/>
+      <point x="138" y="1064" name="inserted"/>
+      <point x="629" y="1464"/>
+      <point x="945" y="1464" type="qcurve" smooth="yes"/>
+      <point x="1267" y="1464" name="inserted"/>
+      <point x="1644" y="1029"/>
+      <point x="1587" y="707" type="qcurve"/>
+      <point x="1587" y="707" type="line"/>
+      <point x="1530" y="385" name="inserted"/>
+      <point x="1051" y="-32"/>
     </contour>
     <contour>
-      <point x="796" y="510" type="qcurve" smooth="yes"/>
-      <point x="882" y="510" name="inserted"/>
-      <point x="1000" y="626"/>
-      <point x="1000" y="716" type="qcurve"/>
-      <point x="1000" y="716" type="line"/>
-      <point x="1000" y="808" name="inserted"/>
-      <point x="882" y="922"/>
-      <point x="796" y="922" type="qcurve" smooth="yes"/>
-      <point x="710" y="922" name="inserted"/>
-      <point x="592" y="808"/>
-      <point x="592" y="716" type="qcurve"/>
-      <point x="592" y="716" type="line"/>
-      <point x="592" y="624" name="inserted"/>
-      <point x="710" y="510"/>
+      <point x="804" y="510" type="qcurve" smooth="yes"/>
+      <point x="890" y="510" name="inserted"/>
+      <point x="1020" y="621"/>
+      <point x="1036" y="711" type="qcurve"/>
+      <point x="1036" y="711" type="line"/>
+      <point x="1052" y="803" name="inserted"/>
+      <point x="947" y="922"/>
+      <point x="861" y="922" type="qcurve" smooth="yes"/>
+      <point x="775" y="922" name="inserted"/>
+      <point x="646" y="814"/>
+      <point x="630" y="722" type="qcurve"/>
+      <point x="630" y="722" type="line"/>
+      <point x="614" y="630" name="inserted"/>
+      <point x="718" y="510"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND0.ufo/glyphs/o.glif
@@ -2,44 +2,45 @@
 <glyph name="o" format="2">
   <advance width="1184"/>
   <unicode hex="006F"/>
-  <guideline x="592" y="561" angle="90" identifier="09VyFa72fV"/>
-  <anchor x="586" y="0" name="bottom"/>
-  <anchor x="592" y="510" name="center"/>
-  <anchor x="808" y="0" name="ogonek"/>
-  <anchor x="587" y="1020" name="top"/>
-  <anchor x="829" y="1020" name="topright"/>
+  <guideline x="600.9194361774" y="561" angle="100" identifier="09VyFa72fV"/>
+  <guideline x="111" y="1023" angle="80" identifier="be4IKyfiJU"/>
+  <anchor x="496" y="0" name="bottom"/>
+  <anchor x="591.9267601613" y="510" name="center"/>
+  <anchor x="718" y="0" name="ogonek"/>
+  <anchor x="676.8535203226" y="1020" name="top"/>
+  <anchor x="918.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="588" y="-36" type="qcurve" smooth="yes"/>
-      <point x="328" y="-36" name="inserted"/>
-      <point x="20" y="292"/>
-      <point x="20" y="512" type="qcurve"/>
-      <point x="20" y="512" type="line"/>
-      <point x="20" y="738" name="inserted"/>
-      <point x="338" y="1068"/>
-      <point x="588" y="1068" type="qcurve" smooth="yes"/>
-      <point x="842" y="1068" name="inserted"/>
-      <point x="1164" y="732"/>
-      <point x="1164" y="512" type="qcurve"/>
-      <point x="1164" y="512" type="line"/>
-      <point x="1164" y="300" name="inserted"/>
-      <point x="850" y="-36"/>
+      <point x="517" y="-36" type="qcurve"/>
+      <point x="260" y="-36" name="inserted"/>
+      <point x="-22" y="307"/>
+      <point x="17" y="527" type="qcurve"/>
+      <point x="17" y="527" type="line"/>
+      <point x="61" y="762" name="inserted"/>
+      <point x="391" y="1068"/>
+      <point x="686.3172153966" y="1068" type="qcurve" smooth="yes"/>
+      <point x="918" y="1068" name="inserted"/>
+      <point x="1197" y="736"/>
+      <point x="1156" y="487" type="qcurve"/>
+      <point x="1156" y="487" type="line"/>
+      <point x="1130" y="302" name="inserted"/>
+      <point x="795" y="-36"/>
     </contour>
     <contour>
-      <point x="592" y="382" type="qcurve" smooth="yes"/>
-      <point x="658" y="382" name="inserted"/>
-      <point x="722" y="456"/>
-      <point x="722" y="510" type="qcurve"/>
-      <point x="722" y="510" type="line"/>
-      <point x="722" y="564" name="inserted"/>
-      <point x="656" y="638"/>
-      <point x="592" y="638" type="qcurve" smooth="yes"/>
-      <point x="528" y="638" name="inserted"/>
-      <point x="460" y="566"/>
-      <point x="460" y="510" type="qcurve"/>
-      <point x="460" y="510" type="line"/>
-      <point x="460" y="454" name="inserted"/>
-      <point x="526" y="382"/>
+      <point x="569.3569066306" y="382" type="qcurve" smooth="yes"/>
+      <point x="635.3569066306" y="382" name="inserted"/>
+      <point x="712.4051032031" y="456"/>
+      <point x="721.9267601613" y="510" type="qcurve"/>
+      <point x="721.9267601613" y="510" type="line"/>
+      <point x="731.4484171196" y="564" name="inserted"/>
+      <point x="678.496613692" y="638"/>
+      <point x="614.496613692" y="638" type="qcurve" smooth="yes"/>
+      <point x="550.496613692" y="638" name="inserted"/>
+      <point x="469.801071081" y="566"/>
+      <point x="459.9267601613" y="510" type="qcurve"/>
+      <point x="459.9267601613" y="510" type="line"/>
+      <point x="450.0524492416" y="454" name="inserted"/>
+      <point x="503.3569066306" y="382"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -59,7 +59,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1778"/>
   <unicode hex="004F"/>
-  <guideline x="889" y="950" angle="90" identifier="WpMUJPty6d"/>
-  <anchor x="889" y="0" name="bottom"/>
-  <anchor x="889" y="715" name="center"/>
-  <anchor x="1124" y="0" name="ogonek"/>
-  <anchor x="889" y="1432" name="top"/>
-  <anchor x="1120" y="1432" name="topright"/>
+  <guideline x="798.5643015787" y="950" angle="90" identifier="WpMUJPty6d"/>
+  <anchor x="954.799722745" y="0" name="bottom"/>
+  <anchor x="954.799722745" y="715" name="center"/>
+  <anchor x="1189.799722745" y="0" name="ogonek"/>
+  <anchor x="954.799722745" y="1432" name="top"/>
+  <anchor x="1185.799722745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="888" y="-32" type="qcurve"/>
-      <point x="557" y="-33"/>
-      <point x="120" y="393"/>
-      <point x="120" y="715" type="qcurve"/>
-      <point x="120" y="715" type="line"/>
-      <point x="120" y="1036"/>
-      <point x="556" y="1465"/>
-      <point x="888" y="1465" type="qcurve"/>
-      <point x="1217" y="1465"/>
-      <point x="1658" y="1034"/>
-      <point x="1658" y="715" type="qcurve"/>
-      <point x="1658" y="715" type="line"/>
-      <point x="1658" y="399"/>
-      <point x="1215" y="-32"/>
+      <point x="792.799722745" y="-32" type="qcurve"/>
+      <point x="465.799722745" y="-33"/>
+      <point x="104.799722745" y="393"/>
+      <point x="155.799722745" y="715" type="qcurve"/>
+      <point x="155.799722745" y="715" type="line"/>
+      <point x="212.799722745" y="1036"/>
+      <point x="724.799722745" y="1465"/>
+      <point x="1056.799722745" y="1465" type="qcurve"/>
+      <point x="1385.799722745" y="1465"/>
+      <point x="1750.799722745" y="1034"/>
+      <point x="1693.799722745" y="715" type="qcurve"/>
+      <point x="1693.799722745" y="715" type="line"/>
+      <point x="1638.799722745" y="399"/>
+      <point x="1119.799722745" y="-32"/>
     </contour>
     <contour>
-      <point x="888" y="108" type="qcurve"/>
-      <point x="1156" y="108"/>
-      <point x="1510" y="455"/>
-      <point x="1510" y="715" type="qcurve"/>
-      <point x="1510" y="715" type="line"/>
-      <point x="1510" y="976"/>
-      <point x="1156" y="1324"/>
-      <point x="888" y="1324" type="qcurve"/>
-      <point x="619" y="1324"/>
-      <point x="268" y="976"/>
-      <point x="268" y="715" type="qcurve"/>
-      <point x="268" y="715" type="line"/>
-      <point x="268" y="453"/>
-      <point x="619" y="108"/>
+      <point x="817.799722745" y="102" type="qcurve"/>
+      <point x="1085.799722745" y="102"/>
+      <point x="1497.799722745" y="455"/>
+      <point x="1543.799722745" y="715" type="qcurve"/>
+      <point x="1543.799722745" y="715" type="line"/>
+      <point x="1589.799722745" y="976"/>
+      <point x="1299.799722745" y="1330"/>
+      <point x="1031.799722745" y="1330" type="qcurve"/>
+      <point x="762.799722745" y="1330"/>
+      <point x="353.799722745" y="976"/>
+      <point x="307.799722745" y="715" type="qcurve"/>
+      <point x="307.799722745" y="715" type="line"/>
+      <point x="261.799722745" y="453"/>
+      <point x="548.799722745" y="102"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/O_slash-bar.glif
@@ -3,28 +3,28 @@
   <advance width="1494"/>
   <outline>
     <contour>
-      <point x="694" y="796" type="line"/>
-      <point x="1240" y="1483" type="line" smooth="yes"/>
-      <point x="1280" y="1533"/>
-      <point x="1280" y="1533"/>
-      <point x="1332" y="1490" type="qcurve"/>
-      <point x="1332" y="1490" type="line"/>
-      <point x="1384" y="1447"/>
-      <point x="1384" y="1447"/>
-      <point x="1347" y="1401" type="qcurve" smooth="yes"/>
-      <point x="798" y="711" type="line"/>
+      <point x="603.5643015787" y="796" type="line"/>
+      <point x="1149.5643015787" y="1483" type="line" smooth="yes"/>
+      <point x="1189.5643015787" y="1533"/>
+      <point x="1189.5643015787" y="1533"/>
+      <point x="1241.5643015787" y="1490" type="qcurve"/>
+      <point x="1241.5643015787" y="1490" type="line"/>
+      <point x="1293.5643015787" y="1447"/>
+      <point x="1293.5643015787" y="1447"/>
+      <point x="1256.5643015787" y="1401" type="qcurve" smooth="yes"/>
+      <point x="707.5643015787" y="711" type="line"/>
     </contour>
     <contour>
-      <point x="144" y="105" type="qcurve"/>
-      <point x="694" y="796" type="line"/>
-      <point x="798" y="711" type="line"/>
-      <point x="251" y="23" type="line"/>
-      <point x="211" y="-27"/>
-      <point x="211" y="-27"/>
-      <point x="159" y="16" type="qcurve"/>
-      <point x="159" y="16" type="line"/>
-      <point x="107" y="59"/>
-      <point x="107" y="59"/>
+      <point x="53.5643015787" y="105" type="qcurve"/>
+      <point x="603.5643015787" y="796" type="line"/>
+      <point x="707.5643015787" y="711" type="line"/>
+      <point x="160.5643015787" y="23" type="line"/>
+      <point x="120.5643015787" y="-27"/>
+      <point x="120.5643015787" y="-27"/>
+      <point x="68.5643015787" y="16" type="qcurve"/>
+      <point x="68.5643015787" y="16" type="line"/>
+      <point x="16.5643015787" y="59"/>
+      <point x="16.5643015787" y="59"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="1778"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="144" yOffset="-38"/>
+    <component base="O" identifier="8938D7FF"/>
+    <component base="Oslash-bar" xOffset="144" yOffset="-38" identifier="9190B161"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>8938D7FF</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>9190B161</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/nine.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/nine.glif
@@ -4,59 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="546" y="1462" type="line"/>
-      <point x="770" y="1462"/>
-      <point x="1061" y="1191"/>
-      <point x="1061" y="993" type="qcurve"/>
-      <point x="1061" y="993" type="line"/>
-      <point x="1061" y="812"/>
-      <point x="686" y="531"/>
-      <point x="525" y="531" type="qcurve"/>
-      <point x="525" y="531" type="line"/>
-      <point x="303" y="531"/>
-      <point x="39" y="793"/>
-      <point x="39" y="987" type="qcurve"/>
-      <point x="39" y="987" type="line"/>
-      <point x="39" y="1187"/>
-      <point x="327" y="1462"/>
-      <point x="546" y="1462" type="qcurve"/>
+      <point x="455.5643015787" y="1462" type="line"/>
+      <point x="679.5643015787" y="1462"/>
+      <point x="970.5643015787" y="1191"/>
+      <point x="970.5643015787" y="993" type="qcurve"/>
+      <point x="970.5643015787" y="993" type="line"/>
+      <point x="970.5643015787" y="812"/>
+      <point x="595.5643015787" y="531"/>
+      <point x="434.5643015787" y="531" type="qcurve"/>
+      <point x="434.5643015787" y="531" type="line"/>
+      <point x="212.5643015787" y="531"/>
+      <point x="-51.4356984213" y="793"/>
+      <point x="-51.4356984213" y="987" type="qcurve"/>
+      <point x="-51.4356984213" y="987" type="line"/>
+      <point x="-51.4356984213" y="1187"/>
+      <point x="236.5643015787" y="1462"/>
+      <point x="455.5643015787" y="1462" type="qcurve"/>
     </contour>
     <contour>
-      <point x="990" y="993" type="line"/>
-      <point x="1061" y="993" type="line"/>
-      <point x="1060" y="826"/>
-      <point x="918" y="572"/>
-      <point x="788" y="416" type="qcurve" smooth="yes"/>
-      <point x="493" y="61" type="line" smooth="yes"/>
-      <point x="418" y="-29"/>
-      <point x="418" y="-29"/>
-      <point x="365" y="7" type="qcurve"/>
-      <point x="365" y="7" type="line"/>
-      <point x="305" y="49"/>
-      <point x="305" y="49"/>
-      <point x="366" y="123" type="qcurve" smooth="yes"/>
-      <point x="675" y="494" type="line" smooth="yes"/>
-      <point x="712" y="539"/>
-      <point x="754" y="588"/>
-      <point x="796" y="636" type="qcurve"/>
+      <point x="899.5643015787" y="993" type="line"/>
+      <point x="970.5643015787" y="993" type="line"/>
+      <point x="969.5643015787" y="826"/>
+      <point x="827.5643015787" y="572"/>
+      <point x="697.5643015787" y="416" type="qcurve" smooth="yes"/>
+      <point x="402.5643015787" y="61" type="line" smooth="yes"/>
+      <point x="327.5643015787" y="-29"/>
+      <point x="327.5643015787" y="-29"/>
+      <point x="274.5643015787" y="7" type="qcurve"/>
+      <point x="274.5643015787" y="7" type="line"/>
+      <point x="214.5643015787" y="49"/>
+      <point x="214.5643015787" y="49"/>
+      <point x="275.5643015787" y="123" type="qcurve" smooth="yes"/>
+      <point x="584.5643015787" y="494" type="line" smooth="yes"/>
+      <point x="621.5643015787" y="539"/>
+      <point x="663.5643015787" y="588"/>
+      <point x="705.5643015787" y="636" type="qcurve"/>
     </contour>
     <contour>
-      <point x="550" y="1327" type="qcurve"/>
-      <point x="550" y="1327" type="line"/>
-      <point x="388" y="1327"/>
-      <point x="178" y="1142"/>
-      <point x="178" y="993" type="qcurve"/>
-      <point x="178" y="993" type="line"/>
-      <point x="178" y="847"/>
-      <point x="384" y="667"/>
-      <point x="546" y="667" type="qcurve"/>
-      <point x="546" y="667" type="line"/>
-      <point x="701" y="667"/>
-      <point x="921" y="850"/>
-      <point x="921" y="993" type="qcurve"/>
-      <point x="921" y="993" type="line"/>
-      <point x="921" y="1139"/>
-      <point x="713" y="1327"/>
+      <point x="459.5643015787" y="1327" type="qcurve"/>
+      <point x="459.5643015787" y="1327" type="line"/>
+      <point x="297.5643015787" y="1327"/>
+      <point x="87.5643015787" y="1142"/>
+      <point x="87.5643015787" y="993" type="qcurve"/>
+      <point x="87.5643015787" y="993" type="line"/>
+      <point x="87.5643015787" y="847"/>
+      <point x="293.5643015787" y="667"/>
+      <point x="455.5643015787" y="667" type="qcurve"/>
+      <point x="455.5643015787" y="667" type="line"/>
+      <point x="610.5643015787" y="667"/>
+      <point x="830.5643015787" y="850"/>
+      <point x="830.5643015787" y="993" type="qcurve"/>
+      <point x="830.5643015787" y="993" type="line"/>
+      <point x="830.5643015787" y="1139"/>
+      <point x="622.5643015787" y="1327"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1286"/>
   <outline>
-    <component base="nine" xOffset="74"/>
+    <component base="nine" xOffset="74" identifier="ED4B3CD3"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>ED4B3CD3</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1221"/>
   <unicode hex="006F"/>
-  <guideline x="611" y="706" angle="90" identifier="tx25E4uoZg"/>
-  <anchor x="611" y="0" name="bottom"/>
-  <anchor x="611" y="510" name="center"/>
-  <anchor x="809" y="0" name="ogonek"/>
-  <anchor x="611" y="1020" name="top"/>
-  <anchor x="781" y="1020" name="topright"/>
+  <guideline x="520.5643015787" y="706" angle="90" identifier="tx25E4uoZg"/>
+  <anchor x="520.6822982812" y="0" name="bottom"/>
+  <anchor x="610.6822982812" y="510" name="center"/>
+  <anchor x="718.6822982812" y="0" name="ogonek"/>
+  <anchor x="700.6822982812" y="1020" name="top"/>
+  <anchor x="870.6822982812" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="609" y="-32" type="qcurve"/>
-      <point x="368" y="-32"/>
-      <point x="66" y="271"/>
-      <point x="66" y="504" type="qcurve"/>
-      <point x="66" y="504" type="line"/>
-      <point x="66" y="737"/>
-      <point x="373" y="1045"/>
-      <point x="609" y="1045" type="qcurve"/>
-      <point x="844" y="1045"/>
-      <point x="1155" y="733"/>
-      <point x="1155" y="505" type="qcurve"/>
-      <point x="1155" y="505" type="line"/>
-      <point x="1155" y="274"/>
-      <point x="847" y="-32"/>
+      <point x="513.6822982812" y="-32" type="qcurve"/>
+      <point x="283.3131186538" y="-32"/>
+      <point x="26.6822982812" y="271"/>
+      <point x="64.6822982812" y="504" type="qcurve"/>
+      <point x="64.6822982812" y="504" type="line"/>
+      <point x="105.6822982812" y="737"/>
+      <point x="463.3131186538" y="1045"/>
+      <point x="703.6822982812" y="1045" type="qcurve"/>
+      <point x="933.3131186538" y="1045"/>
+      <point x="1194.6822982812" y="733"/>
+      <point x="1153.6822982812" y="505" type="qcurve"/>
+      <point x="1153.6822982812" y="505" type="line"/>
+      <point x="1113.6822982812" y="274"/>
+      <point x="768.3131186538" y="-32"/>
     </contour>
     <contour>
-      <point x="611" y="102" type="qcurve"/>
-      <point x="792" y="102"/>
-      <point x="1011" y="325"/>
-      <point x="1011" y="504" type="qcurve"/>
-      <point x="1011" y="504" type="line"/>
-      <point x="1011" y="680"/>
-      <point x="788" y="909"/>
-      <point x="611" y="909" type="qcurve"/>
-      <point x="431" y="909"/>
-      <point x="210" y="684"/>
-      <point x="210" y="504" type="qcurve"/>
-      <point x="210" y="504" type="line"/>
-      <point x="210" y="323"/>
-      <point x="426" y="102"/>
+      <point x="538.6822982812" y="100" type="qcurve"/>
+      <point x="719.6822982812" y="100"/>
+      <point x="978.6822982812" y="325"/>
+      <point x="1009.6822982812" y="504" type="qcurve"/>
+      <point x="1009.6822982812" y="504" type="line"/>
+      <point x="1040.6822982812" y="680"/>
+      <point x="858.6822982812" y="911"/>
+      <point x="681.6822982812" y="911" type="qcurve"/>
+      <point x="501.6822982812" y="911"/>
+      <point x="240.6822982812" y="684"/>
+      <point x="208.6822982812" y="504" type="qcurve"/>
+      <point x="208.6822982812" y="504" type="line"/>
+      <point x="176.6822982812" y="323"/>
+      <point x="353.6822982812" y="100"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/oslash-bar.glif
@@ -3,28 +3,28 @@
   <advance width="1243"/>
   <outline>
     <contour>
-      <point x="575" y="549" type="line"/>
-      <point x="939" y="1043" type="line" smooth="yes"/>
-      <point x="983" y="1102"/>
-      <point x="983" y="1102"/>
-      <point x="1028" y="1065" type="qcurve"/>
-      <point x="1028" y="1065" type="line"/>
-      <point x="1076" y="1026"/>
-      <point x="1076" y="1026"/>
-      <point x="1035" y="970" type="qcurve" smooth="yes"/>
-      <point x="668" y="472" type="line"/>
+      <point x="484.5643015787" y="549" type="line"/>
+      <point x="848.5643015787" y="1043" type="line" smooth="yes"/>
+      <point x="892.5643015787" y="1102"/>
+      <point x="892.5643015787" y="1102"/>
+      <point x="937.5643015787" y="1065" type="qcurve"/>
+      <point x="937.5643015787" y="1065" type="line"/>
+      <point x="985.5643015787" y="1026"/>
+      <point x="985.5643015787" y="1026"/>
+      <point x="944.5643015787" y="970" type="qcurve" smooth="yes"/>
+      <point x="577.5643015787" y="472" type="line"/>
     </contour>
     <contour>
-      <point x="209" y="53" type="qcurve"/>
-      <point x="575" y="549" type="line"/>
-      <point x="668" y="472" type="line"/>
-      <point x="305" y="-20" type="line"/>
-      <point x="261" y="-79"/>
-      <point x="261" y="-79"/>
-      <point x="216" y="-42" type="qcurve"/>
-      <point x="216" y="-42" type="line"/>
-      <point x="168" y="-3"/>
-      <point x="168" y="-3"/>
+      <point x="118.5643015787" y="53" type="qcurve"/>
+      <point x="484.5643015787" y="549" type="line"/>
+      <point x="577.5643015787" y="472" type="line"/>
+      <point x="214.5643015787" y="-20" type="line"/>
+      <point x="170.5643015787" y="-79"/>
+      <point x="170.5643015787" y="-79"/>
+      <point x="125.5643015787" y="-42" type="qcurve"/>
+      <point x="125.5643015787" y="-42" type="line"/>
+      <point x="77.5643015787" y="-3"/>
+      <point x="77.5643015787" y="-3"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1221"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-11" yOffset="-1"/>
+    <component base="o" identifier="0D81BBA9"/>
+    <component base="oslash-bar" xOffset="-11" yOffset="-1" identifier="61C62E0B"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>0D81BBA9</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>61C62E0B</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/six.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/six.glif
@@ -4,59 +4,59 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="567" y="-30" type="line"/>
-      <point x="343" y="-30"/>
-      <point x="52" y="241"/>
-      <point x="52" y="439" type="qcurve"/>
-      <point x="52" y="439" type="line"/>
-      <point x="52" y="620"/>
-      <point x="427" y="901"/>
-      <point x="588" y="901" type="qcurve"/>
-      <point x="588" y="901" type="line"/>
-      <point x="810" y="901"/>
-      <point x="1074" y="639"/>
-      <point x="1074" y="445" type="qcurve"/>
-      <point x="1074" y="445" type="line"/>
-      <point x="1074" y="245"/>
-      <point x="786" y="-30"/>
-      <point x="567" y="-30" type="qcurve"/>
+      <point x="476.5643015787" y="-30" type="line"/>
+      <point x="252.5643015787" y="-30"/>
+      <point x="-38.4356984213" y="241"/>
+      <point x="-38.4356984213" y="439" type="qcurve"/>
+      <point x="-38.4356984213" y="439" type="line"/>
+      <point x="-38.4356984213" y="620"/>
+      <point x="336.5643015787" y="901"/>
+      <point x="497.5643015787" y="901" type="qcurve"/>
+      <point x="497.5643015787" y="901" type="line"/>
+      <point x="719.5643015787" y="901"/>
+      <point x="983.5643015787" y="639"/>
+      <point x="983.5643015787" y="445" type="qcurve"/>
+      <point x="983.5643015787" y="445" type="line"/>
+      <point x="983.5643015787" y="245"/>
+      <point x="695.5643015787" y="-30"/>
+      <point x="476.5643015787" y="-30" type="qcurve"/>
     </contour>
     <contour>
-      <point x="123" y="439" type="line"/>
-      <point x="52" y="439" type="line"/>
-      <point x="53" y="606"/>
-      <point x="195" y="860"/>
-      <point x="325" y="1016" type="qcurve" smooth="yes"/>
-      <point x="620" y="1371" type="line" smooth="yes"/>
-      <point x="695" y="1461"/>
-      <point x="695" y="1461"/>
-      <point x="748" y="1425" type="qcurve"/>
-      <point x="748" y="1425" type="line"/>
-      <point x="808" y="1383"/>
-      <point x="808" y="1383"/>
-      <point x="747" y="1309" type="qcurve" smooth="yes"/>
-      <point x="438" y="938" type="line" smooth="yes"/>
-      <point x="401" y="893"/>
-      <point x="359" y="844"/>
-      <point x="317" y="796" type="qcurve"/>
+      <point x="32.5643015787" y="439" type="line"/>
+      <point x="-38.4356984213" y="439" type="line"/>
+      <point x="-37.4356984213" y="606"/>
+      <point x="104.5643015787" y="860"/>
+      <point x="234.5643015787" y="1016" type="qcurve" smooth="yes"/>
+      <point x="529.5643015787" y="1371" type="line" smooth="yes"/>
+      <point x="604.5643015787" y="1461"/>
+      <point x="604.5643015787" y="1461"/>
+      <point x="657.5643015787" y="1425" type="qcurve"/>
+      <point x="657.5643015787" y="1425" type="line"/>
+      <point x="717.5643015787" y="1383"/>
+      <point x="717.5643015787" y="1383"/>
+      <point x="656.5643015787" y="1309" type="qcurve" smooth="yes"/>
+      <point x="347.5643015787" y="938" type="line" smooth="yes"/>
+      <point x="310.5643015787" y="893"/>
+      <point x="268.5643015787" y="844"/>
+      <point x="226.5643015787" y="796" type="qcurve"/>
     </contour>
     <contour>
-      <point x="563" y="105" type="qcurve"/>
-      <point x="563" y="105" type="line"/>
-      <point x="725" y="105"/>
-      <point x="935" y="290"/>
-      <point x="935" y="439" type="qcurve"/>
-      <point x="935" y="439" type="line"/>
-      <point x="935" y="585"/>
-      <point x="729" y="765"/>
-      <point x="567" y="765" type="qcurve"/>
-      <point x="567" y="765" type="line"/>
-      <point x="412" y="765"/>
-      <point x="192" y="582"/>
-      <point x="192" y="439" type="qcurve"/>
-      <point x="192" y="439" type="line"/>
-      <point x="192" y="293"/>
-      <point x="400" y="105"/>
+      <point x="472.5643015787" y="105" type="qcurve"/>
+      <point x="472.5643015787" y="105" type="line"/>
+      <point x="634.5643015787" y="105"/>
+      <point x="844.5643015787" y="290"/>
+      <point x="844.5643015787" y="439" type="qcurve"/>
+      <point x="844.5643015787" y="439" type="line"/>
+      <point x="844.5643015787" y="585"/>
+      <point x="638.5643015787" y="765"/>
+      <point x="476.5643015787" y="765" type="qcurve"/>
+      <point x="476.5643015787" y="765" type="line"/>
+      <point x="321.5643015787" y="765"/>
+      <point x="101.5643015787" y="582"/>
+      <point x="101.5643015787" y="439" type="qcurve"/>
+      <point x="101.5643015787" y="439" type="line"/>
+      <point x="101.5643015787" y="293"/>
+      <point x="309.5643015787" y="105"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1286"/>
   <outline>
-    <component base="six" xOffset="100"/>
+    <component base="six" xOffset="100" identifier="6C7BE71B"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>6C7BE71B</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/fontinfo.plist
@@ -104,7 +104,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -112,7 +112,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="2668"/>
   <unicode hex="004F"/>
   <guideline x="1334" y="1178" angle="90" identifier="Pp2YPdLn0k"/>
-  <anchor x="1339" y="0" name="bottom"/>
-  <anchor x="1334" y="693" name="center"/>
-  <anchor x="1774" y="0" name="ogonek"/>
-  <anchor x="1334" y="1432" name="top"/>
-  <anchor x="1771" y="1432" name="topright"/>
+  <anchor x="1250" y="0" name="bottom"/>
+  <anchor x="1367" y="693" name="center"/>
+  <anchor x="1685" y="0" name="ogonek"/>
+  <anchor x="1497" y="1432" name="top"/>
+  <anchor x="1934" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1338" y="-41" type="qcurve" smooth="yes"/>
-      <point x="802" y="-41"/>
-      <point x="110" y="372"/>
-      <point x="110" y="691" type="qcurve"/>
-      <point x="110" y="712" type="line"/>
-      <point x="110" y="1045"/>
-      <point x="799" y="1476"/>
-      <point x="1333" y="1476" type="qcurve" smooth="yes"/>
-      <point x="1868" y="1476"/>
-      <point x="2558" y="1045"/>
-      <point x="2558" y="712" type="qcurve"/>
-      <point x="2558" y="691" type="line"/>
-      <point x="2558" y="372"/>
-      <point x="1870" y="-41"/>
+      <point x="1242" y="-41" type="qcurve" smooth="yes"/>
+      <point x="706" y="-41"/>
+      <point x="86" y="372"/>
+      <point x="143" y="691" type="qcurve"/>
+      <point x="146" y="712" type="line"/>
+      <point x="205" y="1045"/>
+      <point x="970" y="1476"/>
+      <point x="1504" y="1476" type="qcurve" smooth="yes"/>
+      <point x="2039" y="1476"/>
+      <point x="2653" y="1045"/>
+      <point x="2594" y="712" type="qcurve"/>
+      <point x="2591" y="691" type="line"/>
+      <point x="2534" y="372"/>
+      <point x="1774" y="-41"/>
     </contour>
     <contour>
-      <point x="1338" y="-30" type="qcurve" smooth="yes"/>
-      <point x="1866" y="-30"/>
-      <point x="2547" y="378"/>
-      <point x="2547" y="693" type="qcurve"/>
-      <point x="2547" y="712" type="line"/>
-      <point x="2547" y="1041"/>
-      <point x="1863" y="1465"/>
-      <point x="1334" y="1465" type="qcurve" smooth="yes"/>
-      <point x="805" y="1465"/>
-      <point x="121" y="1041"/>
-      <point x="121" y="712" type="qcurve"/>
-      <point x="121" y="693" type="line"/>
-      <point x="121" y="378"/>
-      <point x="807" y="-30"/>
+      <point x="1243" y="-30" type="qcurve" smooth="yes"/>
+      <point x="1771" y="-30"/>
+      <point x="2524" y="378"/>
+      <point x="2580" y="693" type="qcurve"/>
+      <point x="2583" y="712" type="line"/>
+      <point x="2641" y="1041"/>
+      <point x="2032" y="1465"/>
+      <point x="1503" y="1465" type="qcurve" smooth="yes"/>
+      <point x="974" y="1465"/>
+      <point x="215" y="1041"/>
+      <point x="157" y="712" type="qcurve"/>
+      <point x="154" y="693" type="line"/>
+      <point x="98" y="378"/>
+      <point x="712" y="-30"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="2668"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="365" yOffset="-75"/>
+    <component base="O" identifier="06A1D5CC"/>
+    <component base="Oslash-bar" xOffset="365" yOffset="-75" identifier="EA325E8F"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>06A1D5CC</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>EA325E8F</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="2226"/>
   <outline>
-    <component base="nine" xOffset="95"/>
+    <component base="nine" xOffset="95" identifier="2F71D502"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>2F71D502</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/glyphs/o.glif
@@ -3,43 +3,43 @@
   <advance width="2036"/>
   <unicode hex="006F"/>
   <guideline x="1020" y="725" angle="90" identifier="PkhB3ZcSZe"/>
-  <anchor x="1019" y="0" name="bottom"/>
-  <anchor x="1020" y="518" name="center"/>
-  <anchor x="1374" y="0" name="ogonek"/>
-  <anchor x="1019" y="1020" name="top"/>
-  <anchor x="1430" y="1020" name="topright"/>
+  <anchor x="929" y="0" name="bottom"/>
+  <anchor x="1021" y="518" name="center"/>
+  <anchor x="1284" y="0" name="ogonek"/>
+  <anchor x="1109" y="1020" name="top"/>
+  <anchor x="1520" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="1019" y="-30" type="qcurve" smooth="yes"/>
-      <point x="578" y="-30"/>
-      <point x="82" y="271"/>
+      <point x="924" y="-30" type="qcurve" smooth="yes"/>
+      <point x="483" y="-30"/>
+      <point x="40" y="271"/>
       <point x="82" y="512" type="qcurve"/>
-      <point x="82" y="514" type="line"/>
-      <point x="82" y="758"/>
-      <point x="578" y="1062"/>
-      <point x="1019" y="1062" type="qcurve" smooth="yes"/>
-      <point x="1459" y="1062"/>
-      <point x="1954" y="758"/>
-      <point x="1954" y="514" type="qcurve"/>
+      <point x="83" y="514" type="line"/>
+      <point x="126" y="758"/>
+      <point x="675" y="1062"/>
+      <point x="1116" y="1062" type="qcurve" smooth="yes"/>
+      <point x="1556" y="1062"/>
+      <point x="1998" y="758"/>
+      <point x="1955" y="514" type="qcurve"/>
       <point x="1954" y="511" type="line"/>
-      <point x="1954" y="270"/>
-      <point x="1459" y="-30"/>
+      <point x="1912" y="270"/>
+      <point x="1364" y="-30"/>
     </contour>
     <contour>
-      <point x="1019" y="-20" type="qcurve" smooth="yes"/>
-      <point x="1455" y="-20"/>
-      <point x="1944" y="275"/>
+      <point x="925" y="-20" type="qcurve" smooth="yes"/>
+      <point x="1361" y="-20"/>
+      <point x="1902" y="275"/>
       <point x="1944" y="511" type="qcurve"/>
-      <point x="1944" y="514" type="line"/>
-      <point x="1944" y="753"/>
-      <point x="1455" y="1052"/>
-      <point x="1019" y="1052" type="qcurve" smooth="yes"/>
-      <point x="582" y="1052"/>
-      <point x="92" y="753"/>
-      <point x="92" y="514" type="qcurve"/>
+      <point x="1945" y="514" type="line"/>
+      <point x="1987" y="753"/>
+      <point x="1550" y="1052"/>
+      <point x="1114" y="1052" type="qcurve" smooth="yes"/>
+      <point x="677" y="1052"/>
+      <point x="135" y="753"/>
+      <point x="93" y="514" type="qcurve"/>
       <point x="92" y="512" type="line"/>
-      <point x="92" y="276"/>
-      <point x="582" y="-20"/>
+      <point x="51" y="276"/>
+      <point x="488" y="-20"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="2036"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="329" yOffset="20"/>
+    <component base="o" identifier="D164B979"/>
+    <component base="oslash-bar" xOffset="329" yOffset="20" identifier="2A2F5140"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>2A2F5140</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>D164B979</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="2226"/>
   <outline>
-    <component base="six" xOffset="114"/>
+    <component base="six" xOffset="114" identifier="EA3325B3"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>EA3325B3</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/fontinfo.plist
@@ -118,7 +118,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -126,7 +126,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,44 @@
 <glyph name="O" format="2">
   <advance width="2576"/>
   <unicode hex="004F"/>
-  <guideline x="1289" y="822" angle="90" identifier="xgsdZgvRt5"/>
-  <anchor x="1289" y="0" name="bottom"/>
-  <anchor x="1289" y="716" name="center"/>
-  <anchor x="1731" y="0" name="ogonek"/>
-  <anchor x="1294" y="1432" name="top"/>
-  <anchor x="1752" y="1432" name="topright"/>
+  <guideline x="1343.94" y="822" angle="100" identifier="xgsdZgvRt5"/>
+  <guideline x="2471" y="170" angle="80" identifier="HNStFf5r6e"/>
+  <anchor x="1199" y="0" name="bottom"/>
+  <anchor x="1325.25012" y="716" name="center"/>
+  <anchor x="1641" y="0" name="ogonek"/>
+  <anchor x="1456.50024" y="1432" name="top"/>
+  <anchor x="1914.50024" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1292" y="-41" type="qcurve" smooth="yes"/>
-      <point x="717" y="-41"/>
-      <point x="44" y="364"/>
-      <point x="44" y="691" type="qcurve"/>
-      <point x="44" y="691" type="line"/>
-      <point x="44" y="1048"/>
-      <point x="710" y="1476"/>
-      <point x="1292" y="1476" type="qcurve" smooth="yes"/>
-      <point x="1862" y="1476"/>
-      <point x="2532" y="1035"/>
-      <point x="2532" y="691" type="qcurve"/>
-      <point x="2532" y="691" type="line"/>
-      <point x="2532" y="374"/>
-      <point x="1826" y="-41"/>
+      <point x="1216" y="-41" type="qcurve" smooth="yes"/>
+      <point x="620" y="-41"/>
+      <point x="25" y="426"/>
+      <point x="89" y="774" type="qcurve"/>
+      <point x="89" y="774" type="line"/>
+      <point x="140" y="1074"/>
+      <point x="851" y="1476"/>
+      <point x="1452" y="1476" type="qcurve" smooth="yes"/>
+      <point x="2024" y="1476"/>
+      <point x="2619" y="1009"/>
+      <point x="2559" y="665" type="qcurve"/>
+      <point x="2559" y="665" type="line"/>
+      <point x="2503" y="348"/>
+      <point x="1787" y="-41"/>
     </contour>
     <contour>
       <point x="1288" y="508" type="qcurve" smooth="yes"/>
       <point x="1473" y="508"/>
-      <point x="1657" y="621"/>
-      <point x="1657" y="717" type="qcurve"/>
-      <point x="1657" y="717" type="line"/>
-      <point x="1657" y="808"/>
-      <point x="1466" y="924"/>
-      <point x="1288" y="924" type="qcurve" smooth="yes"/>
-      <point x="1114" y="924"/>
-      <point x="919" y="812"/>
-      <point x="919" y="717" type="qcurve"/>
-      <point x="919" y="717" type="line"/>
-      <point x="918" y="617"/>
+      <point x="1676" y="621"/>
+      <point x="1693" y="717" type="qcurve"/>
+      <point x="1693" y="717" type="line"/>
+      <point x="1709" y="808"/>
+      <point x="1539" y="924"/>
+      <point x="1361" y="924" type="qcurve" smooth="yes"/>
+      <point x="1187" y="924"/>
+      <point x="972" y="812"/>
+      <point x="955" y="717" type="qcurve"/>
+      <point x="955" y="717" type="line"/>
+      <point x="937" y="617"/>
       <point x="1126" y="508"/>
     </contour>
   </outline>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="2576"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="32" yOffset="50"/>
+    <component base="O" identifier="DA388B72"/>
+    <component base="Oslash-bar" xOffset="32" yOffset="50" identifier="1F680F26"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>1F680F26</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>DA388B72</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="2380"/>
   <outline>
-    <component base="nine" xOffset="117"/>
+    <component base="nine" xOffset="117" identifier="35F00517"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>35F00517</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="2162"/>
   <unicode hex="006F"/>
-  <guideline x="1080" y="585" angle="90" identifier="gSqkPEP17o"/>
-  <anchor x="1085" y="0" name="bottom"/>
-  <anchor x="1080" y="510" name="center"/>
-  <anchor x="1497" y="0" name="ogonek"/>
-  <anchor x="1081" y="1020" name="top"/>
-  <anchor x="1545" y="1020" name="topright"/>
+  <guideline x="1093.15" y="585" angle="100" identifier="gSqkPEP17o"/>
+  <anchor x="995" y="0" name="bottom"/>
+  <anchor x="1079.92676" y="510" name="center"/>
+  <anchor x="1407" y="0" name="ogonek"/>
+  <anchor x="1170.85352" y="1020" name="top"/>
+  <anchor x="1634.85352" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="1085" y="-34" type="qcurve" smooth="yes"/>
-      <point x="573" y="-34"/>
-      <point x="24" y="292"/>
-      <point x="24" y="521" type="qcurve"/>
-      <point x="24" y="521" type="line"/>
-      <point x="25" y="757"/>
-      <point x="581" y="1067"/>
-      <point x="1085" y="1067" type="qcurve"/>
-      <point x="1583" y="1068"/>
-      <point x="2138" y="764"/>
-      <point x="2138" y="520" type="qcurve"/>
-      <point x="2138" y="520" type="line"/>
-      <point x="2138" y="291"/>
-      <point x="1588" y="-34"/>
+      <point x="984" y="-34" type="qcurve"/>
+      <point x="510" y="-43"/>
+      <point x="-7" y="282"/>
+      <point x="38" y="534" type="qcurve"/>
+      <point x="38" y="534" type="line"/>
+      <point x="79" y="758"/>
+      <point x="639" y="1067"/>
+      <point x="1156" y="1067" type="qcurve" smooth="yes"/>
+      <point x="1734" y="1067"/>
+      <point x="2174" y="748"/>
+      <point x="2134" y="509" type="qcurve"/>
+      <point x="2134" y="509" type="line"/>
+      <point x="2091" y="268"/>
+      <point x="1507" y="-34"/>
     </contour>
     <contour>
-      <point x="1080" y="392" type="qcurve" smooth="yes"/>
-      <point x="1218" y="392"/>
-      <point x="1348" y="462"/>
-      <point x="1348" y="510" type="qcurve"/>
-      <point x="1348" y="510" type="line"/>
-      <point x="1348" y="561"/>
-      <point x="1217" y="632"/>
-      <point x="1080" y="632" type="qcurve" smooth="yes"/>
-      <point x="943" y="632"/>
-      <point x="814" y="568"/>
-      <point x="814" y="511" type="qcurve"/>
-      <point x="814" y="511" type="line"/>
-      <point x="814" y="462"/>
-      <point x="942" y="392"/>
+      <point x="1066" y="401" type="qcurve" smooth="yes"/>
+      <point x="1196" y="401"/>
+      <point x="1338" y="465"/>
+      <point x="1348" y="522" type="qcurve"/>
+      <point x="1348" y="522" type="line"/>
+      <point x="1357" y="571"/>
+      <point x="1243" y="641"/>
+      <point x="1108" y="641" type="qcurve" smooth="yes"/>
+      <point x="964" y="641"/>
+      <point x="833" y="571"/>
+      <point x="824" y="523" type="qcurve"/>
+      <point x="824" y="523" type="line"/>
+      <point x="815" y="472"/>
+      <point x="929" y="401"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="2162"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-160" yOffset="8"/>
+    <component base="o" identifier="358A7A9F"/>
+    <component base="oslash-bar" xOffset="-160" yOffset="8" identifier="EF2AF9EE"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>358A7A9F</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>EF2AF9EE</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="2380"/>
   <outline>
-    <component base="six" xOffset="111"/>
+    <component base="six" xOffset="111" identifier="F29F8862"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>F29F8862</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/fontinfo.plist
@@ -108,7 +108,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -116,7 +116,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="2678"/>
   <unicode hex="004F"/>
   <guideline x="1340" y="931" angle="90" identifier="HXBLHywR3S"/>
-  <anchor x="1341" y="0" name="bottom"/>
-  <anchor x="1337" y="708" name="center"/>
-  <anchor x="1791" y="0" name="ogonek"/>
-  <anchor x="1347" y="1432" name="top"/>
-  <anchor x="1797" y="1432" name="topright"/>
+  <anchor x="1231" y="0" name="bottom"/>
+  <anchor x="1352" y="708" name="center"/>
+  <anchor x="1681" y="0" name="ogonek"/>
+  <anchor x="1490" y="1432" name="top"/>
+  <anchor x="1940" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1342" y="-40" type="qcurve" smooth="yes"/>
-      <point x="765" y="-41"/>
-      <point x="110" y="375"/>
-      <point x="110" y="700" type="qcurve"/>
-      <point x="110" y="700" type="line"/>
-      <point x="110" y="1034"/>
-      <point x="756" y="1476"/>
-      <point x="1342" y="1476" type="qcurve" smooth="yes"/>
-      <point x="1914" y="1476"/>
-      <point x="2568" y="1038"/>
-      <point x="2568" y="701" type="qcurve"/>
-      <point x="2568" y="701" type="line"/>
-      <point x="2568" y="378"/>
-      <point x="1911" y="-39"/>
+      <point x="1246" y="-40" type="qcurve" smooth="yes"/>
+      <point x="658" y="-40"/>
+      <point x="88" y="373"/>
+      <point x="145" y="698" type="qcurve"/>
+      <point x="145" y="698" type="line"/>
+      <point x="204" y="1034"/>
+      <point x="931" y="1476"/>
+      <point x="1513" y="1476" type="qcurve" smooth="yes"/>
+      <point x="2086" y="1476"/>
+      <point x="2662" y="1030"/>
+      <point x="2603" y="693" type="qcurve"/>
+      <point x="2603" y="693" type="line"/>
+      <point x="2546" y="371"/>
+      <point x="1840" y="-40"/>
     </contour>
     <contour>
-      <point x="1338" y="106" type="qcurve" smooth="yes"/>
-      <point x="1842" y="106"/>
-      <point x="2412" y="442"/>
-      <point x="2412" y="701" type="qcurve"/>
-      <point x="2412" y="701" type="line"/>
-      <point x="2412" y="971"/>
-      <point x="1835" y="1328"/>
-      <point x="1338" y="1328" type="qcurve" smooth="yes"/>
-      <point x="834" y="1328"/>
-      <point x="266" y="977"/>
-      <point x="266" y="700" type="qcurve"/>
-      <point x="266" y="700" type="line"/>
-      <point x="266" y="437"/>
-      <point x="842" y="106"/>
+      <point x="1265" y="106" type="qcurve" smooth="yes"/>
+      <point x="1786" y="106"/>
+      <point x="2399" y="440"/>
+      <point x="2447" y="701" type="qcurve"/>
+      <point x="2447" y="701" type="line"/>
+      <point x="2494" y="969"/>
+      <point x="2006" y="1330"/>
+      <point x="1485" y="1330" type="qcurve" smooth="yes"/>
+      <point x="978" y="1330"/>
+      <point x="348" y="953"/>
+      <point x="300" y="684" type="qcurve"/>
+      <point x="300" y="684" type="line"/>
+      <point x="254" y="421"/>
+      <point x="773" y="106"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="2678"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="-4" yOffset="1"/>
+    <component base="O" identifier="A04B5A19"/>
+    <component base="Oslash-bar" xOffset="-4" yOffset="1" identifier="0CDB44CA"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>0CDB44CA</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>A04B5A19</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="2210"/>
   <outline>
-    <component base="nine" xOffset="63"/>
+    <component base="nine" xOffset="63" identifier="F29C49EA"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>F29C49EA</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/o.glif
@@ -3,43 +3,43 @@
   <advance width="2042"/>
   <unicode hex="006F"/>
   <guideline x="1021" y="722" angle="90" identifier="q2RpYucGy6"/>
-  <anchor x="1015" y="0" name="bottom"/>
-  <anchor x="1021" y="510" name="center"/>
-  <anchor x="1405" y="0" name="ogonek"/>
-  <anchor x="1015" y="1020" name="top"/>
-  <anchor x="1398" y="1020" name="topright"/>
+  <anchor x="924" y="0" name="bottom"/>
+  <anchor x="1020" y="510" name="center"/>
+  <anchor x="1314" y="0" name="ogonek"/>
+  <anchor x="1104" y="1020" name="top"/>
+  <anchor x="1487" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="1021" y="-40" type="qcurve" smooth="yes"/>
-      <point x="585" y="-40"/>
-      <point x="70" y="271"/>
-      <point x="70" y="512" type="qcurve"/>
-      <point x="70" y="512" type="line"/>
-      <point x="70" y="747"/>
-      <point x="585" y="1060"/>
-      <point x="1021" y="1060" type="qcurve" smooth="yes"/>
-      <point x="1463" y="1060"/>
-      <point x="1972" y="751"/>
-      <point x="1972" y="513" type="qcurve"/>
-      <point x="1972" y="513" type="line"/>
-      <point x="1972" y="276"/>
-      <point x="1442" y="-40"/>
+      <point x="918" y="-40" type="qcurve" smooth="yes"/>
+      <point x="477" y="-40"/>
+      <point x="26" y="266"/>
+      <point x="70" y="505" type="qcurve"/>
+      <point x="70" y="505" type="line"/>
+      <point x="113" y="747"/>
+      <point x="658" y="1060"/>
+      <point x="1120" y="1060" type="qcurve" smooth="yes"/>
+      <point x="1546" y="1060"/>
+      <point x="2014" y="750"/>
+      <point x="1972" y="512" type="qcurve"/>
+      <point x="1972" y="512" type="line"/>
+      <point x="1927" y="272"/>
+      <point x="1376" y="-40"/>
     </contour>
     <contour>
-      <point x="1023" y="102" type="qcurve" smooth="yes"/>
-      <point x="1406" y="102"/>
-      <point x="1824" y="338"/>
-      <point x="1824" y="512" type="qcurve"/>
-      <point x="1824" y="512" type="line"/>
-      <point x="1824" y="688"/>
-      <point x="1402" y="918"/>
-      <point x="1023" y="918" type="qcurve" smooth="yes"/>
-      <point x="639" y="918"/>
-      <point x="218" y="687"/>
-      <point x="218" y="511" type="qcurve"/>
-      <point x="218" y="511" type="line"/>
-      <point x="218" y="339"/>
-      <point x="637" y="102"/>
+      <point x="950" y="99" type="qcurve" smooth="yes"/>
+      <point x="1338" y="99"/>
+      <point x="1793" y="335"/>
+      <point x="1824" y="511" type="qcurve"/>
+      <point x="1824" y="511" type="line"/>
+      <point x="1855" y="687"/>
+      <point x="1473" y="921"/>
+      <point x="1093" y="921" type="qcurve" smooth="yes"/>
+      <point x="712" y="921"/>
+      <point x="249" y="686"/>
+      <point x="219" y="505" type="qcurve"/>
+      <point x="219" y="505" type="line"/>
+      <point x="188" y="333"/>
+      <point x="564" y="99"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/oslash-bar.glif
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="2233"/>
-  <guideline x="2479" y="1301" angle="330.0915726785949" identifier="b7dHgIgP3N"/>
-  <guideline x="198" y="-216" angle="121.20051460398064" identifier="1agSAJDp7E"/>
+  <guideline x="2479" y="1301" angle="330.0916" identifier="b7dHgIgP3N"/>
+  <guideline x="198" y="-216" angle="121.2005" identifier="1agSAJDp7E"/>
   <outline>
     <contour>
       <point x="1099" y="552" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="2042"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-116" yOffset="17"/>
+    <component base="o" identifier="E4D4423E"/>
+    <component base="oslash-bar" xOffset="-116" yOffset="17" identifier="024D25C3"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>024D25C3</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>E4D4423E</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="2210"/>
   <outline>
-    <component base="six" xOffset="92"/>
+    <component base="six" xOffset="92" identifier="29331CD0"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>29331CD0</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -59,7 +59,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="436"/>
   <unicode hex="004F"/>
   <guideline x="217" y="1092" angle="90" identifier="mstAkvuY4u"/>
-  <anchor x="217" y="0" name="bottom"/>
-  <anchor x="217" y="716" name="center"/>
-  <anchor x="259" y="0" name="ogonek"/>
-  <anchor x="218" y="1432" name="top"/>
-  <anchor x="258" y="1432" name="topright"/>
+  <anchor x="127" y="0" name="bottom"/>
+  <anchor x="253" y="716" name="center"/>
+  <anchor x="169" y="0" name="ogonek"/>
+  <anchor x="381" y="1432" name="top"/>
+  <anchor x="421" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="217" y="-4" type="qcurve" smooth="yes"/>
-      <point x="139" y="-4"/>
-      <point x="70" y="91"/>
-      <point x="70" y="197" type="qcurve"/>
-      <point x="70" y="1233" type="line"/>
-      <point x="70" y="1340"/>
-      <point x="140" y="1436"/>
-      <point x="218" y="1436" type="qcurve" smooth="yes"/>
-      <point x="296" y="1436"/>
-      <point x="366" y="1340"/>
-      <point x="366" y="1233" type="qcurve"/>
-      <point x="366" y="197" type="line"/>
-      <point x="366" y="91"/>
-      <point x="296" y="-4"/>
+      <point x="126" y="-4" type="qcurve" smooth="yes"/>
+      <point x="50" y="-4"/>
+      <point x="-4" y="91"/>
+      <point x="15" y="197" type="qcurve"/>
+      <point x="197" y="1233" type="line"/>
+      <point x="216" y="1340"/>
+      <point x="304" y="1436"/>
+      <point x="381" y="1436" type="qcurve" smooth="yes"/>
+      <point x="459" y="1436"/>
+      <point x="512" y="1340"/>
+      <point x="493" y="1233" type="qcurve"/>
+      <point x="311" y="197" type="line"/>
+      <point x="292" y="91"/>
+      <point x="203" y="-4"/>
     </contour>
     <contour>
-      <point x="217" y="0" type="qcurve" smooth="yes"/>
-      <point x="293" y="0"/>
-      <point x="362" y="93"/>
-      <point x="362" y="197" type="qcurve"/>
-      <point x="362" y="1233" type="line"/>
-      <point x="362" y="1338"/>
-      <point x="294" y="1432"/>
-      <point x="218" y="1432" type="qcurve" smooth="yes"/>
-      <point x="142" y="1432"/>
-      <point x="74" y="1338"/>
-      <point x="74" y="1233" type="qcurve"/>
-      <point x="74" y="197" type="line"/>
-      <point x="74" y="93"/>
-      <point x="142" y="0"/>
+      <point x="127" y="0" type="qcurve" smooth="yes"/>
+      <point x="203" y="0"/>
+      <point x="288" y="93"/>
+      <point x="307" y="197" type="qcurve"/>
+      <point x="489" y="1233" type="line"/>
+      <point x="508" y="1338"/>
+      <point x="457" y="1432"/>
+      <point x="381" y="1432" type="qcurve" smooth="yes"/>
+      <point x="305" y="1432"/>
+      <point x="220" y="1338"/>
+      <point x="201" y="1233" type="qcurve"/>
+      <point x="19" y="197" type="line"/>
+      <point x="0" y="93"/>
+      <point x="52" y="0"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/O_slash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Oslash-bar" format="2">
   <advance width="1352"/>
-  <guideline x="429" y="-26" angle="348.58264778922745" identifier="67E9cgsZbI"/>
+  <guideline x="429" y="-26" angle="348.5826" identifier="67E9cgsZbI"/>
   <outline>
     <contour>
       <point x="664" y="721" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="436"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="-450" yOffset="-14"/>
+    <component base="O" identifier="D744F04C"/>
+    <component base="Oslash-bar" xOffset="-450" yOffset="-14" identifier="F484F908"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>D744F04C</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>F484F908</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="386"/>
   <outline>
-    <component base="nine" xOffset="10"/>
+    <component base="nine" xOffset="10" identifier="469F0D23"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>469F0D23</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/o.glif
@@ -3,43 +3,43 @@
   <advance width="426"/>
   <unicode hex="006F"/>
   <guideline x="213" y="664" angle="90" identifier="Sx7NTqd2ON"/>
-  <anchor x="221" y="0" name="bottom"/>
-  <anchor x="213" y="510" name="center"/>
-  <anchor x="252" y="0" name="ogonek"/>
-  <anchor x="223" y="1020" name="top"/>
-  <anchor x="285" y="1020" name="topright"/>
+  <anchor x="130" y="0" name="bottom"/>
+  <anchor x="212" y="510" name="center"/>
+  <anchor x="161" y="0" name="ogonek"/>
+  <anchor x="312" y="1020" name="top"/>
+  <anchor x="374" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="211" y="-4" type="qcurve" smooth="yes"/>
-      <point x="134" y="-4"/>
-      <point x="65" y="95"/>
-      <point x="65" y="205" type="qcurve"/>
-      <point x="65" y="823" type="line"/>
-      <point x="65" y="934"/>
-      <point x="136" y="1032"/>
-      <point x="213" y="1032" type="qcurve" smooth="yes"/>
-      <point x="292" y="1032"/>
-      <point x="361" y="934"/>
-      <point x="361" y="823" type="qcurve"/>
-      <point x="361" y="205" type="line"/>
-      <point x="361" y="95"/>
-      <point x="290" y="-4"/>
+      <point x="120" y="-4" type="qcurve" smooth="yes"/>
+      <point x="43" y="-4"/>
+      <point x="-9" y="95"/>
+      <point x="11" y="205" type="qcurve"/>
+      <point x="120" y="823" type="line"/>
+      <point x="139" y="934"/>
+      <point x="227" y="1032"/>
+      <point x="304" y="1032" type="qcurve" smooth="yes"/>
+      <point x="383" y="1032"/>
+      <point x="435" y="934"/>
+      <point x="416" y="823" type="qcurve"/>
+      <point x="307" y="205" type="line"/>
+      <point x="287" y="95"/>
+      <point x="199" y="-4"/>
     </contour>
     <contour>
-      <point x="211" y="0" type="qcurve" smooth="yes"/>
-      <point x="288" y="0"/>
-      <point x="357" y="97"/>
-      <point x="357" y="206" type="qcurve"/>
-      <point x="357" y="823" type="line"/>
-      <point x="357" y="932"/>
-      <point x="290" y="1028"/>
-      <point x="213" y="1028" type="qcurve"/>
-      <point x="138" y="1028"/>
-      <point x="69" y="932"/>
-      <point x="69" y="823" type="qcurve"/>
-      <point x="69" y="206" type="line"/>
-      <point x="69" y="97"/>
-      <point x="136" y="0"/>
+      <point x="120" y="0" type="qcurve" smooth="yes"/>
+      <point x="197" y="0"/>
+      <point x="284" y="97"/>
+      <point x="303" y="206" type="qcurve"/>
+      <point x="412" y="823" type="line"/>
+      <point x="431" y="932"/>
+      <point x="381" y="1028"/>
+      <point x="304" y="1028" type="qcurve"/>
+      <point x="229" y="1028"/>
+      <point x="143" y="932"/>
+      <point x="124" y="823" type="qcurve"/>
+      <point x="15" y="206" type="line"/>
+      <point x="-4" y="97"/>
+      <point x="45" y="0"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="426"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-83" yOffset="24"/>
+    <component base="o" identifier="F91AFC2D"/>
+    <component base="oslash-bar" xOffset="-83" yOffset="24" identifier="B2FE1078"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>B2FE1078</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>F91AFC2D</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="386"/>
   <outline>
-    <component base="six" xOffset="10"/>
+    <component base="six" xOffset="10" identifier="5C03E3CA"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>5C03E3CA</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND0.ufo/fontinfo.plist
@@ -122,7 +122,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -130,7 +130,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1332"/>
   <unicode hex="004F"/>
-  <guideline x="666" y="0" angle="90" identifier="0M3O9gaZ6r"/>
-  <anchor x="666" y="0" name="bottom"/>
-  <anchor x="664" y="716" name="center"/>
-  <anchor x="876" y="0" name="ogonek"/>
-  <anchor x="666" y="1433" name="top"/>
-  <anchor x="831" y="1432" name="topright"/>
+  <guideline x="576" y="0" angle="100" identifier="0M3O9gaZ6r"/>
+  <anchor x="576" y="0" name="bottom"/>
+  <anchor x="700.2501181872609" y="716" name="center"/>
+  <anchor x="786" y="0" name="ogonek"/>
+  <anchor x="828.6765633552303" y="1433" name="top"/>
+  <anchor x="993.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="666" y="-32" type="qcurve" smooth="yes"/>
-      <point x="374" y="-32"/>
-      <point x="24" y="373"/>
-      <point x="24" y="720" type="qcurve"/>
-      <point x="24" y="729" type="line"/>
-      <point x="24" y="1071"/>
-      <point x="376" y="1460"/>
-      <point x="666" y="1460" type="qcurve" smooth="yes"/>
-      <point x="956" y="1460"/>
-      <point x="1308" y="1059"/>
-      <point x="1308" y="729" type="qcurve"/>
-      <point x="1308" y="720" type="line"/>
-      <point x="1308" y="383"/>
-      <point x="956" y="-32"/>
+      <point x="580" y="-32" type="qcurve" smooth="yes"/>
+      <point x="308" y="-32"/>
+      <point x="0" y="373"/>
+      <point x="61" y="720" type="qcurve"/>
+      <point x="63" y="729" type="line"/>
+      <point x="123" y="1071"/>
+      <point x="514" y="1460"/>
+      <point x="827" y="1460" type="qcurve" smooth="yes"/>
+      <point x="1104" y="1460"/>
+      <point x="1406" y="1069"/>
+      <point x="1347" y="729" type="qcurve"/>
+      <point x="1345" y="720" type="line"/>
+      <point x="1284" y="357"/>
+      <point x="896" y="-32"/>
     </contour>
     <contour>
-      <point x="666" y="525" type="qcurve" smooth="yes"/>
-      <point x="705" y="525"/>
-      <point x="739" y="574"/>
-      <point x="739" y="633" type="qcurve"/>
-      <point x="739" y="801" type="line"/>
-      <point x="739" y="862"/>
-      <point x="705" y="913"/>
-      <point x="666" y="913" type="qcurve" smooth="yes"/>
-      <point x="627" y="913"/>
-      <point x="593" y="862"/>
-      <point x="593" y="801" type="qcurve"/>
-      <point x="593" y="633" type="line"/>
-      <point x="593" y="574"/>
-      <point x="627" y="525"/>
+      <point x="669" y="525" type="qcurve" smooth="yes"/>
+      <point x="708" y="525"/>
+      <point x="751" y="574"/>
+      <point x="761" y="633" type="qcurve" smooth="yes"/>
+      <point x="790" y="801" type="line" smooth="yes"/>
+      <point x="801" y="862"/>
+      <point x="776" y="913"/>
+      <point x="737" y="913" type="qcurve" smooth="yes"/>
+      <point x="698" y="913"/>
+      <point x="655" y="862"/>
+      <point x="644" y="801" type="qcurve" smooth="yes"/>
+      <point x="615" y="633" type="line" smooth="yes"/>
+      <point x="605" y="574"/>
+      <point x="630" y="525"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1150"/>
   <unicode hex="006F"/>
-  <anchor x="575" y="0" name="bottom"/>
-  <anchor x="578" y="510" name="center"/>
-  <anchor x="776" y="0" name="ogonek"/>
-  <anchor x="575" y="1020" name="top"/>
-  <anchor x="752" y="1020" name="topright"/>
+  <anchor x="485" y="0" name="bottom"/>
+  <anchor x="577.9267601613171" y="510" name="center"/>
+  <anchor x="686" y="0" name="ogonek"/>
+  <anchor x="664.8535203226343" y="1020" name="top"/>
+  <anchor x="841.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="570" y="-32" type="qcurve"/>
-      <point x="328" y="-32"/>
-      <point x="16" y="276"/>
-      <point x="16" y="514" type="qcurve"/>
-      <point x="16" y="514" type="line"/>
-      <point x="16" y="751"/>
-      <point x="328" y="1058"/>
-      <point x="570" y="1058" type="qcurve" smooth="yes"/>
-      <point x="816" y="1058"/>
-      <point x="1134" y="751"/>
-      <point x="1134" y="514" type="qcurve"/>
-      <point x="1134" y="514" type="line"/>
-      <point x="1134" y="276"/>
-      <point x="816" y="-32"/>
+      <point x="493" y="-32" type="qcurve"/>
+      <point x="265" y="-32"/>
+      <point x="-25" y="276"/>
+      <point x="17" y="514" type="qcurve"/>
+      <point x="17" y="514" type="line"/>
+      <point x="58" y="755"/>
+      <point x="386" y="1058"/>
+      <point x="630" y="1058" type="qcurve" smooth="yes"/>
+      <point x="894" y="1058"/>
+      <point x="1176" y="751"/>
+      <point x="1135" y="514" type="qcurve"/>
+      <point x="1135" y="514" type="line"/>
+      <point x="1093" y="270"/>
+      <point x="760" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="420" type="qcurve" smooth="yes"/>
-      <point x="608" y="420"/>
-      <point x="630" y="452"/>
-      <point x="630" y="482" type="qcurve"/>
-      <point x="630" y="542" type="line"/>
-      <point x="630" y="582"/>
-      <point x="606" y="614"/>
-      <point x="576" y="614" type="qcurve" smooth="yes"/>
-      <point x="544" y="614"/>
-      <point x="520" y="580"/>
-      <point x="520" y="542" type="qcurve"/>
-      <point x="520" y="482" type="line"/>
-      <point x="520" y="453"/>
-      <point x="544" y="420"/>
+      <point x="560" y="420" type="qcurve" smooth="yes"/>
+      <point x="590" y="420"/>
+      <point x="619" y="452"/>
+      <point x="625" y="482" type="qcurve" smooth="yes"/>
+      <point x="636" y="542" type="line" smooth="yes"/>
+      <point x="643" y="582"/>
+      <point x="621" y="614"/>
+      <point x="594" y="614" type="qcurve" smooth="yes"/>
+      <point x="562" y="614"/>
+      <point x="532" y="580"/>
+      <point x="526" y="542" type="qcurve" smooth="yes"/>
+      <point x="515" y="482" type="line" smooth="yes"/>
+      <point x="510" y="453"/>
+      <point x="531" y="420"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/fontinfo.plist
@@ -119,7 +119,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -127,7 +127,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="496"/>
   <unicode hex="004F"/>
   <guideline x="248" y="867" angle="90" identifier="fy38GVYztR"/>
-  <anchor x="248" y="0" name="bottom"/>
-  <anchor x="248" y="716" name="center"/>
-  <anchor x="319" y="0" name="ogonek"/>
-  <anchor x="247" y="1432" name="top"/>
-  <anchor x="333" y="1432" name="topright"/>
+  <anchor x="158" y="0" name="bottom"/>
+  <anchor x="284" y="716" name="center"/>
+  <anchor x="229" y="0" name="ogonek"/>
+  <anchor x="409" y="1432" name="top"/>
+  <anchor x="495" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="248" y="-10" type="qcurve" smooth="yes"/>
-      <point x="150" y="-10"/>
-      <point x="44" y="114"/>
-      <point x="44" y="224" type="qcurve"/>
-      <point x="44" y="1216" type="line" smooth="yes"/>
-      <point x="44" y="1328"/>
-      <point x="148" y="1446"/>
-      <point x="248" y="1446" type="qcurve" smooth="yes"/>
-      <point x="348" y="1446"/>
-      <point x="452" y="1328"/>
-      <point x="452" y="1216" type="qcurve"/>
-      <point x="452" y="224" type="line" smooth="yes"/>
-      <point x="452" y="114"/>
-      <point x="346" y="-10"/>
+      <point x="156" y="-10" type="qcurve" smooth="yes"/>
+      <point x="58" y="-10"/>
+      <point x="-26" y="114"/>
+      <point x="-7" y="224" type="qcurve"/>
+      <point x="168" y="1216" type="line" smooth="yes"/>
+      <point x="188" y="1328"/>
+      <point x="313" y="1446"/>
+      <point x="413" y="1446" type="qcurve" smooth="yes"/>
+      <point x="513" y="1446"/>
+      <point x="596" y="1328"/>
+      <point x="576" y="1216" type="qcurve"/>
+      <point x="401" y="224" type="line" smooth="yes"/>
+      <point x="382" y="114"/>
+      <point x="254" y="-10"/>
     </contour>
     <contour>
-      <point x="248" y="130" type="qcurve" smooth="yes"/>
-      <point x="284" y="130"/>
-      <point x="312" y="176"/>
-      <point x="312" y="232" type="qcurve"/>
-      <point x="312" y="1202" type="line" smooth="yes"/>
-      <point x="312" y="1256"/>
-      <point x="282" y="1304"/>
-      <point x="248" y="1304" type="qcurve" smooth="yes"/>
-      <point x="214" y="1304"/>
-      <point x="184" y="1256"/>
-      <point x="184" y="1202" type="qcurve"/>
-      <point x="184" y="232" type="line" smooth="yes"/>
-      <point x="184" y="176"/>
-      <point x="212" y="130"/>
+      <point x="181" y="130" type="qcurve" smooth="yes"/>
+      <point x="217" y="130"/>
+      <point x="253" y="176"/>
+      <point x="263" y="232" type="qcurve"/>
+      <point x="434" y="1202" type="line" smooth="yes"/>
+      <point x="444" y="1257"/>
+      <point x="420" y="1304"/>
+      <point x="387" y="1304" type="qcurve" smooth="yes"/>
+      <point x="352" y="1304"/>
+      <point x="315" y="1256"/>
+      <point x="306" y="1202" type="qcurve"/>
+      <point x="135" y="232" type="line" smooth="yes"/>
+      <point x="125" y="176"/>
+      <point x="145" y="130"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="496"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="-404" yOffset="-6"/>
+    <component base="O" identifier="52008255"/>
+    <component base="Oslash-bar" xOffset="-404" yOffset="-6" identifier="3F8846D3"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>3F8846D3</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>52008255</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="474"/>
   <outline>
-    <component base="nine" xOffset="6"/>
+    <component base="nine" xOffset="6" identifier="FDC2F139"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>FDC2F139</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/glyphs/o.glif
@@ -3,43 +3,43 @@
   <advance width="424"/>
   <unicode hex="006F"/>
   <guideline x="212" y="621" angle="90" identifier="76TN0N3iUx"/>
-  <anchor x="212" y="0" name="bottom"/>
+  <anchor x="122" y="0" name="bottom"/>
   <anchor x="212" y="510" name="center"/>
-  <anchor x="286" y="0" name="ogonek"/>
-  <anchor x="212" y="1020" name="top"/>
-  <anchor x="284" y="1020" name="topright"/>
+  <anchor x="196" y="0" name="ogonek"/>
+  <anchor x="301" y="1020" name="top"/>
+  <anchor x="373" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="212" y="-12" type="qcurve" smooth="yes"/>
-      <point x="124" y="-12"/>
-      <point x="36" y="92"/>
-      <point x="36" y="198" type="qcurve"/>
-      <point x="36" y="816" type="line"/>
-      <point x="36" y="924"/>
-      <point x="124" y="1032"/>
-      <point x="212" y="1032" type="qcurve" smooth="yes"/>
-      <point x="296" y="1032"/>
-      <point x="388" y="920"/>
-      <point x="388" y="816" type="qcurve"/>
-      <point x="388" y="198" type="line"/>
-      <point x="388" y="92"/>
-      <point x="300" y="-12"/>
+      <point x="120" y="-12" type="qcurve" smooth="yes"/>
+      <point x="32" y="-12"/>
+      <point x="-38" y="92"/>
+      <point x="-19" y="198" type="qcurve"/>
+      <point x="90" y="816" type="line"/>
+      <point x="109" y="924"/>
+      <point x="216" y="1032"/>
+      <point x="304" y="1032" type="qcurve" smooth="yes"/>
+      <point x="388" y="1032"/>
+      <point x="460" y="920"/>
+      <point x="442" y="816" type="qcurve"/>
+      <point x="333" y="198" type="line"/>
+      <point x="314" y="92"/>
+      <point x="208" y="-12"/>
     </contour>
     <contour>
-      <point x="212" y="122" type="qcurve" smooth="yes"/>
-      <point x="234" y="122"/>
-      <point x="254" y="160"/>
-      <point x="254" y="198" type="qcurve"/>
-      <point x="254" y="824" type="line" smooth="yes"/>
-      <point x="254" y="866"/>
-      <point x="234" y="896"/>
-      <point x="212" y="896" type="qcurve" smooth="yes"/>
-      <point x="190" y="896"/>
-      <point x="170" y="866"/>
-      <point x="170" y="824" type="qcurve"/>
-      <point x="170" y="198" type="line" smooth="yes"/>
-      <point x="170" y="160"/>
-      <point x="190" y="122"/>
+      <point x="143" y="122" type="qcurve" smooth="yes"/>
+      <point x="165" y="122"/>
+      <point x="192" y="160"/>
+      <point x="199" y="198" type="qcurve"/>
+      <point x="309" y="824" type="line" smooth="yes"/>
+      <point x="316" y="866"/>
+      <point x="302" y="896"/>
+      <point x="280" y="896" type="qcurve" smooth="yes"/>
+      <point x="258" y="896"/>
+      <point x="232" y="866"/>
+      <point x="225" y="824" type="qcurve"/>
+      <point x="115" y="198" type="line" smooth="yes"/>
+      <point x="108" y="160"/>
+      <point x="121" y="122"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="424"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-204" yOffset="20"/>
+    <component base="o" identifier="2A62BD95"/>
+    <component base="oslash-bar" xOffset="-204" yOffset="20" identifier="5656488B"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>2A62BD95</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>5656488B</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="474"/>
   <outline>
-    <component base="six" xOffset="3"/>
+    <component base="six" xOffset="3" identifier="D64AAC58"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>D64AAC58</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/fontinfo.plist
@@ -47,7 +47,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -55,7 +55,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="836"/>
   <unicode hex="004F"/>
   <guideline x="416" y="1016" angle="90" identifier="w7kVbh16nr"/>
-  <anchor x="430" y="0" name="bottom"/>
+  <anchor x="304" y="0" name="bottom"/>
   <anchor x="416" y="716" name="center"/>
-  <anchor x="518" y="0" name="ogonek"/>
-  <anchor x="431" y="1432" name="top"/>
-  <anchor x="531" y="1432" name="topright"/>
+  <anchor x="392" y="0" name="ogonek"/>
+  <anchor x="557" y="1432" name="top"/>
+  <anchor x="657" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="417" y="-13" type="qcurve" smooth="yes"/>
-      <point x="272" y="-13" name="inserted"/>
-      <point x="115" y="169"/>
-      <point x="115" y="337" type="qcurve"/>
-      <point x="115" y="1093" type="line"/>
-      <point x="115" y="1262" name="inserted"/>
-      <point x="272" y="1445"/>
-      <point x="418" y="1445" type="qcurve" smooth="yes"/>
-      <point x="563" y="1445" name="inserted"/>
-      <point x="721" y="1262"/>
-      <point x="721" y="1093" type="qcurve"/>
-      <point x="721" y="337" type="line"/>
-      <point x="721" y="169" name="inserted"/>
-      <point x="564" y="-13"/>
+      <point x="325" y="-13" type="qcurve" smooth="yes"/>
+      <point x="180" y="-13" name="inserted"/>
+      <point x="55" y="169"/>
+      <point x="84" y="337" type="qcurve"/>
+      <point x="218" y="1093" type="line"/>
+      <point x="247" y="1262" name="inserted"/>
+      <point x="438" y="1445"/>
+      <point x="583" y="1445" type="qcurve" smooth="yes"/>
+      <point x="728" y="1445" name="inserted"/>
+      <point x="853" y="1262"/>
+      <point x="824" y="1093" type="qcurve"/>
+      <point x="690" y="337" type="line"/>
+      <point x="661" y="169" name="inserted"/>
+      <point x="471" y="-13"/>
     </contour>
     <contour>
-      <point x="417" y="-9" type="qcurve" smooth="yes"/>
-      <point x="560" y="-9" name="inserted"/>
-      <point x="716" y="171"/>
-      <point x="716" y="337" type="qcurve"/>
-      <point x="716" y="1094" type="line"/>
-      <point x="716" y="1260" name="inserted"/>
-      <point x="561" y="1441"/>
-      <point x="417" y="1441" type="qcurve" smooth="yes"/>
-      <point x="274" y="1441" name="inserted"/>
-      <point x="119" y="1260"/>
-      <point x="119" y="1094" type="qcurve"/>
-      <point x="119" y="337" type="line"/>
-      <point x="119" y="171" name="inserted"/>
-      <point x="274" y="-9"/>
+      <point x="325" y="-9" type="qcurve" smooth="yes"/>
+      <point x="468" y="-9" name="inserted"/>
+      <point x="657" y="170"/>
+      <point x="686" y="337" type="qcurve"/>
+      <point x="820" y="1094" type="line"/>
+      <point x="849" y="1260" name="inserted"/>
+      <point x="726" y="1441"/>
+      <point x="581" y="1441" type="qcurve" smooth="yes"/>
+      <point x="439" y="1441" name="inserted"/>
+      <point x="251" y="1260"/>
+      <point x="222" y="1094" type="qcurve"/>
+      <point x="88" y="337" type="line"/>
+      <point x="59" y="171" name="inserted"/>
+      <point x="183" y="-9"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="836"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="-251" yOffset="-20"/>
+    <component base="O" identifier="5C2D9D60"/>
+    <component base="Oslash-bar" xOffset="-251" yOffset="-20" identifier="7598B3CE"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>5C2D9D60</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>7598B3CE</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="627"/>
   <outline>
-    <component base="nine" xOffset="26"/>
+    <component base="nine" xOffset="26" identifier="761560A6"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>761560A6</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/glyphs/o.glif
@@ -3,43 +3,43 @@
   <advance width="658"/>
   <unicode hex="006F"/>
   <guideline x="332" y="787" angle="90" identifier="a1Alpt9wPG"/>
-  <anchor x="328" y="0" name="bottom"/>
-  <anchor x="330" y="510" name="center"/>
-  <anchor x="407" y="0" name="ogonek"/>
-  <anchor x="329" y="1020" name="top"/>
-  <anchor x="426" y="1020" name="topright"/>
+  <anchor x="237" y="0" name="bottom"/>
+  <anchor x="329" y="510" name="center"/>
+  <anchor x="316" y="0" name="ogonek"/>
+  <anchor x="418" y="1020" name="top"/>
+  <anchor x="515" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="328" y="-10" type="qcurve" smooth="yes"/>
-      <point x="210" y="-10" name="inserted"/>
-      <point x="77" y="141"/>
-      <point x="77" y="287" type="qcurve"/>
-      <point x="77" y="741" type="line"/>
-      <point x="77" y="886" name="inserted"/>
-      <point x="211" y="1037"/>
-      <point x="329" y="1037" type="qcurve" smooth="yes"/>
-      <point x="448" y="1037" name="inserted"/>
-      <point x="581" y="886"/>
-      <point x="581" y="741" type="qcurve"/>
-      <point x="581" y="287" type="line"/>
-      <point x="581" y="141" name="inserted"/>
-      <point x="446" y="-10"/>
+      <point x="236" y="-10" type="qcurve" smooth="yes"/>
+      <point x="119" y="-10" name="inserted"/>
+      <point x="11" y="141"/>
+      <point x="37" y="287" type="qcurve"/>
+      <point x="117" y="741" type="line"/>
+      <point x="143" y="886" name="inserted"/>
+      <point x="303" y="1037"/>
+      <point x="421" y="1037" type="qcurve" smooth="yes"/>
+      <point x="540" y="1037" name="inserted"/>
+      <point x="647" y="885"/>
+      <point x="621" y="741" type="qcurve"/>
+      <point x="541" y="287" type="line"/>
+      <point x="515" y="141" name="inserted"/>
+      <point x="354" y="-10"/>
     </contour>
     <contour>
-      <point x="328" y="-6" type="qcurve" smooth="yes"/>
-      <point x="445" y="-6" name="inserted"/>
-      <point x="578" y="143"/>
-      <point x="578" y="287" type="qcurve"/>
-      <point x="578" y="741" type="line"/>
-      <point x="578" y="884" name="inserted"/>
-      <point x="447" y="1033"/>
-      <point x="329" y="1033" type="qcurve" smooth="yes"/>
-      <point x="213" y="1033" name="inserted"/>
-      <point x="81" y="884"/>
-      <point x="81" y="741" type="qcurve"/>
-      <point x="81" y="287" type="line"/>
-      <point x="81" y="143" name="inserted"/>
-      <point x="212" y="-6"/>
+      <point x="236" y="-6" type="qcurve" smooth="yes"/>
+      <point x="353" y="-6" name="inserted"/>
+      <point x="512" y="143"/>
+      <point x="537" y="287" type="qcurve"/>
+      <point x="617" y="741" type="line"/>
+      <point x="642" y="884" name="inserted"/>
+      <point x="539" y="1033"/>
+      <point x="421" y="1033" type="qcurve" smooth="yes"/>
+      <point x="305" y="1033" name="inserted"/>
+      <point x="146" y="884"/>
+      <point x="121" y="741" type="qcurve"/>
+      <point x="41" y="287" type="line"/>
+      <point x="16" y="143" name="inserted"/>
+      <point x="120" y="-6"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="658"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-51" yOffset="12"/>
+    <component base="o" identifier="30E185D4"/>
+    <component base="oslash-bar" xOffset="-51" yOffset="12" identifier="A4A6179C"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>30E185D4</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>A4A6179C</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="627"/>
   <outline>
-    <component base="six" xOffset="19"/>
+    <component base="six" xOffset="19" identifier="325BEE1C"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>325BEE1C</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/fontinfo.plist
@@ -47,7 +47,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -55,7 +55,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1419"/>
   <unicode hex="004F"/>
-  <anchor x="708" y="0" name="bottom"/>
-  <anchor x="706" y="716" name="center"/>
-  <anchor x="933" y="0" name="ogonek"/>
-  <anchor x="708" y="1433" name="top"/>
-  <anchor x="891" y="1432" name="topright"/>
+  <anchor x="618" y="0" name="bottom"/>
+  <anchor x="742.2501181872609" y="716" name="center"/>
+  <anchor x="843" y="0" name="ogonek"/>
+  <anchor x="870.6765633552303" y="1433" name="top"/>
+  <anchor x="1053.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="709" y="-32" type="qcurve" smooth="yes"/>
-      <point x="410" y="-32" name="inserted"/>
-      <point x="29" y="350"/>
-      <point x="29" y="678" type="qcurve"/>
-      <point x="29" y="765" type="line"/>
-      <point x="29" y="1089" name="inserted"/>
-      <point x="408" y="1461"/>
-      <point x="709" y="1461" type="qcurve" smooth="yes"/>
-      <point x="1011" y="1461" name="inserted"/>
-      <point x="1389" y="1078"/>
-      <point x="1389" y="764" type="qcurve"/>
-      <point x="1389" y="678" type="line"/>
-      <point x="1389" y="360" name="inserted"/>
-      <point x="1008" y="-32"/>
+      <point x="613" y="-32" type="qcurve" smooth="yes"/>
+      <point x="337" y="-32" name="inserted"/>
+      <point x="0" y="350"/>
+      <point x="59" y="678" type="qcurve" smooth="yes"/>
+      <point x="74" y="765" type="line" smooth="yes"/>
+      <point x="131" y="1089" name="inserted"/>
+      <point x="526" y="1461"/>
+      <point x="846" y="1461" type="qcurve" smooth="yes"/>
+      <point x="1164" y="1461" name="inserted"/>
+      <point x="1489" y="1078"/>
+      <point x="1434" y="764" type="qcurve"/>
+      <point x="1419" y="678" type="line"/>
+      <point x="1362" y="360" name="inserted"/>
+      <point x="945" y="-32"/>
     </contour>
     <contour>
-      <point x="709" y="518" type="qcurve" smooth="yes"/>
-      <point x="766" y="518" name="inserted"/>
-      <point x="826" y="589"/>
-      <point x="826" y="658" type="qcurve"/>
-      <point x="826" y="771" type="line"/>
-      <point x="826" y="842" name="inserted"/>
-      <point x="766" y="914"/>
-      <point x="709" y="914" type="qcurve" smooth="yes"/>
-      <point x="652" y="914" name="inserted"/>
-      <point x="593" y="842"/>
-      <point x="593" y="771" type="qcurve"/>
-      <point x="593" y="658" type="line"/>
-      <point x="593" y="589" name="inserted"/>
-      <point x="652" y="518"/>
+      <point x="710" y="518" type="qcurve" smooth="yes"/>
+      <point x="767" y="518" name="inserted"/>
+      <point x="840" y="589"/>
+      <point x="852" y="658" type="qcurve" smooth="yes"/>
+      <point x="872" y="771" type="line" smooth="yes"/>
+      <point x="884" y="842" name="inserted"/>
+      <point x="837" y="914"/>
+      <point x="780" y="914" type="qcurve" smooth="yes"/>
+      <point x="723" y="914" name="inserted"/>
+      <point x="651" y="842"/>
+      <point x="639" y="771" type="qcurve" smooth="yes"/>
+      <point x="619" y="658" type="line" smooth="yes"/>
+      <point x="607" y="589" name="inserted"/>
+      <point x="653" y="518"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/glyphs/O_slash-bar.glif
@@ -3,28 +3,28 @@
   <advance width="1392"/>
   <outline>
     <contour>
-      <point x="567" y="818" type="line"/>
-      <point x="1016" y="1416" type="line" smooth="yes"/>
-      <point x="1095" y="1521"/>
-      <point x="1095" y="1521"/>
-      <point x="1227" y="1425" type="qcurve"/>
-      <point x="1227" y="1425" type="line"/>
-      <point x="1354" y="1333"/>
-      <point x="1354" y="1333"/>
-      <point x="1271" y="1222" type="qcurve" smooth="yes"/>
-      <point x="827" y="629" type="line"/>
+      <point x="477" y="818" type="line"/>
+      <point x="926" y="1416" type="line" smooth="yes"/>
+      <point x="1005" y="1521"/>
+      <point x="1005" y="1521"/>
+      <point x="1137" y="1425" type="qcurve"/>
+      <point x="1137" y="1425" type="line"/>
+      <point x="1264" y="1333"/>
+      <point x="1264" y="1333"/>
+      <point x="1181" y="1222" type="qcurve" smooth="yes"/>
+      <point x="737" y="629" type="line"/>
     </contour>
     <contour>
-      <point x="118" y="221" type="qcurve" smooth="yes"/>
-      <point x="567" y="818" type="line"/>
-      <point x="827" y="629" type="line"/>
-      <point x="373" y="27" type="line" smooth="yes"/>
-      <point x="294" y="-78"/>
-      <point x="294" y="-78"/>
-      <point x="162" y="18" type="qcurve"/>
-      <point x="162" y="18" type="line"/>
-      <point x="35" y="110"/>
-      <point x="35" y="110"/>
+      <point x="28" y="221" type="qcurve" smooth="yes"/>
+      <point x="477" y="818" type="line"/>
+      <point x="737" y="629" type="line"/>
+      <point x="283" y="27" type="line" smooth="yes"/>
+      <point x="204" y="-78"/>
+      <point x="204" y="-78"/>
+      <point x="72" y="18" type="qcurve"/>
+      <point x="72" y="18" type="line"/>
+      <point x="-55" y="110"/>
+      <point x="-55" y="110"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/glyphs/nine.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/glyphs/nine.glif
@@ -4,59 +4,59 @@
   <unicode hex="0039"/>
   <outline>
     <contour>
-      <point x="543" y="1459" type="line"/>
-      <point x="782" y="1459" name="inserted"/>
-      <point x="1080" y="1195"/>
-      <point x="1080" y="972" type="qcurve"/>
-      <point x="1080" y="902" type="line"/>
-      <point x="1080" y="731" name="inserted"/>
-      <point x="752" y="490"/>
-      <point x="534" y="490" type="qcurve"/>
-      <point x="534" y="490" type="line"/>
-      <point x="321" y="490" name="inserted"/>
-      <point x="21" y="687"/>
-      <point x="21" y="898" type="qcurve"/>
-      <point x="21" y="961" type="line"/>
-      <point x="21" y="1189" name="inserted"/>
-      <point x="312" y="1459"/>
-      <point x="543" y="1459" type="qcurve"/>
+      <point x="453" y="1459" type="line"/>
+      <point x="692" y="1459" name="inserted"/>
+      <point x="990" y="1195"/>
+      <point x="990" y="972" type="qcurve"/>
+      <point x="990" y="902" type="line"/>
+      <point x="990" y="731" name="inserted"/>
+      <point x="662" y="490"/>
+      <point x="444" y="490" type="qcurve"/>
+      <point x="444" y="490" type="line"/>
+      <point x="231" y="490" name="inserted"/>
+      <point x="-69" y="687"/>
+      <point x="-69" y="898" type="qcurve"/>
+      <point x="-69" y="961" type="line"/>
+      <point x="-69" y="1189" name="inserted"/>
+      <point x="222" y="1459"/>
+      <point x="453" y="1459" type="qcurve"/>
     </contour>
     <contour>
-      <point x="842" y="901" type="line"/>
-      <point x="1080" y="901" type="line"/>
-      <point x="1080" y="777"/>
-      <point x="989" y="550"/>
-      <point x="873" y="404" type="qcurve" smooth="yes"/>
-      <point x="669" y="147" type="line"/>
-      <point x="514" y="-46"/>
-      <point x="514" y="-46"/>
-      <point x="342" y="91" type="qcurve"/>
-      <point x="342" y="91" type="line"/>
-      <point x="166" y="231"/>
-      <point x="166" y="231"/>
-      <point x="284" y="364" type="qcurve"/>
-      <point x="325" y="411" type="line" smooth="yes"/>
-      <point x="365" y="456"/>
-      <point x="455" y="544"/>
-      <point x="515" y="573" type="qcurve"/>
+      <point x="752" y="901" type="line"/>
+      <point x="990" y="901" type="line"/>
+      <point x="990" y="777"/>
+      <point x="899" y="550"/>
+      <point x="783" y="404" type="qcurve" smooth="yes"/>
+      <point x="579" y="147" type="line"/>
+      <point x="424" y="-46"/>
+      <point x="424" y="-46"/>
+      <point x="252" y="91" type="qcurve"/>
+      <point x="252" y="91" type="line"/>
+      <point x="76" y="231"/>
+      <point x="76" y="231"/>
+      <point x="194" y="364" type="qcurve"/>
+      <point x="235" y="411" type="line" smooth="yes"/>
+      <point x="275" y="456"/>
+      <point x="365" y="544"/>
+      <point x="425" y="573" type="qcurve"/>
     </contour>
     <contour>
-      <point x="546" y="1043" type="qcurve"/>
-      <point x="546" y="1043" type="line"/>
-      <point x="515" y="1043" name="inserted"/>
-      <point x="478" y="1003"/>
-      <point x="479" y="961" type="qcurve"/>
-      <point x="479" y="929" type="line"/>
-      <point x="478" y="885" name="inserted"/>
-      <point x="517" y="846"/>
-      <point x="546" y="847" type="qcurve"/>
-      <point x="546" y="847" type="line"/>
-      <point x="576" y="847" name="inserted"/>
-      <point x="613" y="885"/>
-      <point x="613" y="929" type="qcurve"/>
-      <point x="613" y="961" type="line"/>
-      <point x="614" y="1004" name="inserted"/>
-      <point x="577" y="1043"/>
+      <point x="456" y="1043" type="qcurve"/>
+      <point x="456" y="1043" type="line"/>
+      <point x="425" y="1043" name="inserted"/>
+      <point x="388" y="1003"/>
+      <point x="389" y="961" type="qcurve"/>
+      <point x="389" y="929" type="line"/>
+      <point x="388" y="885" name="inserted"/>
+      <point x="427" y="846"/>
+      <point x="456" y="847" type="qcurve"/>
+      <point x="456" y="847" type="line"/>
+      <point x="486" y="847" name="inserted"/>
+      <point x="523" y="885"/>
+      <point x="523" y="929" type="qcurve"/>
+      <point x="523" y="961" type="line"/>
+      <point x="524" y="1004" name="inserted"/>
+      <point x="487" y="1043"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1161"/>
   <unicode hex="006F"/>
-  <anchor x="579" y="0" name="bottom"/>
-  <anchor x="583" y="510" name="center"/>
-  <anchor x="793" y="0" name="ogonek"/>
-  <anchor x="579" y="1020" name="top"/>
-  <anchor x="778" y="1020" name="topright"/>
+  <anchor x="489" y="0" name="bottom"/>
+  <anchor x="582.9267601613171" y="510" name="center"/>
+  <anchor x="703" y="0" name="ogonek"/>
+  <anchor x="668.8535203226343" y="1020" name="top"/>
+  <anchor x="867.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="325" y="-33" name="inserted"/>
-      <point x="17" y="262"/>
-      <point x="17" y="505" type="qcurve"/>
-      <point x="17" y="522" type="line"/>
-      <point x="17" y="766" name="inserted"/>
-      <point x="325" y="1061"/>
-      <point x="576" y="1061" type="qcurve" smooth="yes"/>
-      <point x="829" y="1061" name="inserted"/>
-      <point x="1144" y="765"/>
-      <point x="1144" y="522" type="qcurve"/>
-      <point x="1144" y="505" type="line"/>
-      <point x="1144" y="264" name="inserted"/>
-      <point x="829" y="-33"/>
+      <point x="490" y="-33" type="qcurve" smooth="yes"/>
+      <point x="255" y="-33" name="inserted"/>
+      <point x="-27" y="262"/>
+      <point x="16" y="505" type="qcurve"/>
+      <point x="19" y="522" type="line"/>
+      <point x="62" y="766" name="inserted"/>
+      <point x="388" y="1061"/>
+      <point x="658" y="1061" type="qcurve" smooth="yes"/>
+      <point x="927" y="1061" name="inserted"/>
+      <point x="1189" y="765"/>
+      <point x="1146" y="522" type="qcurve"/>
+      <point x="1143" y="505" type="line"/>
+      <point x="1101" y="264" name="inserted"/>
+      <point x="762" y="-33"/>
     </contour>
     <contour>
-      <point x="581" y="407" type="qcurve" smooth="yes"/>
-      <point x="619" y="407" name="inserted"/>
-      <point x="661" y="452"/>
-      <point x="661" y="491" type="qcurve"/>
-      <point x="661" y="537" type="line"/>
-      <point x="661" y="579" name="inserted"/>
-      <point x="617" y="622"/>
-      <point x="581" y="622" type="qcurve" smooth="yes"/>
-      <point x="545" y="622" name="inserted"/>
-      <point x="500" y="580"/>
-      <point x="500" y="537" type="qcurve"/>
-      <point x="500" y="492" type="line"/>
-      <point x="500" y="452" name="inserted"/>
-      <point x="544" y="408"/>
+      <point x="563" y="407" type="qcurve" smooth="yes"/>
+      <point x="601" y="407" name="inserted"/>
+      <point x="651" y="452"/>
+      <point x="658" y="491" type="qcurve" smooth="yes"/>
+      <point x="666" y="537" type="line" smooth="yes"/>
+      <point x="673" y="579" name="inserted"/>
+      <point x="637" y="622"/>
+      <point x="601" y="622" type="qcurve" smooth="yes"/>
+      <point x="565" y="622" name="inserted"/>
+      <point x="513" y="580"/>
+      <point x="505" y="537" type="qcurve" smooth="yes"/>
+      <point x="497" y="492" type="line" smooth="yes"/>
+      <point x="490" y="452" name="inserted"/>
+      <point x="526" y="408"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/glyphs/oslash-bar.glif
@@ -1,32 +1,32 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="1226"/>
-  <guideline x="647" y="842" angle="0" identifier="UrsdY3C35E"/>
-  <guideline x="754" y="189" angle="0" identifier="ogOOHsjQjX"/>
+  <guideline x="557" y="842" angle="0" identifier="UrsdY3C35E"/>
+  <guideline x="664" y="189" angle="0" identifier="ogOOHsjQjX"/>
   <outline>
     <contour>
-      <point x="519" y="590" type="line"/>
-      <point x="886" y="1015" type="line" smooth="yes"/>
-      <point x="956" y="1096"/>
-      <point x="956" y="1096"/>
-      <point x="1046" y="1018" type="qcurve"/>
-      <point x="1046" y="1018" type="line"/>
-      <point x="1135" y="941"/>
-      <point x="1135" y="941"/>
-      <point x="1070" y="867" type="qcurve" smooth="yes"/>
-      <point x="692" y="436" type="line"/>
+      <point x="429" y="590" type="line"/>
+      <point x="796" y="1015" type="line" smooth="yes"/>
+      <point x="866" y="1096"/>
+      <point x="866" y="1096"/>
+      <point x="956" y="1018" type="qcurve"/>
+      <point x="956" y="1018" type="line"/>
+      <point x="1045" y="941"/>
+      <point x="1045" y="941"/>
+      <point x="980" y="867" type="qcurve" smooth="yes"/>
+      <point x="602" y="436" type="line"/>
     </contour>
     <contour>
-      <point x="145" y="158" type="qcurve" smooth="yes"/>
-      <point x="519" y="590" type="line"/>
-      <point x="692" y="436" type="line"/>
-      <point x="329" y="10" type="line" smooth="yes"/>
-      <point x="259" y="-72"/>
-      <point x="259" y="-72"/>
-      <point x="169" y="7" type="qcurve"/>
-      <point x="169" y="7" type="line"/>
-      <point x="80" y="83"/>
-      <point x="80" y="83"/>
+      <point x="55" y="158" type="qcurve" smooth="yes"/>
+      <point x="429" y="590" type="line"/>
+      <point x="602" y="436" type="line"/>
+      <point x="239" y="10" type="line" smooth="yes"/>
+      <point x="169" y="-72"/>
+      <point x="169" y="-72"/>
+      <point x="79" y="7" type="qcurve"/>
+      <point x="79" y="7" type="line"/>
+      <point x="-10" y="83"/>
+      <point x="-10" y="83"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/glyphs/six.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo/glyphs/six.glif
@@ -4,59 +4,59 @@
   <unicode hex="0036"/>
   <outline>
     <contour>
-      <point x="562" y="-32" type="line"/>
-      <point x="323" y="-32" name="inserted"/>
-      <point x="25" y="241"/>
-      <point x="25" y="463" type="qcurve"/>
-      <point x="25" y="533" type="line"/>
-      <point x="25" y="704" name="inserted"/>
-      <point x="353" y="945"/>
-      <point x="571" y="945" type="qcurve"/>
-      <point x="571" y="945" type="line"/>
-      <point x="784" y="945" name="inserted"/>
-      <point x="1084" y="749"/>
-      <point x="1084" y="537" type="qcurve"/>
-      <point x="1084" y="475" type="line"/>
-      <point x="1084" y="247" name="inserted"/>
-      <point x="793" y="-32"/>
-      <point x="562" y="-32" type="qcurve"/>
+      <point x="472" y="-32" type="line"/>
+      <point x="233" y="-32" name="inserted"/>
+      <point x="-65" y="241"/>
+      <point x="-65" y="463" type="qcurve"/>
+      <point x="-65" y="533" type="line"/>
+      <point x="-65" y="704" name="inserted"/>
+      <point x="263" y="945"/>
+      <point x="481" y="945" type="qcurve"/>
+      <point x="481" y="945" type="line"/>
+      <point x="694" y="945" name="inserted"/>
+      <point x="994" y="749"/>
+      <point x="994" y="537" type="qcurve"/>
+      <point x="994" y="475" type="line"/>
+      <point x="994" y="247" name="inserted"/>
+      <point x="703" y="-32"/>
+      <point x="472" y="-32" type="qcurve"/>
     </contour>
     <contour>
-      <point x="257" y="534" type="line"/>
-      <point x="25" y="534" type="line"/>
-      <point x="25" y="658"/>
-      <point x="115" y="886"/>
-      <point x="232" y="1031" type="qcurve" smooth="yes"/>
-      <point x="453" y="1308" type="line"/>
-      <point x="608" y="1501"/>
-      <point x="608" y="1501"/>
-      <point x="779" y="1364" type="qcurve"/>
-      <point x="779" y="1364" type="line"/>
-      <point x="955" y="1224"/>
-      <point x="955" y="1224"/>
-      <point x="837" y="1091" type="qcurve"/>
-      <point x="780" y="1024" type="line" smooth="yes"/>
-      <point x="741" y="979"/>
-      <point x="650" y="891"/>
-      <point x="590" y="862" type="qcurve"/>
+      <point x="167" y="534" type="line"/>
+      <point x="-65" y="534" type="line"/>
+      <point x="-65" y="658"/>
+      <point x="25" y="886"/>
+      <point x="142" y="1031" type="qcurve" smooth="yes"/>
+      <point x="363" y="1308" type="line"/>
+      <point x="518" y="1501"/>
+      <point x="518" y="1501"/>
+      <point x="689" y="1364" type="qcurve"/>
+      <point x="689" y="1364" type="line"/>
+      <point x="865" y="1224"/>
+      <point x="865" y="1224"/>
+      <point x="747" y="1091" type="qcurve"/>
+      <point x="690" y="1024" type="line" smooth="yes"/>
+      <point x="651" y="979"/>
+      <point x="560" y="891"/>
+      <point x="500" y="862" type="qcurve"/>
     </contour>
     <contour>
-      <point x="559" y="393" type="qcurve"/>
-      <point x="559" y="393" type="line"/>
-      <point x="590" y="393" name="inserted"/>
-      <point x="627" y="432"/>
-      <point x="626" y="474" type="qcurve"/>
-      <point x="626" y="507" type="line"/>
-      <point x="627" y="551" name="inserted"/>
-      <point x="588" y="589"/>
-      <point x="559" y="589" type="qcurve"/>
-      <point x="559" y="589" type="line"/>
-      <point x="529" y="589" name="inserted"/>
-      <point x="492" y="550"/>
-      <point x="492" y="507" type="qcurve"/>
-      <point x="492" y="474" type="line"/>
-      <point x="491" y="431" name="inserted"/>
-      <point x="528" y="392"/>
+      <point x="469" y="393" type="qcurve"/>
+      <point x="469" y="393" type="line"/>
+      <point x="500" y="393" name="inserted"/>
+      <point x="537" y="432"/>
+      <point x="536" y="474" type="qcurve"/>
+      <point x="536" y="507" type="line"/>
+      <point x="537" y="551" name="inserted"/>
+      <point x="498" y="589"/>
+      <point x="469" y="589" type="qcurve"/>
+      <point x="469" y="589" type="line"/>
+      <point x="439" y="589" name="inserted"/>
+      <point x="402" y="550"/>
+      <point x="402" y="507" type="qcurve"/>
+      <point x="402" y="474" type="line"/>
+      <point x="401" y="431" name="inserted"/>
+      <point x="438" y="392"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND0.ufo/fontinfo.plist
@@ -47,7 +47,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -55,7 +55,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND0.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="818"/>
   <unicode hex="004F"/>
-  <guideline x="409" y="1100" angle="90" identifier="QpdvYzwgyk"/>
-  <anchor x="462" y="0" name="bottom"/>
-  <anchor x="409" y="716" name="center"/>
-  <anchor x="572" y="0" name="ogonek"/>
-  <anchor x="461" y="1432" name="top"/>
-  <anchor x="595" y="1432" name="topright"/>
+  <guideline x="512.9596787793" y="1100" angle="100" identifier="QpdvYzwgyk"/>
+  <anchor x="372" y="0" name="bottom"/>
+  <anchor x="445.2501181873" y="716" name="center"/>
+  <anchor x="482" y="0" name="ogonek"/>
+  <anchor x="623.5002363745" y="1432" name="top"/>
+  <anchor x="757.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="409" y="-18" type="qcurve"/>
-      <point x="257" y="-18"/>
-      <point x="84" y="168"/>
-      <point x="84" y="318" type="qcurve"/>
-      <point x="84" y="1119" type="line"/>
-      <point x="84" y="1269"/>
-      <point x="255" y="1452"/>
-      <point x="409" y="1452" type="qcurve"/>
-      <point x="562" y="1452"/>
-      <point x="734" y="1268"/>
-      <point x="734" y="1119" type="qcurve"/>
-      <point x="734" y="318" type="line"/>
-      <point x="734" y="170"/>
-      <point x="560" y="-18"/>
+      <point x="315.8261143472" y="-18" type="qcurve"/>
+      <point x="169" y="-18"/>
+      <point x="24" y="168"/>
+      <point x="50" y="318" type="qcurve" smooth="yes"/>
+      <point x="191" y="1119" type="line" smooth="yes"/>
+      <point x="218" y="1269"/>
+      <point x="410" y="1452"/>
+      <point x="575.0267759887" y="1452" type="qcurve"/>
+      <point x="718" y="1452"/>
+      <point x="868" y="1268"/>
+      <point x="841" y="1119" type="qcurve" smooth="yes"/>
+      <point x="700" y="318" type="line" smooth="yes"/>
+      <point x="674" y="170"/>
+      <point x="479" y="-18"/>
     </contour>
     <contour>
-      <point x="409" y="123" type="qcurve"/>
-      <point x="498" y="122"/>
-      <point x="592" y="229"/>
-      <point x="592" y="320" type="qcurve"/>
-      <point x="592" y="1113" type="line"/>
-      <point x="592" y="1202"/>
-      <point x="497" y="1309"/>
-      <point x="409" y="1309" type="qcurve"/>
-      <point x="321" y="1309"/>
-      <point x="227" y="1202"/>
-      <point x="227" y="1113" type="qcurve"/>
-      <point x="227" y="320" type="line"/>
-      <point x="227" y="229"/>
-      <point x="320" y="122"/>
+      <point x="340.6882186271" y="123" type="qcurve"/>
+      <point x="429.5118916464" y="122"/>
+      <point x="542" y="229"/>
+      <point x="558" y="320" type="qcurve" smooth="yes"/>
+      <point x="698" y="1113" type="line" smooth="yes"/>
+      <point x="714" y="1202"/>
+      <point x="637.8120177474" y="1309"/>
+      <point x="549.8120177474" y="1309" type="qcurve"/>
+      <point x="461.8120177474" y="1309"/>
+      <point x="349" y="1202"/>
+      <point x="333" y="1113" type="qcurve" smooth="yes"/>
+      <point x="193" y="320" type="line" smooth="yes"/>
+      <point x="177" y="229"/>
+      <point x="251.5118916464" y="122"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND0.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="690"/>
   <unicode hex="006F"/>
-  <guideline x="346" y="697" angle="90" identifier="61czlfv11v"/>
-  <anchor x="345" y="0" name="bottom"/>
-  <anchor x="345" y="510" name="center"/>
-  <anchor x="459" y="0" name="ogonek"/>
-  <anchor x="345" y="1020" name="top"/>
-  <anchor x="450" y="1020" name="topright"/>
+  <guideline x="378.8999055538" y="697" angle="100" identifier="61czlfv11v"/>
+  <anchor x="255" y="0" name="bottom"/>
+  <anchor x="344.9267601613" y="510" name="center"/>
+  <anchor x="369" y="0" name="ogonek"/>
+  <anchor x="434.8535203226" y="1020" name="top"/>
+  <anchor x="539.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="345" y="-19" type="qcurve"/>
-      <point x="214" y="-19"/>
-      <point x="63" y="138"/>
-      <point x="63" y="283" type="qcurve"/>
-      <point x="63" y="730" type="line"/>
-      <point x="63" y="875"/>
-      <point x="215" y="1036"/>
-      <point x="345" y="1036" type="qcurve"/>
-      <point x="472" y="1036"/>
-      <point x="627" y="871"/>
-      <point x="627" y="730" type="qcurve"/>
-      <point x="627" y="283" type="line"/>
-      <point x="627" y="140"/>
-      <point x="476" y="-19"/>
+      <point x="251.6497873665" y="-19" type="qcurve"/>
+      <point x="126" y="-19"/>
+      <point x="-3" y="138"/>
+      <point x="23" y="283" type="qcurve" smooth="yes"/>
+      <point x="102" y="730" type="line" smooth="yes"/>
+      <point x="127" y="875"/>
+      <point x="298" y="1036"/>
+      <point x="435" y="1037" type="qcurve"/>
+      <point x="557" y="1036"/>
+      <point x="691" y="871"/>
+      <point x="666" y="730" type="qcurve" smooth="yes"/>
+      <point x="587" y="283" type="line" smooth="yes"/>
+      <point x="562" y="140"/>
+      <point x="398" y="-19"/>
     </contour>
     <contour>
-      <point x="346" y="115" type="qcurve"/>
-      <point x="413" y="115"/>
-      <point x="489" y="201"/>
-      <point x="489" y="281" type="qcurve"/>
-      <point x="489" y="736" type="line"/>
-      <point x="489" y="818"/>
-      <point x="412" y="900"/>
-      <point x="346" y="900" type="qcurve"/>
-      <point x="278" y="900"/>
-      <point x="200" y="819"/>
-      <point x="200" y="736" type="qcurve"/>
-      <point x="200" y="281" type="line"/>
-      <point x="200" y="200"/>
-      <point x="277" y="115"/>
+      <point x="276.2776027815" y="115" type="qcurve"/>
+      <point x="343.2776027815" y="115"/>
+      <point x="434" y="201"/>
+      <point x="449" y="281" type="qcurve" smooth="yes"/>
+      <point x="529" y="736" type="line" smooth="yes"/>
+      <point x="543" y="818"/>
+      <point x="480.6942826376" y="900"/>
+      <point x="414.6942826376" y="900" type="qcurve"/>
+      <point x="346.6942826376" y="900"/>
+      <point x="254" y="819"/>
+      <point x="240" y="736" type="qcurve" smooth="yes"/>
+      <point x="160" y="281" type="line" smooth="yes"/>
+      <point x="145" y="200"/>
+      <point x="207.2776027815" y="115"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/fontinfo.plist
@@ -47,7 +47,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -55,7 +55,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1397"/>
   <unicode hex="004F"/>
-  <guideline x="699" y="1059" angle="90" identifier="dSSIUOYMRV"/>
-  <anchor x="728" y="0" name="bottom"/>
-  <anchor x="699" y="716" name="center"/>
-  <anchor x="892" y="0" name="ogonek"/>
-  <anchor x="728" y="1432" name="top"/>
-  <anchor x="892" y="1432" name="topright"/>
+  <guideline x="795.73" y="1059" angle="100" identifier="dSSIUOYMRV"/>
+  <anchor x="638" y="0" name="bottom"/>
+  <anchor x="735.25012" y="716" name="center"/>
+  <anchor x="802" y="0" name="ogonek"/>
+  <anchor x="890.50024" y="1432" name="top"/>
+  <anchor x="1054.50024" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="698" y="-26" type="qcurve" smooth="yes"/>
-      <point x="426" y="-26" name="inserted"/>
-      <point x="110" y="320"/>
-      <point x="110" y="612" type="qcurve"/>
-      <point x="110" y="819" type="line"/>
-      <point x="110" y="1112" name="inserted"/>
-      <point x="426" y="1458"/>
-      <point x="698" y="1458" type="qcurve" smooth="yes"/>
-      <point x="971" y="1458" name="inserted"/>
-      <point x="1287" y="1112"/>
-      <point x="1287" y="819" type="qcurve"/>
-      <point x="1287" y="612" type="line"/>
-      <point x="1287" y="320" name="inserted"/>
-      <point x="971" y="-26"/>
+      <point x="603.4155" y="-26" type="qcurve" smooth="yes"/>
+      <point x="331.4155" y="-26" name="inserted"/>
+      <point x="76.42463" y="320"/>
+      <point x="127.91211" y="612" type="qcurve"/>
+      <point x="164.4118" y="819" type="line"/>
+      <point x="216.0756" y="1112" name="inserted"/>
+      <point x="593.08474" y="1458"/>
+      <point x="865.08474" y="1458" type="qcurve" smooth="yes"/>
+      <point x="1138.08474" y="1458" name="inserted"/>
+      <point x="1393.0756" y="1112"/>
+      <point x="1341.4118" y="819" type="qcurve"/>
+      <point x="1304.91211" y="612" type="line"/>
+      <point x="1253.42463" y="320" name="inserted"/>
+      <point x="876.4155" y="-26"/>
     </contour>
     <contour>
-      <point x="698" y="-22" type="qcurve" smooth="yes"/>
-      <point x="969" y="-22" name="inserted"/>
-      <point x="1283" y="321"/>
-      <point x="1283" y="612" type="qcurve"/>
-      <point x="1283" y="819" type="line"/>
-      <point x="1283" y="1110" name="inserted"/>
-      <point x="969" y="1454"/>
-      <point x="698" y="1454" type="qcurve" smooth="yes"/>
-      <point x="428" y="1454" name="inserted"/>
-      <point x="114" y="1110"/>
-      <point x="114" y="819" type="qcurve"/>
-      <point x="114" y="612" type="line"/>
-      <point x="114" y="321" name="inserted"/>
-      <point x="428" y="-22"/>
+      <point x="604.12081" y="-22" type="qcurve" smooth="yes"/>
+      <point x="875.12081" y="-22" name="inserted"/>
+      <point x="1249.60096" y="321"/>
+      <point x="1300.91211" y="612" type="qcurve"/>
+      <point x="1337.4118" y="819" type="line"/>
+      <point x="1388.72295" y="1110" name="inserted"/>
+      <point x="1135.37943" y="1454"/>
+      <point x="864.37943" y="1454" type="qcurve" smooth="yes"/>
+      <point x="594.37943" y="1454" name="inserted"/>
+      <point x="219.72295" y="1110"/>
+      <point x="168.4118" y="819" type="qcurve"/>
+      <point x="131.91211" y="612" type="line"/>
+      <point x="80.60096" y="321" name="inserted"/>
+      <point x="334.12081" y="-22"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="1397"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="36" yOffset="-35"/>
+    <component base="O" identifier="98854993"/>
+    <component base="Oslash-bar" xOffset="36" yOffset="-35" identifier="51ECA5F0"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>51ECA5F0</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>98854993</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1085"/>
   <outline>
-    <component base="nine" xOffset="105"/>
+    <component base="nine" xOffset="105" identifier="BAEE26C0"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>BAEE26C0</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1056"/>
   <unicode hex="006F"/>
-  <guideline x="528" y="665" angle="90" identifier="XPeaOfI5kn"/>
-  <anchor x="529" y="0" name="bottom"/>
-  <anchor x="527" y="510" name="center"/>
-  <anchor x="665" y="0" name="ogonek"/>
-  <anchor x="528" y="1020" name="top"/>
-  <anchor x="673" y="1020" name="topright"/>
+  <guideline x="555.26" y="665" angle="100" identifier="XPeaOfI5kn"/>
+  <anchor x="439" y="0" name="bottom"/>
+  <anchor x="526.92676" y="510" name="center"/>
+  <anchor x="575" y="0" name="ogonek"/>
+  <anchor x="617.85352" y="1020" name="top"/>
+  <anchor x="762.85352" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="527" y="-18" type="qcurve" smooth="yes"/>
-      <point x="335" y="-18" name="inserted"/>
-      <point x="93" y="224"/>
-      <point x="93" y="434" type="qcurve"/>
-      <point x="93" y="591" type="line"/>
-      <point x="93" y="801" name="inserted"/>
-      <point x="335" y="1043"/>
-      <point x="528" y="1043" type="qcurve" smooth="yes"/>
-      <point x="721" y="1043" name="inserted"/>
-      <point x="963" y="801"/>
-      <point x="963" y="591" type="qcurve"/>
-      <point x="963" y="434" type="line"/>
-      <point x="963" y="224" name="inserted"/>
-      <point x="720" y="-18"/>
+      <point x="433.82611" y="-18" type="qcurve" smooth="yes"/>
+      <point x="241.82611" y="-18" name="inserted"/>
+      <point x="42.49724" y="224"/>
+      <point x="79.52591" y="434" type="qcurve"/>
+      <point x="107.20925" y="591" type="line"/>
+      <point x="144.23791" y="801" name="inserted"/>
+      <point x="429" y="1043"/>
+      <point x="621.90904" y="1043" type="qcurve" smooth="yes"/>
+      <point x="814" y="1043" name="inserted"/>
+      <point x="1014.23791" y="801"/>
+      <point x="977.20925" y="591" type="qcurve"/>
+      <point x="949.52591" y="434" type="line"/>
+      <point x="912.49724" y="224" name="inserted"/>
+      <point x="626.82611" y="-18"/>
     </contour>
     <contour>
-      <point x="527" y="-14" type="qcurve" smooth="yes"/>
-      <point x="718" y="-14" name="inserted"/>
-      <point x="959" y="226"/>
-      <point x="959" y="434" type="qcurve"/>
-      <point x="959" y="591" type="line"/>
-      <point x="959" y="799" name="inserted"/>
-      <point x="719" y="1039"/>
-      <point x="528" y="1039" type="qcurve" smooth="yes"/>
-      <point x="337" y="1039" name="inserted"/>
-      <point x="97" y="799"/>
-      <point x="97" y="591" type="qcurve"/>
-      <point x="97" y="434" type="line"/>
-      <point x="97" y="226" name="inserted"/>
-      <point x="337" y="-14"/>
+      <point x="434.53142" y="-14" type="qcurve" smooth="yes"/>
+      <point x="625.53142" y="-14" name="inserted"/>
+      <point x="908.8499" y="226"/>
+      <point x="945.52591" y="434" type="qcurve"/>
+      <point x="973.20925" y="591" type="line"/>
+      <point x="1009.88526" y="799" name="inserted"/>
+      <point x="812.20373" y="1039"/>
+      <point x="621.20373" y="1039" type="qcurve" smooth="yes"/>
+      <point x="430.20373" y="1039" name="inserted"/>
+      <point x="147.88526" y="799"/>
+      <point x="111.20925" y="591" type="qcurve"/>
+      <point x="83.52591" y="434" type="line"/>
+      <point x="46.8499" y="226" name="inserted"/>
+      <point x="244.53142" y="-14"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1056"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="31" yOffset="2"/>
+    <component base="o" identifier="FDEE5313"/>
+    <component base="oslash-bar" xOffset="31" yOffset="2" identifier="E12CB250"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>E12CB250</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>FDEE5313</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1085"/>
   <outline>
-    <component base="six" xOffset="94"/>
+    <component base="six" xOffset="94" identifier="DF16A5E4"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>DF16A5E4</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND0.ufo/fontinfo.plist
@@ -47,7 +47,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -55,7 +55,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -1,45 +1,46 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="O" format="2">
-  <advance width="1540"/>
+  <advance width="1539"/>
   <unicode hex="004F"/>
-  <guideline x="770" y="814" angle="90" identifier="KpA493V8oE"/>
-  <anchor x="766" y="0" name="bottom"/>
-  <anchor x="770" y="716" name="center"/>
-  <anchor x="1000" y="0" name="ogonek"/>
-  <anchor x="766" y="1432" name="top"/>
-  <anchor x="975" y="1432" name="topright"/>
+  <guideline x="820" y="826" angle="80" identifier="KpA493V8oE"/>
+  <guideline x="1463" y="284" angle="80" identifier="J1tQAd7kEP"/>
+  <anchor x="677.0040322581" y="0" name="bottom"/>
+  <anchor x="807.0040322581" y="716" name="center"/>
+  <anchor x="911.0040322581" y="0" name="ogonek"/>
+  <anchor x="929.0040322581" y="1432" name="top"/>
+  <anchor x="1138.0040322581" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="770" y="-32" type="qcurve" smooth="yes"/>
-      <point x="460" y="-32" name="inserted"/>
-      <point x="37" y="363"/>
-      <point x="37" y="705" type="qcurve"/>
-      <point x="37" y="731" type="line"/>
-      <point x="37" y="1071" name="inserted"/>
-      <point x="452" y="1463"/>
-      <point x="770" y="1463" type="qcurve" smooth="yes"/>
-      <point x="1088" y="1463" name="inserted"/>
-      <point x="1503" y="1059"/>
-      <point x="1503" y="731" type="qcurve"/>
-      <point x="1503" y="705" type="line"/>
-      <point x="1503" y="375" name="inserted"/>
-      <point x="1080" y="-32"/>
+      <point x="723.0040322581" y="-32" type="qcurve" smooth="yes"/>
+      <point x="381.0040322581" y="-32" name="inserted"/>
+      <point x="20" y="396"/>
+      <point x="70" y="694" type="qcurve" smooth="yes"/>
+      <point x="83" y="772" type="line" smooth="yes"/>
+      <point x="137" y="1097" name="inserted"/>
+      <point x="561" y="1463"/>
+      <point x="897" y="1463" type="qcurve" smooth="yes"/>
+      <point x="1239" y="1463" name="inserted"/>
+      <point x="1595" y="1023"/>
+      <point x="1537" y="711" type="qcurve" smooth="yes"/>
+      <point x="1523" y="635" type="line" smooth="yes"/>
+      <point x="1466" y="327" name="inserted"/>
+      <point x="1033.0040322581" y="-32"/>
     </contour>
     <contour>
-      <point x="770" y="508" type="qcurve" smooth="yes"/>
-      <point x="852" y="508" name="inserted"/>
-      <point x="948" y="611"/>
-      <point x="948" y="694" type="qcurve"/>
-      <point x="948" y="728" type="line"/>
-      <point x="948" y="814" name="inserted"/>
-      <point x="852" y="915"/>
-      <point x="770" y="915" type="qcurve" smooth="yes"/>
-      <point x="688" y="915" name="inserted"/>
-      <point x="592" y="814"/>
-      <point x="592" y="728" type="qcurve"/>
-      <point x="592" y="694" type="line"/>
-      <point x="592" y="609" name="inserted"/>
-      <point x="688" y="508"/>
+      <point x="774.0040322581" y="508" type="qcurve" smooth="yes"/>
+      <point x="867" y="508" name="inserted"/>
+      <point x="964" y="609"/>
+      <point x="979" y="687" type="qcurve" smooth="yes"/>
+      <point x="986" y="723" type="line" smooth="yes"/>
+      <point x="1003" y="809" name="inserted"/>
+      <point x="916" y="915"/>
+      <point x="835" y="915" type="qcurve" smooth="yes"/>
+      <point x="738" y="915" name="inserted"/>
+      <point x="644" y="817"/>
+      <point x="630" y="731" type="qcurve" smooth="yes"/>
+      <point x="624" y="697" type="line" smooth="yes"/>
+      <point x="610" y="615" name="inserted"/>
+      <point x="695" y="508"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND0.ufo/glyphs/o.glif
@@ -3,43 +3,43 @@
   <advance width="1177"/>
   <unicode hex="006F"/>
   <guideline x="589" y="562" angle="90" identifier="ZDdOC7Qw5a"/>
-  <anchor x="584" y="0" name="bottom"/>
-  <anchor x="589" y="510" name="center"/>
-  <anchor x="811" y="0" name="ogonek"/>
-  <anchor x="585" y="1020" name="top"/>
-  <anchor x="814" y="1020" name="topright"/>
+  <anchor x="493.726443769" y="0" name="bottom"/>
+  <anchor x="588.726443769" y="510" name="center"/>
+  <anchor x="720.726443769" y="0" name="ogonek"/>
+  <anchor x="674.726443769" y="1020" name="top"/>
+  <anchor x="903.726443769" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="584" y="-35" type="qcurve" smooth="yes"/>
-      <point x="321" y="-35" name="inserted"/>
-      <point x="19" y="267"/>
-      <point x="19" y="492" type="qcurve"/>
-      <point x="19" y="533" type="line"/>
-      <point x="19" y="763" name="inserted"/>
-      <point x="321" y="1066"/>
-      <point x="584" y="1066" type="qcurve" smooth="yes"/>
-      <point x="847" y="1066" name="inserted"/>
-      <point x="1158" y="761"/>
-      <point x="1158" y="533" type="qcurve"/>
-      <point x="1158" y="492" type="line"/>
-      <point x="1158" y="270" name="inserted"/>
-      <point x="847" y="-35"/>
+      <point x="487.726443769" y="-35" type="qcurve" smooth="yes"/>
+      <point x="224.726443769" y="-35" name="inserted"/>
+      <point x="-24.273556231" y="267"/>
+      <point x="15.726443769" y="492" type="qcurve"/>
+      <point x="22.726443769" y="533" type="line"/>
+      <point x="63.726443769" y="763" name="inserted"/>
+      <point x="418.726443769" y="1066"/>
+      <point x="681.726443769" y="1066" type="qcurve" smooth="yes"/>
+      <point x="944.726443769" y="1066" name="inserted"/>
+      <point x="1201.726443769" y="761"/>
+      <point x="1161.726443769" y="533" type="qcurve"/>
+      <point x="1154.726443769" y="492" type="line"/>
+      <point x="1115.726443769" y="270" name="inserted"/>
+      <point x="750.726443769" y="-35"/>
     </contour>
     <contour>
-      <point x="589" y="390" type="qcurve" smooth="yes"/>
-      <point x="648" y="390" name="inserted"/>
-      <point x="704" y="454"/>
-      <point x="704" y="504" type="qcurve"/>
-      <point x="704" y="516" type="line"/>
-      <point x="704" y="567" name="inserted"/>
-      <point x="646" y="633"/>
-      <point x="589" y="633" type="qcurve" smooth="yes"/>
-      <point x="531" y="633" name="inserted"/>
-      <point x="472" y="569"/>
-      <point x="472" y="517" type="qcurve"/>
-      <point x="472" y="505" type="line"/>
-      <point x="472" y="453" name="inserted"/>
-      <point x="530" y="390"/>
+      <point x="567.726443769" y="390" type="qcurve" smooth="yes"/>
+      <point x="626.726443769" y="390" name="inserted"/>
+      <point x="693.726443769" y="454"/>
+      <point x="702.726443769" y="504" type="qcurve"/>
+      <point x="704.726443769" y="516" type="line"/>
+      <point x="713.726443769" y="567" name="inserted"/>
+      <point x="667.726443769" y="633"/>
+      <point x="610.726443769" y="633" type="qcurve" smooth="yes"/>
+      <point x="552.726443769" y="633" name="inserted"/>
+      <point x="481.726443769" y="569"/>
+      <point x="472.726443769" y="517" type="qcurve"/>
+      <point x="470.726443769" y="505" type="line"/>
+      <point x="461.726443769" y="453" name="inserted"/>
+      <point x="508.726443769" y="390"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND0.ufo/fontinfo.plist
@@ -47,7 +47,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -55,7 +55,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND0.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="1522"/>
   <unicode hex="004F"/>
   <guideline x="760" y="1068" angle="90" identifier="PlasAoLz9u"/>
-  <anchor x="761" y="0" name="bottom"/>
-  <anchor x="760" y="716" name="center"/>
-  <anchor x="964" y="0" name="ogonek"/>
-  <anchor x="761" y="1432" name="top"/>
-  <anchor x="963" y="1432" name="topright"/>
+  <anchor x="671.1359223301" y="0" name="bottom"/>
+  <anchor x="796.1359223301" y="716" name="center"/>
+  <anchor x="874.1359223301" y="0" name="ogonek"/>
+  <anchor x="923.1359223301" y="1432" name="top"/>
+  <anchor x="1125.1359223301" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="760" y="-28" type="qcurve"/>
-      <point x="456" y="-28"/>
-      <point x="104" y="337"/>
-      <point x="104" y="617" type="qcurve"/>
-      <point x="104" y="815" type="line"/>
-      <point x="104" y="1094"/>
-      <point x="455" y="1461"/>
-      <point x="760" y="1461" type="qcurve"/>
-      <point x="1064" y="1461"/>
-      <point x="1418" y="1093"/>
-      <point x="1418" y="815" type="qcurve"/>
-      <point x="1418" y="617" type="line"/>
-      <point x="1418" y="342"/>
-      <point x="1062" y="-28"/>
+      <point x="696.1359223301" y="-28" type="qcurve"/>
+      <point x="385.1359223301" y="-28"/>
+      <point x="73.1359223301" y="337"/>
+      <point x="123.1359223301" y="617" type="qcurve"/>
+      <point x="159.1359223301" y="823" type="line" smooth="yes"/>
+      <point x="206.1359223301" y="1094"/>
+      <point x="596.1359223301" y="1461"/>
+      <point x="918.1359223301" y="1461" type="qcurve"/>
+      <point x="1222.1359223301" y="1461"/>
+      <point x="1520.1359223301" y="1093"/>
+      <point x="1471.1359223301" y="815" type="qcurve"/>
+      <point x="1434.1359223301" y="601" type="line" smooth="yes"/>
+      <point x="1390.1359223301" y="342"/>
+      <point x="998.1359223301" y="-28"/>
     </contour>
     <contour>
-      <point x="760" y="112" type="qcurve"/>
-      <point x="1002" y="112"/>
-      <point x="1271" y="399"/>
-      <point x="1271" y="618" type="qcurve"/>
-      <point x="1271" y="812" type="line"/>
-      <point x="1271" y="1032"/>
-      <point x="1002" y="1316"/>
-      <point x="760" y="1316" type="qcurve"/>
-      <point x="518" y="1316"/>
-      <point x="251" y="1032"/>
-      <point x="251" y="812" type="qcurve"/>
-      <point x="251" y="618" type="line"/>
-      <point x="251" y="398"/>
-      <point x="518" y="112"/>
+      <point x="689.1359223301" y="112" type="qcurve"/>
+      <point x="931.1359223301" y="112"/>
+      <point x="1251.1359223301" y="399"/>
+      <point x="1290.1359223301" y="618" type="qcurve"/>
+      <point x="1324.1359223301" y="812" type="line"/>
+      <point x="1363.1359223301" y="1032"/>
+      <point x="1146.1359223301" y="1316"/>
+      <point x="899.1359223301" y="1316" type="qcurve"/>
+      <point x="657.1359223301" y="1316"/>
+      <point x="344.1359223301" y="1049"/>
+      <point x="304.1359223301" y="812" type="qcurve"/>
+      <point x="266.1359223301" y="598" type="line" smooth="yes"/>
+      <point x="231.1359223301" y="398"/>
+      <point x="447.1359223301" y="112"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND0.ufo/glyphs/o.glif
@@ -1,45 +1,45 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o" format="2">
-  <advance width="1062"/>
+  <advance width="1063"/>
   <unicode hex="006F"/>
   <guideline x="532" y="634" angle="90" identifier="3Ztd5Sklc8"/>
-  <anchor x="531" y="0" name="bottom"/>
-  <anchor x="532" y="510" name="center"/>
-  <anchor x="707" y="0" name="ogonek"/>
-  <anchor x="531" y="1020" name="top"/>
-  <anchor x="682" y="1020" name="topright"/>
+  <anchor x="441.3896103896" y="0" name="bottom"/>
+  <anchor x="532.3896103896" y="510" name="center"/>
+  <anchor x="617.3896103896" y="0" name="ogonek"/>
+  <anchor x="620.3896103896" y="1020" name="top"/>
+  <anchor x="771.3896103896" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="530" y="-28" type="qcurve"/>
-      <point x="319" y="-28"/>
-      <point x="60" y="225"/>
-      <point x="60" y="443" type="qcurve"/>
-      <point x="60" y="567" type="line"/>
-      <point x="60" y="784"/>
-      <point x="323" y="1042"/>
-      <point x="530" y="1042" type="qcurve"/>
-      <point x="735" y="1042"/>
-      <point x="1002" y="780"/>
-      <point x="1001" y="567" type="qcurve"/>
-      <point x="1001" y="443" type="line"/>
-      <point x="1002" y="228"/>
-      <point x="738" y="-28"/>
+      <point x="460.3896103896" y="-28" type="qcurve"/>
+      <point x="236.3896103896" y="-28"/>
+      <point x="8.3896103896" y="217"/>
+      <point x="48.3896103896" y="443" type="qcurve" smooth="yes"/>
+      <point x="74.3896103896" y="592" type="line" smooth="yes"/>
+      <point x="111.3896103896" y="800"/>
+      <point x="387.3896103896" y="1042"/>
+      <point x="613.3896103896" y="1042" type="qcurve"/>
+      <point x="818.3896103896" y="1042"/>
+      <point x="1052.3896103896" y="798"/>
+      <point x="1014.3896103896" y="583" type="qcurve" smooth="yes"/>
+      <point x="983.3896103896" y="406" type="line" smooth="yes"/>
+      <point x="950.3896103896" y="221"/>
+      <point x="681.3896103896" y="-28"/>
     </contour>
     <contour>
-      <point x="532" y="106" type="qcurve"/>
-      <point x="680" y="106"/>
-      <point x="859" y="282"/>
-      <point x="859" y="443" type="qcurve"/>
-      <point x="859" y="568" type="line"/>
-      <point x="859" y="728"/>
-      <point x="677" y="906"/>
-      <point x="532" y="906" type="qcurve"/>
-      <point x="383" y="906"/>
-      <point x="202" y="731"/>
-      <point x="202" y="568" type="qcurve"/>
-      <point x="202" y="443" type="line"/>
-      <point x="202" y="280"/>
-      <point x="379" y="106"/>
+      <point x="465.3896103896" y="106" type="qcurve"/>
+      <point x="623.3896103896" y="106"/>
+      <point x="818.3896103896" y="276"/>
+      <point x="844.3896103896" y="424" type="qcurve" smooth="yes"/>
+      <point x="874.3896103896" y="595" type="line" smooth="yes"/>
+      <point x="899.3896103896" y="736"/>
+      <point x="752.3896103896" y="907"/>
+      <point x="594.3896103896" y="907" type="qcurve"/>
+      <point x="434.3896103896" y="907"/>
+      <point x="241.3896103896" y="734"/>
+      <point x="215.3896103896" y="583" type="qcurve" smooth="yes"/>
+      <point x="190.3896103896" y="443" type="line" smooth="yes"/>
+      <point x="160.3896103896" y="273"/>
+      <point x="310.3896103896" y="106"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1-ROND0.ufo/fontinfo.plist
@@ -39,7 +39,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -47,7 +47,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="776"/>
   <unicode hex="004F"/>
-  <anchor x="387" y="0" name="bottom"/>
-  <anchor x="387" y="717" name="center"/>
-  <anchor x="478" y="0" name="ogonek"/>
-  <anchor x="388" y="1432" name="top"/>
-  <anchor x="607" y="1432" name="topright"/>
+  <anchor x="297" y="0" name="bottom"/>
+  <anchor x="423.4264451679694" y="717" name="center"/>
+  <anchor x="388" y="0" name="ogonek"/>
+  <anchor x="550.5002363745218" y="1432" name="top"/>
+  <anchor x="769.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="386" y="-19" type="qcurve" smooth="yes"/>
-      <point x="255" y="-19"/>
-      <point x="105" y="255"/>
-      <point x="105" y="653" type="qcurve" smooth="yes"/>
-      <point x="105" y="786" type="line" smooth="yes"/>
-      <point x="105" y="1176"/>
-      <point x="255" y="1442"/>
-      <point x="386" y="1442" type="qcurve" smooth="yes"/>
-      <point x="521" y="1442"/>
-      <point x="671" y="1175"/>
-      <point x="671" y="786" type="qcurve" smooth="yes"/>
-      <point x="671" y="653" type="line" smooth="yes"/>
-      <point x="671" y="259"/>
-      <point x="522" y="-19"/>
+      <point x="292.64978736653916" y="-19" type="qcurve" smooth="yes"/>
+      <point x="152" y="-19"/>
+      <point x="59.96338008065857" y="255"/>
+      <point x="130.14151840262764" y="653" type="qcurve" smooth="yes"/>
+      <point x="153.59300683685348" y="786" type="line" smooth="yes"/>
+      <point x="222.3605293131548" y="1176"/>
+      <point x="416" y="1442"/>
+      <point x="550.2635061816065" y="1442" type="qcurve" smooth="yes"/>
+      <point x="695" y="1442"/>
+      <point x="788.1842023324464" y="1175"/>
+      <point x="719.5930068368534" y="786" type="qcurve" smooth="yes"/>
+      <point x="696.1415184026276" y="653" type="line" smooth="yes"/>
+      <point x="626.6686880034924" y="259"/>
+      <point x="431" y="-19"/>
     </contour>
     <contour>
-      <point x="386" y="13" type="qcurve" smooth="yes"/>
-      <point x="503" y="13"/>
-      <point x="634" y="269"/>
-      <point x="634" y="674" type="qcurve" smooth="yes"/>
-      <point x="634" y="765" type="line" smooth="yes"/>
-      <point x="634" y="1160"/>
-      <point x="500" y="1408"/>
-      <point x="386" y="1408" type="qcurve" smooth="yes"/>
-      <point x="275" y="1408"/>
-      <point x="142" y="1162"/>
-      <point x="142" y="765" type="qcurve" smooth="yes"/>
-      <point x="142" y="674" type="line" smooth="yes"/>
-      <point x="142" y="268"/>
-      <point x="274" y="13"/>
+      <point x="298.29225074921004" y="13" type="qcurve" smooth="yes"/>
+      <point x="411" y="13"/>
+      <point x="591.431957810577" y="269"/>
+      <point x="662.8443849975054" y="674" type="qcurve" smooth="yes"/>
+      <point x="678.8901402419757" y="765" type="line" smooth="yes"/>
+      <point x="748.5392976218194" y="1160"/>
+      <point x="673" y="1408"/>
+      <point x="544.2683888375186" y="1408" type="qcurve" smooth="yes"/>
+      <point x="436" y="1408"/>
+      <point x="256.8919515832363" y="1162"/>
+      <point x="186.8901402419757" y="765" type="qcurve" smooth="yes"/>
+      <point x="170.84438499750536" y="674" type="line" smooth="yes"/>
+      <point x="99.25563082986861" y="268"/>
+      <point x="174" y="13"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="635"/>
   <unicode hex="006F"/>
-  <anchor x="318" y="0" name="bottom"/>
-  <anchor x="317" y="510" name="center"/>
-  <anchor x="394" y="0" name="ogonek"/>
-  <anchor x="320" y="1026" name="top"/>
-  <anchor x="400" y="1026" name="topright"/>
+  <anchor x="228" y="0" name="bottom"/>
+  <anchor x="316.92676016131713" y="510" name="center"/>
+  <anchor x="304" y="0" name="ogonek"/>
+  <anchor x="410.91148220688507" y="1026" name="top"/>
+  <anchor x="490.911482206885" y="1026" name="topright"/>
   <outline>
     <contour>
-      <point x="318" y="-16" type="qcurve" smooth="yes"/>
-      <point x="206" y="-16"/>
-      <point x="89" y="226"/>
-      <point x="89" y="485" type="qcurve"/>
-      <point x="89" y="531" type="line"/>
-      <point x="89" y="804"/>
-      <point x="205" y="1037"/>
-      <point x="320" y="1037" type="qcurve" smooth="yes"/>
-      <point x="432" y="1037"/>
-      <point x="546" y="796"/>
-      <point x="546" y="531" type="qcurve"/>
-      <point x="546" y="485" type="line"/>
-      <point x="546" y="228"/>
-      <point x="434" y="-16"/>
+      <point x="225.1787683086646" y="-16" type="qcurve"/>
+      <point x="112" y="-16"/>
+      <point x="38.849897640113085" y="226"/>
+      <point x="84.51858564360552" y="485" type="qcurve"/>
+      <point x="92.62962675619491" y="531" type="line"/>
+      <point x="140.76689248960585" y="804"/>
+      <point x="293" y="1036"/>
+      <point x="412.8510789946782" y="1037" type="qcurve"/>
+      <point x="524" y="1037"/>
+      <point x="596.3562766439381" y="796"/>
+      <point x="549.6296267561949" y="531" type="qcurve"/>
+      <point x="541.5185856436055" y="485" type="line"/>
+      <point x="496.20255160153" y="228"/>
+      <point x="345" y="-16"/>
     </contour>
     <contour>
-      <point x="318" y="16" type="qcurve" smooth="yes"/>
-      <point x="417" y="16"/>
-      <point x="513" y="246"/>
-      <point x="513" y="458" type="qcurve"/>
-      <point x="513" y="559" type="line"/>
-      <point x="513" y="775"/>
-      <point x="419" y="1005"/>
-      <point x="320" y="1005" type="qcurve" smooth="yes"/>
-      <point x="219" y="1005"/>
-      <point x="122" y="781"/>
-      <point x="122" y="559" type="qcurve"/>
-      <point x="122" y="458" type="line"/>
-      <point x="122" y="247"/>
-      <point x="217" y="16"/>
+      <point x="230.8212316913354" y="16" type="qcurve" smooth="yes"/>
+      <point x="329.8212316913354" y="16"/>
+      <point x="466.37643725428234" y="246"/>
+      <point x="503.75775716447697" y="458" type="qcurve"/>
+      <point x="521.5667822160319" y="559" type="line"/>
+      <point x="559.6534100490603" y="775"/>
+      <point x="506.2086156120073" y="1005"/>
+      <point x="407.2086156120073" y="1005" type="qcurve" smooth="yes"/>
+      <point x="306.2086156120073" y="1005"/>
+      <point x="169.71137193331117" y="781"/>
+      <point x="130.56678221603192" y="559" type="qcurve"/>
+      <point x="112.75775716447697" y="458" type="line"/>
+      <point x="75.55276423499083" y="247"/>
+      <point x="129.82123169133544" y="16"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1000-ROND0.ufo/fontinfo.plist
@@ -43,7 +43,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -51,7 +51,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1352"/>
   <unicode hex="004F"/>
-  <anchor x="687" y="0" name="bottom"/>
-  <anchor x="684" y="707" name="center"/>
-  <anchor x="867" y="0" name="ogonek"/>
-  <anchor x="687" y="1432" name="top"/>
-  <anchor x="923" y="1432" name="topright"/>
+  <anchor x="597" y="0" name="bottom"/>
+  <anchor x="718.6631753608847" y="707" name="center"/>
+  <anchor x="777" y="0" name="ogonek"/>
+  <anchor x="849.5002363745218" y="1432" name="top"/>
+  <anchor x="1085.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="676" y="-28" type="qcurve" smooth="yes"/>
-      <point x="415" y="-28"/>
-      <point x="61" y="322"/>
-      <point x="61" y="716" type="qcurve"/>
-      <point x="61" y="716" type="line"/>
-      <point x="61" y="1110"/>
-      <point x="419" y="1459"/>
-      <point x="676" y="1459" type="qcurve" smooth="yes"/>
-      <point x="933" y="1459"/>
-      <point x="1292" y="1097"/>
-      <point x="1292" y="716" type="qcurve"/>
-      <point x="1292" y="716" type="line"/>
-      <point x="1292" y="339"/>
-      <point x="937" y="-28"/>
+      <point x="581.0628445401629" y="-28" type="qcurve" smooth="yes"/>
+      <point x="316" y="-28"/>
+      <point x="27.77728778812572" y="322"/>
+      <point x="97.25011818726091" y="716" type="qcurve"/>
+      <point x="97.25011818726091" y="716" type="line"/>
+      <point x="166.72294858639611" y="1110"/>
+      <point x="556" y="1459"/>
+      <point x="843.2610648536504" y="1459" type="qcurve" smooth="yes"/>
+      <point x="1104" y="1459"/>
+      <point x="1395.430697837186" y="1097"/>
+      <point x="1328.250118187261" y="716" type="qcurve"/>
+      <point x="1328.250118187261" y="716" type="line"/>
+      <point x="1261.7748464601696" y="339"/>
+      <point x="872" y="-28"/>
     </contour>
     <contour>
-      <point x="674" y="416" type="qcurve" smooth="yes"/>
-      <point x="744" y="416"/>
-      <point x="802" y="539"/>
-      <point x="802" y="693" type="qcurve"/>
-      <point x="802" y="731" type="line"/>
-      <point x="802" y="893"/>
-      <point x="744" y="1014"/>
-      <point x="674" y="1014" type="qcurve" smooth="yes"/>
-      <point x="604" y="1014"/>
-      <point x="551" y="894"/>
-      <point x="551" y="731" type="qcurve"/>
-      <point x="551" y="693" type="line"/>
-      <point x="551" y="539"/>
-      <point x="605" y="416"/>
+      <point x="657.3520239747214" y="416" type="qcurve" smooth="yes"/>
+      <point x="727.3520239747214" y="416"/>
+      <point x="807.0402426018626" y="539"/>
+      <point x="834.1945976309662" y="693" type="qcurve"/>
+      <point x="840.8950228978879" y="731" type="line"/>
+      <point x="869.4599937726592" y="893"/>
+      <point x="832.7955584383835" y="1014"/>
+      <point x="762.7955584383835" y="1014" type="qcurve" smooth="yes"/>
+      <point x="692.7955584383835" y="1014"/>
+      <point x="618.6363207533677" y="894"/>
+      <point x="589.8950228978879" y="731" type="qcurve"/>
+      <point x="583.1945976309662" y="693" type="line"/>
+      <point x="556.0402426018626" y="539"/>
+      <point x="588.3520239747214" y="416"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1000-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1180"/>
   <unicode hex="006F"/>
-  <anchor x="603" y="0" name="bottom"/>
-  <anchor x="593" y="514" name="center"/>
-  <anchor x="813" y="0" name="ogonek"/>
-  <anchor x="603" y="1026" name="top"/>
-  <anchor x="795" y="1026" name="topright"/>
+  <anchor x="513" y="0" name="bottom"/>
+  <anchor x="593.632068084151" y="514" name="center"/>
+  <anchor x="723" y="0" name="ogonek"/>
+  <anchor x="693.911482206885" y="1026" name="top"/>
+  <anchor x="885.911482206885" y="1026" name="topright"/>
   <outline>
     <contour>
-      <point x="590" y="-38" type="qcurve" smooth="yes"/>
-      <point x="349" y="-38"/>
-      <point x="39" y="258"/>
-      <point x="39" y="518" type="qcurve"/>
-      <point x="39" y="518" type="line"/>
-      <point x="39" y="782"/>
-      <point x="349" y="1079"/>
-      <point x="590" y="1079" type="qcurve" smooth="yes"/>
-      <point x="832" y="1079"/>
-      <point x="1142" y="779"/>
-      <point x="1142" y="518" type="qcurve"/>
-      <point x="1142" y="518" type="line"/>
-      <point x="1142" y="258"/>
-      <point x="832" y="-38"/>
+      <point x="493.2995747330783" y="-38" type="qcurve"/>
+      <point x="258" y="-38"/>
+      <point x="-5.507638977216033" y="258"/>
+      <point x="40.33737600698487" y="518" type="qcurve"/>
+      <point x="40.33737600698487" y="518" type="line"/>
+      <point x="86.88769891401961" y="782"/>
+      <point x="434" y="1079"/>
+      <point x="690.2568121844337" y="1079" type="qcurve"/>
+      <point x="925" y="1079"/>
+      <point x="1189.3587179718943" y="779"/>
+      <point x="1143.3373760069849" y="518" type="qcurve"/>
+      <point x="1143.3373760069849" y="518" type="line"/>
+      <point x="1097.492361022784" y="258"/>
+      <point x="751" y="-38"/>
     </contour>
     <contour>
-      <point x="590" y="338" type="qcurve" smooth="yes"/>
-      <point x="644" y="338"/>
-      <point x="687" y="422"/>
-      <point x="687" y="516" type="qcurve"/>
-      <point x="687" y="516" type="line"/>
-      <point x="687" y="609"/>
-      <point x="641" y="692"/>
-      <point x="590" y="692" type="qcurve" smooth="yes"/>
-      <point x="539" y="692"/>
-      <point x="493" y="609"/>
-      <point x="493" y="516" type="qcurve"/>
-      <point x="493" y="516" type="line"/>
-      <point x="493" y="424"/>
-      <point x="539" y="338"/>
+      <point x="559.5985194794612" y="338" type="qcurve" smooth="yes"/>
+      <point x="613.5985194794612" y="338"/>
+      <point x="671.4099858589723" y="422"/>
+      <point x="687.9847220455679" y="516" type="qcurve"/>
+      <point x="687.9847220455679" y="516" type="line"/>
+      <point x="704.3831312514552" y="609"/>
+      <point x="673.0182706502578" y="692"/>
+      <point x="622.0182706502578" y="692" type="qcurve" smooth="yes"/>
+      <point x="571.0182706502578" y="692"/>
+      <point x="510.3831312514552" y="609"/>
+      <point x="493.9847220455679" y="516" type="qcurve"/>
+      <point x="493.9847220455679" y="516" type="line"/>
+      <point x="477.76263982038915" y="424"/>
+      <point x="508.5985194794612" y="338"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght400-ROND0.ufo/fontinfo.plist
@@ -39,7 +39,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -47,7 +47,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght400-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="724"/>
   <unicode hex="004F"/>
-  <anchor x="361" y="0" name="bottom"/>
-  <anchor x="362" y="711" name="center"/>
-  <anchor x="470" y="0" name="ogonek"/>
-  <anchor x="363" y="1432" name="top"/>
-  <anchor x="581" y="1432" name="topright"/>
+  <anchor x="271" y="0" name="bottom"/>
+  <anchor x="397.3684832837186" y="711" name="center"/>
+  <anchor x="380" y="0" name="ogonek"/>
+  <anchor x="525.5002363745218" y="1432" name="top"/>
+  <anchor x="743.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="362" y="-22" type="qcurve" smooth="yes"/>
-      <point x="220" y="-22"/>
-      <point x="66" y="221"/>
-      <point x="66" y="681" type="qcurve"/>
-      <point x="66" y="727" type="line"/>
-      <point x="66" y="1200"/>
-      <point x="224" y="1445"/>
-      <point x="362" y="1445" type="qcurve" smooth="yes"/>
-      <point x="499" y="1445"/>
-      <point x="658" y="1200"/>
-      <point x="658" y="727" type="qcurve"/>
-      <point x="658" y="681" type="line"/>
-      <point x="658" y="222"/>
-      <point x="503" y="-22"/>
+      <point x="268.1208064244138" y="-22" type="qcurve"/>
+      <point x="127" y="-22"/>
+      <point x="14.96826273657075" y="221"/>
+      <point x="96.07867386246465" y="681" type="qcurve"/>
+      <point x="104.18971497505404" y="727" type="line"/>
+      <point x="187.59237685015796" y="1200"/>
+      <point x="376" y="1445"/>
+      <point x="526.7924871237319" y="1445" type="qcurve"/>
+      <point x="673" y="1445"/>
+      <point x="779.592376850158" y="1200"/>
+      <point x="696.189714975054" y="727" type="qcurve"/>
+      <point x="688.0786738624647" y="681" type="line"/>
+      <point x="607.1445897172792" y="222"/>
+      <point x="412" y="-22"/>
     </contour>
     <contour>
-      <point x="362" y="122" type="qcurve" smooth="yes"/>
-      <point x="424" y="122"/>
-      <point x="496" y="273"/>
-      <point x="496" y="631" type="qcurve"/>
-      <point x="496" y="769" type="line"/>
-      <point x="496" y="1144"/>
-      <point x="422" y="1295"/>
-      <point x="362" y="1295" type="qcurve" smooth="yes"/>
-      <point x="300" y="1295"/>
-      <point x="229" y="1145"/>
-      <point x="229" y="769" type="qcurve"/>
-      <point x="229" y="631" type="line"/>
-      <point x="229" y="273"/>
-      <point x="299" y="122"/>
+      <point x="293.51189164643273" y="122" type="qcurve" smooth="yes"/>
+      <point x="358" y="122"/>
+      <point x="454.1372657334109" y="273"/>
+      <point x="517.2623248270414" y="631" type="qcurve"/>
+      <point x="541.5954481648096" y="769" type="line"/>
+      <point x="607.7180659304839" y="1144"/>
+      <point x="563" y="1295"/>
+      <point x="500.34344001746217" y="1295" type="qcurve" smooth="yes"/>
+      <point x="436" y="1295"/>
+      <point x="340.8943929111924" y="1145"/>
+      <point x="274.59544816480957" y="769" type="qcurve"/>
+      <point x="250.26232482704143" y="631" type="line"/>
+      <point x="187.1372657334109" y="273"/>
+      <point x="229" y="122"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght400-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="629"/>
   <unicode hex="006F"/>
-  <anchor x="316" y="0" name="bottom"/>
-  <anchor x="314" y="512" name="center"/>
-  <anchor x="391" y="0" name="ogonek"/>
-  <anchor x="316" y="1026" name="top"/>
-  <anchor x="396" y="1026" name="topright"/>
+  <anchor x="226" y="0" name="bottom"/>
+  <anchor x="314.27941412273407" y="512" name="center"/>
+  <anchor x="301" y="0" name="ogonek"/>
+  <anchor x="406.91148220688507" y="1026" name="top"/>
+  <anchor x="486.911482206885" y="1026" name="topright"/>
   <outline>
     <contour>
-      <point x="315" y="-13" type="qcurve" smooth="yes"/>
-      <point x="195" y="-13"/>
-      <point x="58" y="206"/>
-      <point x="58" y="500" type="qcurve"/>
-      <point x="58" y="537" type="line"/>
-      <point x="58" y="833"/>
-      <point x="192" y="1038"/>
-      <point x="315" y="1038" type="qcurve" smooth="yes"/>
-      <point x="439" y="1038"/>
-      <point x="571" y="833"/>
-      <point x="571" y="537" type="qcurve"/>
-      <point x="571" y="500" type="line"/>
-      <point x="571" y="206"/>
-      <point x="435" y="-13"/>
+      <point x="222.70774925078996" y="-13" type="qcurve"/>
+      <point x="91" y="-13"/>
+      <point x="4.323358025943776" y="206"/>
+      <point x="56.16349035423249" y="500" type="qcurve"/>
+      <point x="62.68758864044571" y="537" type="line"/>
+      <point x="114.88037493015133" y="833"/>
+      <point x="276" y="1038"/>
+      <point x="408.0274059753866" y="1038" type="qcurve"/>
+      <point x="529" y="1038"/>
+      <point x="627.8803749301513" y="833"/>
+      <point x="575.6875886404457" y="537" type="qcurve"/>
+      <point x="569.1634903542325" y="500" type="line"/>
+      <point x="517.3233580259438" y="206"/>
+      <point x="364" y="-13"/>
     </contour>
     <contour>
-      <point x="315" y="119" type="qcurve" smooth="yes"/>
-      <point x="369" y="119"/>
-      <point x="417" y="236"/>
-      <point x="417" y="438" type="qcurve"/>
-      <point x="417" y="570" type="line"/>
-      <point x="417" y="779"/>
-      <point x="370" y="896"/>
-      <point x="315" y="896" type="qcurve" smooth="yes"/>
-      <point x="259" y="896"/>
-      <point x="211" y="778"/>
-      <point x="211" y="570" type="qcurve"/>
-      <point x="211" y="438" type="line"/>
-      <point x="211" y="236"/>
-      <point x="260" y="119"/>
+      <point x="245.98291070430736" y="119" type="qcurve" smooth="yes"/>
+      <point x="304" y="119"/>
+      <point x="368.6131674471977" y="236"/>
+      <point x="404.23121755030763" y="438" type="qcurve"/>
+      <point x="427.50637900382503" y="570" type="line"/>
+      <point x="464.3587179718942" y="779"/>
+      <point x="437.9889747147846" y="896"/>
+      <point x="382.9889747147846" y="896" type="qcurve" smooth="yes"/>
+      <point x="326.9889747147846" y="896"/>
+      <point x="258.18239099118574" y="778"/>
+      <point x="221.50637900382503" y="570" type="qcurve"/>
+      <point x="198.23121755030763" y="438" type="line"/>
+      <point x="162.61316744719772" y="236"/>
+      <point x="187" y="119"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND0.ufo/fontinfo.plist
@@ -88,7 +88,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -96,7 +96,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1644"/>
   <unicode hex="004F"/>
-  <anchor x="822" y="0" name="bottom"/>
-  <anchor x="821" y="716" name="center"/>
-  <anchor x="1044" y="0" name="ogonek"/>
-  <anchor x="822" y="1432" name="top"/>
-  <anchor x="1046" y="1432" name="topright"/>
+  <anchor x="732" y="0" name="bottom"/>
+  <anchor x="857.2501181872609" y="716" name="center"/>
+  <anchor x="954" y="0" name="ogonek"/>
+  <anchor x="984.5002363745218" y="1432" name="top"/>
+  <anchor x="1208.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="822" y="-32" type="qcurve" smooth="yes"/>
-      <point x="512" y="-32"/>
-      <point x="86" y="396"/>
-      <point x="86" y="716" type="qcurve"/>
-      <point x="86" y="716" type="line"/>
-      <point x="86" y="1030"/>
-      <point x="510" y="1464"/>
-      <point x="822" y="1464" type="qcurve" smooth="yes"/>
-      <point x="1134" y="1464"/>
-      <point x="1558" y="1030"/>
-      <point x="1558" y="716" type="qcurve"/>
-      <point x="1558" y="716" type="line"/>
-      <point x="1558" y="402"/>
-      <point x="1130" y="-32"/>
+      <point x="726" y="-32" type="qcurve" smooth="yes"/>
+      <point x="416" y="-32"/>
+      <point x="65.82548436055214" y="396"/>
+      <point x="122.25011818726091" y="716" type="qcurve"/>
+      <point x="122" y="716" type="line"/>
+      <point x="178" y="1033"/>
+      <point x="675" y="1464"/>
+      <point x="990" y="1464" type="qcurve" smooth="yes"/>
+      <point x="1302" y="1464"/>
+      <point x="1649.616790129719" y="1030"/>
+      <point x="1594.250118187261" y="716" type="qcurve"/>
+      <point x="1594" y="716" type="line"/>
+      <point x="1539" y="398"/>
+      <point x="1038" y="-32"/>
     </contour>
     <contour>
-      <point x="822" y="-2" type="qcurve" smooth="yes"/>
-      <point x="1114" y="-2"/>
-      <point x="1526" y="410"/>
-      <point x="1526" y="716" type="qcurve"/>
-      <point x="1526" y="716" type="line"/>
-      <point x="1526" y="1020"/>
-      <point x="1116" y="1434"/>
-      <point x="822" y="1434" type="qcurve" smooth="yes"/>
-      <point x="526" y="1434"/>
-      <point x="118" y="1022"/>
-      <point x="118" y="716" type="qcurve"/>
-      <point x="118" y="716" type="line"/>
-      <point x="118" y="408"/>
-      <point x="528" y="-2"/>
+      <point x="732" y="-2" type="qcurve" smooth="yes"/>
+      <point x="1024" y="-2"/>
+      <point x="1508.2940620904706" y="410"/>
+      <point x="1562.250118187261" y="716" type="qcurve"/>
+      <point x="1562" y="716" type="line"/>
+      <point x="1616" y="1023"/>
+      <point x="1285" y="1434"/>
+      <point x="985" y="1434" type="qcurve" smooth="yes"/>
+      <point x="689" y="1434"/>
+      <point x="208.2061742840512" y="1022"/>
+      <point x="154.2501181872609" y="716" type="qcurve"/>
+      <point x="154" y="716" type="line"/>
+      <point x="100" y="402"/>
+      <point x="437" y="-2"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND0.ufo/glyphs/o.glif
@@ -9,35 +9,35 @@
   <anchor x="835.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="508.3575366173292" y="-32" type="qcurve" smooth="yes"/>
-      <point x="278.3575366173291" y="-32"/>
-      <point x="54.31359271411941" y="274"/>
-      <point x="94.86879827706633" y="504" type="qcurve"/>
-      <point x="94.86879827706633" y="504" type="line"/>
-      <point x="135.07134987859635" y="732"/>
-      <point x="477.0274059753866" y="1038"/>
-      <point x="697.0274059753866" y="1038" type="qcurve" smooth="yes"/>
-      <point x="917.0274059753866" y="1038"/>
-      <point x="1148.0133879943455" y="726"/>
-      <point x="1108.8687982770664" y="504" type="qcurve"/>
-      <point x="1108.8687982770664" y="504" type="line"/>
-      <point x="1069.3715545983703" y="280"/>
-      <point x="738.3575366173292" y="-32"/>
+      <point x="508" y="-32" type="qcurve" smooth="yes"/>
+      <point x="278" y="-32"/>
+      <point x="54" y="274"/>
+      <point x="95" y="504" type="qcurve"/>
+      <point x="95" y="504" type="line"/>
+      <point x="135" y="732"/>
+      <point x="469" y="1038"/>
+      <point x="697" y="1038" type="qcurve" smooth="yes"/>
+      <point x="917" y="1038"/>
+      <point x="1148" y="726"/>
+      <point x="1109" y="504" type="qcurve"/>
+      <point x="1109" y="504" type="line"/>
+      <point x="1069" y="280"/>
+      <point x="746" y="-32"/>
     </contour>
     <contour>
-      <point x="513.6473460385831" y="-2" type="qcurve" smooth="yes"/>
-      <point x="722" y="-2"/>
-      <point x="1038.429516482621" y="286"/>
-      <point x="1076.8687982770664" y="504" type="qcurve"/>
+      <point x="514" y="-2" type="qcurve" smooth="yes"/>
+      <point x="724" y="-2"/>
+      <point x="1038" y="286"/>
+      <point x="1077" y="504" type="qcurve"/>
       <point x="1077" y="504" type="line"/>
       <point x="1115" y="717"/>
       <point x="905" y="1011"/>
       <point x="692" y="1010" type="qcurve"/>
       <point x="488" y="1010"/>
-      <point x="165.66073403292864" y="724"/>
-      <point x="126.86879827706633" y="504" type="qcurve"/>
-      <point x="126.86879827706633" y="504" type="line"/>
-      <point x="87.72420855978712" y="282"/>
+      <point x="166" y="724"/>
+      <point x="127" y="504" type="qcurve"/>
+      <point x="127" y="504" type="line"/>
+      <point x="88" y="282"/>
       <point x="294" y="-2"/>
     </contour>
   </outline>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1206"/>
   <unicode hex="006F"/>
-  <anchor x="604" y="0" name="bottom"/>
-  <anchor x="603" y="510" name="center"/>
-  <anchor x="793" y="0" name="ogonek"/>
-  <anchor x="604" y="1020" name="top"/>
-  <anchor x="746" y="1020" name="topright"/>
+  <anchor x="514" y="0" name="bottom"/>
+  <anchor x="602.9267601613171" y="510" name="center"/>
+  <anchor x="703" y="0" name="ogonek"/>
+  <anchor x="693.8535203226343" y="1020" name="top"/>
+  <anchor x="835.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="604" y="-32" type="qcurve" smooth="yes"/>
-      <point x="374" y="-32"/>
-      <point x="96" y="274"/>
-      <point x="96" y="504" type="qcurve"/>
-      <point x="96" y="504" type="line"/>
-      <point x="96" y="732"/>
-      <point x="384" y="1038"/>
-      <point x="604" y="1038" type="qcurve" smooth="yes"/>
-      <point x="824" y="1038"/>
-      <point x="1110" y="726"/>
-      <point x="1110" y="504" type="qcurve"/>
-      <point x="1110" y="504" type="line"/>
-      <point x="1110" y="280"/>
-      <point x="834" y="-32"/>
+      <point x="508.3575366173292" y="-32" type="qcurve" smooth="yes"/>
+      <point x="278.3575366173291" y="-32"/>
+      <point x="54.31359271411941" y="274"/>
+      <point x="94.86879827706633" y="504" type="qcurve"/>
+      <point x="94.86879827706633" y="504" type="line"/>
+      <point x="135.07134987859635" y="732"/>
+      <point x="477.0274059753866" y="1038"/>
+      <point x="697.0274059753866" y="1038" type="qcurve" smooth="yes"/>
+      <point x="917.0274059753866" y="1038"/>
+      <point x="1148.0133879943455" y="726"/>
+      <point x="1108.8687982770664" y="504" type="qcurve"/>
+      <point x="1108.8687982770664" y="504" type="line"/>
+      <point x="1069.3715545983703" y="280"/>
+      <point x="738.3575366173292" y="-32"/>
     </contour>
     <contour>
-      <point x="604" y="-2" type="qcurve" smooth="yes"/>
-      <point x="812" y="-2"/>
-      <point x="1078" y="286"/>
-      <point x="1078" y="504" type="qcurve"/>
-      <point x="1078" y="504" type="line"/>
-      <point x="1078" y="716"/>
-      <point x="808" y="1010"/>
-      <point x="604" y="1010" type="qcurve" smooth="yes"/>
-      <point x="400" y="1010"/>
-      <point x="128" y="724"/>
-      <point x="128" y="504" type="qcurve"/>
-      <point x="128" y="504" type="line"/>
-      <point x="128" y="282"/>
-      <point x="394" y="-2"/>
+      <point x="513.6473460385831" y="-2" type="qcurve" smooth="yes"/>
+      <point x="722" y="-2"/>
+      <point x="1038.429516482621" y="286"/>
+      <point x="1076.8687982770664" y="504" type="qcurve"/>
+      <point x="1077" y="504" type="line"/>
+      <point x="1115" y="717"/>
+      <point x="905" y="1011"/>
+      <point x="692" y="1010" type="qcurve"/>
+      <point x="488" y="1010"/>
+      <point x="165.66073403292864" y="724"/>
+      <point x="126.86879827706633" y="504" type="qcurve"/>
+      <point x="126.86879827706633" y="504" type="line"/>
+      <point x="87.72420855978712" y="282"/>
+      <point x="294" y="-2"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND0.ufo/fontinfo.plist
@@ -74,7 +74,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -82,7 +82,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -3,6 +3,11 @@
   <advance width="1640"/>
   <unicode hex="004F"/>
   <guideline x="820" y="0" angle="90" identifier="YxXI3YIqmn"/>
+  <guideline x="1701" y="1224" angle="80" identifier="r3g3VbK5O4"/>
+  <guideline x="1208" y="1143" angle="80" identifier="SqgxfoyIYO"/>
+  <guideline x="645" y="1086" angle="80" identifier="VaP2gRRUK2"/>
+  <guideline x="953.7313889724" y="1332.2770754636" angle="0" identifier="SBkiNjDdFN"/>
+  <guideline x="193" y="1238" angle="80" identifier="h4A95ikQTi"/>
   <anchor x="820" y="0" name="bottom"/>
   <anchor x="819" y="712" name="center"/>
   <anchor x="1048" y="0" name="ogonek"/>
@@ -10,36 +15,36 @@
   <anchor x="1042" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="820" y="-32" type="qcurve" smooth="yes"/>
-      <point x="518" y="-32" name="inserted"/>
-      <point x="64" y="360"/>
-      <point x="64" y="716" type="qcurve"/>
-      <point x="64" y="716" type="line"/>
-      <point x="64" y="1072" name="inserted"/>
-      <point x="522" y="1464"/>
-      <point x="820" y="1464" type="qcurve" smooth="yes"/>
-      <point x="1118" y="1464" name="inserted"/>
-      <point x="1576" y="1058"/>
-      <point x="1576" y="716" type="qcurve"/>
-      <point x="1576" y="716" type="line"/>
-      <point x="1576" y="374" name="inserted"/>
-      <point x="1122" y="-32"/>
+      <point x="757" y="-32" type="qcurve" smooth="yes"/>
+      <point x="436" y="-32" name="inserted"/>
+      <point x="41" y="379"/>
+      <point x="104" y="735" type="qcurve"/>
+      <point x="104" y="735" type="line"/>
+      <point x="165" y="1069" name="inserted"/>
+      <point x="645" y="1464"/>
+      <point x="962" y="1464" type="qcurve" smooth="yes"/>
+      <point x="1281" y="1464" name="inserted"/>
+      <point x="1671" y="1046"/>
+      <point x="1610" y="704" type="qcurve"/>
+      <point x="1610" y="704" type="line"/>
+      <point x="1550" y="367" name="inserted"/>
+      <point x="1069" y="-32"/>
     </contour>
     <contour>
-      <point x="820" y="436" type="qcurve" smooth="yes"/>
-      <point x="938" y="436" name="inserted"/>
-      <point x="1096" y="594"/>
-      <point x="1096" y="716" type="qcurve"/>
-      <point x="1096" y="716" type="line"/>
-      <point x="1096" y="840" name="inserted"/>
-      <point x="938" y="996"/>
-      <point x="820" y="996" type="qcurve" smooth="yes"/>
-      <point x="704" y="996" name="inserted"/>
-      <point x="544" y="840"/>
-      <point x="544" y="716" type="qcurve"/>
-      <point x="544" y="716" type="line"/>
-      <point x="544" y="592" name="inserted"/>
-      <point x="702" y="436"/>
+      <point x="815" y="436" type="qcurve" smooth="yes"/>
+      <point x="942" y="436" name="inserted"/>
+      <point x="1110" y="586"/>
+      <point x="1131" y="708" type="qcurve"/>
+      <point x="1131" y="708" type="line"/>
+      <point x="1153" y="832" name="inserted"/>
+      <point x="1029" y="996"/>
+      <point x="898" y="996" type="qcurve" smooth="yes"/>
+      <point x="768" y="996" name="inserted"/>
+      <point x="603" y="846"/>
+      <point x="581" y="722" type="qcurve"/>
+      <point x="581" y="722" type="line"/>
+      <point x="559" y="598" name="inserted"/>
+      <point x="689" y="436"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/O_slash-bar.glif
@@ -3,8 +3,8 @@
   <advance width="1352"/>
   <guideline x="1136" y="1556" angle="0" identifier="fvnbo6j53E"/>
   <guideline x="935" y="203" angle="0" identifier="d9WG2Xza9B"/>
-  <guideline x="1379" y="1430" angle="311.74588385830623" identifier="yp1HhutcJH"/>
-  <guideline x="82.25272750458731" y="264.7575895073989" angle="0" identifier="TIKSdIvz4t"/>
+  <guideline x="1379" y="1430" angle="311.7458838583" identifier="yp1HhutcJH"/>
+  <guideline x="82.2527275046" y="264.7575895074" angle="0" identifier="TIKSdIvz4t"/>
   <outline>
     <contour>
       <point x="594" y="871" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/o.glif
@@ -1,45 +1,49 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o" format="2">
-  <advance width="1352"/>
+  <advance width="1351"/>
   <unicode hex="006F"/>
   <guideline x="676" y="0" angle="90" identifier="oZaZpTlb3t"/>
-  <anchor x="674" y="0" name="bottom"/>
-  <anchor x="675" y="511" name="center"/>
-  <anchor x="950" y="0" name="ogonek"/>
-  <anchor x="676" y="1020" name="top"/>
-  <anchor x="964" y="1020" name="topright"/>
+  <guideline x="1367" y="883" angle="80" identifier="IzkxAHGxOH"/>
+  <guideline x="885" y="766" angle="80" identifier="Mzu3pdv5rF"/>
+  <guideline x="573" y="854" angle="80" identifier="FVXnqLor3K"/>
+  <guideline x="140" y="1016" angle="80" identifier="uZbFxmobNG"/>
+  <anchor x="583" y="0" name="bottom"/>
+  <anchor x="674" y="511" name="center"/>
+  <anchor x="859" y="0" name="ogonek"/>
+  <anchor x="765" y="1020" name="top"/>
+  <anchor x="1053" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="676" y="-44" type="qcurve"/>
-      <point x="378" y="-44" name="inserted"/>
-      <point x="50" y="274"/>
-      <point x="50" y="516" type="qcurve"/>
-      <point x="50" y="516" type="line"/>
-      <point x="50" y="758" name="inserted"/>
-      <point x="386" y="1080"/>
-      <point x="676" y="1080" type="qcurve"/>
-      <point x="966" y="1080" name="inserted"/>
-      <point x="1302" y="750"/>
-      <point x="1302" y="516" type="qcurve"/>
-      <point x="1302" y="516" type="line"/>
-      <point x="1302" y="281" name="inserted"/>
-      <point x="975" y="-44"/>
+      <point x="621" y="-44" type="qcurve"/>
+      <point x="325" y="-44" name="inserted"/>
+      <point x="12" y="298"/>
+      <point x="55" y="540" type="qcurve"/>
+      <point x="55" y="540" type="line"/>
+      <point x="98" y="776" name="inserted"/>
+      <point x="439" y="1080"/>
+      <point x="739" y="1080" type="qcurve"/>
+      <point x="1031" y="1080" name="inserted"/>
+      <point x="1340" y="736"/>
+      <point x="1299" y="498" type="qcurve"/>
+      <point x="1299" y="498" type="line"/>
+      <point x="1258" y="263" name="inserted"/>
+      <point x="909" y="-44"/>
     </contour>
     <contour>
-      <point x="676" y="342" type="qcurve" smooth="yes"/>
-      <point x="758" y="342" name="inserted"/>
-      <point x="840" y="440"/>
-      <point x="840" y="512" type="qcurve"/>
-      <point x="840" y="512" type="line"/>
-      <point x="840" y="584" name="inserted"/>
-      <point x="756" y="682"/>
-      <point x="676" y="682" type="qcurve" smooth="yes"/>
-      <point x="596" y="682" name="inserted"/>
-      <point x="512" y="584"/>
-      <point x="512" y="512" type="qcurve"/>
-      <point x="512" y="512" type="line"/>
-      <point x="512" y="440" name="inserted"/>
-      <point x="594" y="342"/>
+      <point x="655" y="342" type="qcurve" smooth="yes"/>
+      <point x="737" y="342" name="inserted"/>
+      <point x="827" y="436"/>
+      <point x="839" y="505" type="qcurve"/>
+      <point x="839" y="505" type="line"/>
+      <point x="852" y="585" name="inserted"/>
+      <point x="782" y="682"/>
+      <point x="698" y="682" type="qcurve" smooth="yes"/>
+      <point x="618" y="682" name="inserted"/>
+      <point x="527" y="587"/>
+      <point x="513" y="520" type="qcurve"/>
+      <point x="513" y="520" type="line"/>
+      <point x="501" y="440" name="inserted"/>
+      <point x="572" y="342"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND0.ufo/glyphs/oslash-bar.glif
@@ -3,7 +3,7 @@
   <advance width="1194"/>
   <guideline x="714" y="880" angle="0" identifier="Iwq6ljlUe2"/>
   <guideline x="793" y="147" angle="0" identifier="T8IdXXEZNg"/>
-  <guideline x="1033" y="967" angle="311.6580561427389" identifier="EQHxbY05Pq"/>
+  <guideline x="1033" y="967" angle="311.6580561427" identifier="EQHxbY05Pq"/>
   <outline>
     <contour>
       <point x="536" y="589" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND0.ufo/fontinfo.plist
@@ -60,7 +60,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -68,7 +68,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>
@@ -122,7 +122,7 @@
     <key>postscriptUnderlineThickness</key>
     <integer>168</integer>
     <key>styleName</key>
-    <string>Italic</string>
+    <string>Regular</string>
     <key>trademark</key>
     <string>Google Sans is a trademark of Google.</string>
     <key>unitsPerEm</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND0.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="1648"/>
   <unicode hex="004F"/>
   <guideline x="1717" y="1140" angle="90" identifier="zTMwEwyU8s"/>
-  <anchor x="824" y="2" name="bottom"/>
-  <anchor x="823" y="716" name="center"/>
-  <anchor x="1055" y="2" name="ogonek"/>
-  <anchor x="824" y="1432" name="top"/>
-  <anchor x="1078" y="1432" name="topright"/>
+  <anchor x="733.7242888403" y="2" name="bottom"/>
+  <anchor x="858.7242888403" y="716" name="center"/>
+  <anchor x="964.7242888403" y="2" name="ogonek"/>
+  <anchor x="985.7242888403" y="1432" name="top"/>
+  <anchor x="1239.7242888403" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="824" y="-32" type="qcurve"/>
-      <point x="512" y="-32"/>
-      <point x="90" y="402"/>
-      <point x="90" y="719" type="qcurve"/>
-      <point x="90" y="719" type="line"/>
-      <point x="90" y="1036"/>
-      <point x="514" y="1464"/>
-      <point x="824" y="1464" type="qcurve"/>
-      <point x="1133" y="1464"/>
-      <point x="1558" y="1039"/>
-      <point x="1558" y="719" type="qcurve"/>
-      <point x="1558" y="719" type="line"/>
-      <point x="1558" y="402"/>
-      <point x="1136" y="-32"/>
+      <point x="727.7242888403" y="-32" type="qcurve"/>
+      <point x="415.7242888403" y="-32"/>
+      <point x="70.7242888403" y="402"/>
+      <point x="126.7242888403" y="719" type="qcurve"/>
+      <point x="126.7242888403" y="719" type="line"/>
+      <point x="181.7242888403" y="1036"/>
+      <point x="681.7242888403" y="1464"/>
+      <point x="991.7242888403" y="1464" type="qcurve"/>
+      <point x="1300.7242888403" y="1464"/>
+      <point x="1650.7242888403" y="1039"/>
+      <point x="1594.7242888403" y="719" type="qcurve"/>
+      <point x="1594.7242888403" y="719" type="line"/>
+      <point x="1538.7242888403" y="402"/>
+      <point x="1039.7242888403" y="-32"/>
     </contour>
     <contour>
-      <point x="824" y="130" type="qcurve"/>
-      <point x="1064" y="130"/>
-      <point x="1386" y="464"/>
-      <point x="1386" y="719" type="qcurve"/>
-      <point x="1386" y="719" type="line"/>
-      <point x="1386" y="975"/>
-      <point x="1061" y="1302"/>
-      <point x="824" y="1302" type="qcurve"/>
-      <point x="586" y="1302"/>
-      <point x="262" y="973"/>
-      <point x="262" y="719" type="qcurve"/>
-      <point x="262" y="719" type="line"/>
-      <point x="262" y="464"/>
-      <point x="584" y="130"/>
+      <point x="756.7242888403" y="130" type="qcurve"/>
+      <point x="996.7242888403" y="130"/>
+      <point x="1377.7242888403" y="464"/>
+      <point x="1422.7242888403" y="719" type="qcurve"/>
+      <point x="1422.7242888403" y="719" type="line"/>
+      <point x="1467.7242888403" y="975"/>
+      <point x="1199.7242888403" y="1302"/>
+      <point x="962.7242888403" y="1302" type="qcurve"/>
+      <point x="724.7242888403" y="1302"/>
+      <point x="342.7242888403" y="973"/>
+      <point x="298.7242888403" y="719" type="qcurve"/>
+      <point x="298.7242888403" y="719" type="line"/>
+      <point x="253.7242888403" y="464"/>
+      <point x="516.7242888403" y="130"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1192"/>
   <unicode hex="006F"/>
-  <anchor x="596" y="0" name="bottom"/>
-  <anchor x="596" y="510" name="center"/>
-  <anchor x="785" y="0" name="ogonek"/>
-  <anchor x="596" y="1020" name="top"/>
-  <anchor x="780" y="1020" name="topright"/>
+  <anchor x="506.2678746755" y="0" name="bottom"/>
+  <anchor x="596.1946348368" y="510" name="center"/>
+  <anchor x="695.2678746755" y="0" name="ogonek"/>
+  <anchor x="686.1213949981" y="1020" name="top"/>
+  <anchor x="870.1213949981" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="596" y="-32" type="qcurve"/>
-      <point x="370" y="-32"/>
-      <point x="72" y="278"/>
-      <point x="72" y="511" type="qcurve"/>
-      <point x="72" y="511" type="line"/>
-      <point x="72" y="748"/>
-      <point x="371" y="1052"/>
-      <point x="596" y="1052" type="qcurve"/>
-      <point x="820" y="1052"/>
-      <point x="1120" y="745"/>
-      <point x="1120" y="511" type="qcurve"/>
-      <point x="1120" y="511" type="line"/>
-      <point x="1120" y="278"/>
-      <point x="823" y="-32"/>
+      <point x="500.6254112928" y="-32" type="qcurve"/>
+      <point x="272" y="-32"/>
+      <point x="31" y="268"/>
+      <point x="72.3709618175" y="511" type="qcurve"/>
+      <point x="72.3709618175" y="511" type="line"/>
+      <point x="114.1604562454" y="748"/>
+      <point x="457" y="1052"/>
+      <point x="691.7638583808" y="1052" type="qcurve"/>
+      <point x="919" y="1052"/>
+      <point x="1162" y="755"/>
+      <point x="1120.3709618175" y="511" type="qcurve"/>
+      <point x="1120.3709618175" y="511" type="line"/>
+      <point x="1079.2867753124" y="278"/>
+      <point x="738" y="-32"/>
     </contour>
     <contour>
-      <point x="596" y="122" type="qcurve"/>
-      <point x="746" y="122"/>
-      <point x="950" y="340"/>
-      <point x="950" y="511" type="qcurve"/>
-      <point x="950" y="511" type="line"/>
-      <point x="950" y="685"/>
-      <point x="744" y="898"/>
-      <point x="596" y="898" type="qcurve"/>
-      <point x="446" y="898"/>
-      <point x="240" y="684"/>
-      <point x="240" y="511" type="qcurve"/>
-      <point x="240" y="511" type="line"/>
-      <point x="240" y="340"/>
-      <point x="444" y="122"/>
+      <point x="527.7797663219" y="122" type="qcurve"/>
+      <point x="677.7797663219" y="122"/>
+      <point x="920.2190481163" y="340"/>
+      <point x="950.3709618175" y="511" type="qcurve"/>
+      <point x="950.3709618175" y="511" type="line"/>
+      <point x="981" y="699"/>
+      <point x="820" y="898"/>
+      <point x="664.6095033517" y="898" type="qcurve"/>
+      <point x="514.6095033517" y="898"/>
+      <point x="270.8755294801" y="684"/>
+      <point x="240.3709618175" y="511" type="qcurve"/>
+      <point x="240.3709618175" y="511" type="line"/>
+      <point x="210" y="325"/>
+      <point x="369" y="122"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND0.ufo/fontinfo.plist
@@ -78,7 +78,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -86,7 +86,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND0.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="2453"/>
   <unicode hex="004F"/>
   <guideline x="1227" y="1333" angle="90" identifier="NdNAS6hVej"/>
-  <anchor x="1226" y="1" name="bottom"/>
-  <anchor x="1227" y="722" name="center"/>
-  <anchor x="1591" y="0" name="ogonek"/>
-  <anchor x="1227" y="1438" name="top"/>
-  <anchor x="1417" y="1438" name="topright"/>
+  <anchor x="1136.0485468601519" y="1" name="bottom"/>
+  <anchor x="1264.0485468601519" y="722" name="center"/>
+  <anchor x="1501.0485468601519" y="0" name="ogonek"/>
+  <anchor x="1391.0485468601519" y="1438" name="top"/>
+  <anchor x="1580.8850432105169" y="1438" name="topright"/>
   <outline>
     <contour>
-      <point x="1226" y="-37" type="qcurve" smooth="yes"/>
-      <point x="757" y="-37"/>
-      <point x="116" y="382"/>
-      <point x="116" y="716" type="qcurve"/>
-      <point x="116" y="716" type="line"/>
-      <point x="116" y="1039"/>
-      <point x="756" y="1469"/>
-      <point x="1226" y="1469" type="qcurve" smooth="yes"/>
-      <point x="1696" y="1469"/>
-      <point x="2337" y="1039"/>
-      <point x="2337" y="715" type="qcurve"/>
-      <point x="2337" y="715" type="line"/>
-      <point x="2337" y="388"/>
-      <point x="1693" y="-37"/>
+      <point x="1129" y="-37" type="qcurve" smooth="yes"/>
+      <point x="670" y="-37"/>
+      <point x="93" y="386"/>
+      <point x="152" y="716" type="qcurve"/>
+      <point x="152" y="716" type="line"/>
+      <point x="209" y="1039"/>
+      <point x="915" y="1469"/>
+      <point x="1395" y="1469" type="qcurve" smooth="yes"/>
+      <point x="1855" y="1469"/>
+      <point x="2430" y="1039"/>
+      <point x="2373" y="715" type="qcurve"/>
+      <point x="2373" y="715" type="line"/>
+      <point x="2315" y="388"/>
+      <point x="1606" y="-37"/>
     </contour>
     <contour>
-      <point x="1227" y="-6" type="qcurve" smooth="yes"/>
-      <point x="1679" y="-6"/>
-      <point x="2302" y="404"/>
-      <point x="2302" y="715" type="qcurve"/>
-      <point x="2302" y="715" type="line"/>
-      <point x="2302" y="1025"/>
-      <point x="1679" y="1438"/>
-      <point x="1227" y="1438" type="qcurve" smooth="yes"/>
-      <point x="772" y="1438"/>
-      <point x="151" y="1027"/>
-      <point x="151" y="716" type="qcurve"/>
-      <point x="151" y="716" type="line"/>
-      <point x="151" y="402"/>
-      <point x="773" y="-6"/>
+      <point x="1136" y="-6" type="qcurve" smooth="yes"/>
+      <point x="1588" y="-6"/>
+      <point x="2283" y="404"/>
+      <point x="2338" y="715" type="qcurve"/>
+      <point x="2338" y="715" type="line"/>
+      <point x="2393" y="1025"/>
+      <point x="1846" y="1438"/>
+      <point x="1391" y="1438" type="qcurve" smooth="yes"/>
+      <point x="936" y="1438"/>
+      <point x="242" y="1027"/>
+      <point x="187" y="716" type="qcurve"/>
+      <point x="187" y="716" type="line"/>
+      <point x="132" y="402"/>
+      <point x="679" y="-6"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1768"/>
   <unicode hex="006F"/>
-  <anchor x="888" y="0" name="bottom"/>
-  <anchor x="884" y="505" name="center"/>
-  <anchor x="1196" y="0" name="ogonek"/>
-  <anchor x="889" y="1020" name="top"/>
-  <anchor x="1006" y="1020" name="topright"/>
+  <anchor x="797.6147107368065" y="0" name="bottom"/>
+  <anchor x="882.6147107368065" y="505" name="center"/>
+  <anchor x="1105.6147107368065" y="0" name="ogonek"/>
+  <anchor x="978.6147107368065" y="1020" name="top"/>
+  <anchor x="1095.6147107368065" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="885" y="-39" type="qcurve" smooth="yes"/>
-      <point x="540" y="-39"/>
-      <point x="110" y="274"/>
-      <point x="110" y="511" type="qcurve"/>
-      <point x="110" y="511" type="line"/>
-      <point x="110" y="742"/>
-      <point x="553" y="1049"/>
-      <point x="888" y="1049" type="qcurve" smooth="yes"/>
-      <point x="1222" y="1049"/>
-      <point x="1658" y="737"/>
-      <point x="1658" y="510" type="qcurve"/>
-      <point x="1658" y="510" type="line"/>
-      <point x="1658" y="276"/>
-      <point x="1231" y="-39"/>
+      <point x="788" y="-39" type="qcurve"/>
+      <point x="451" y="-39"/>
+      <point x="68" y="270"/>
+      <point x="111" y="515" type="qcurve"/>
+      <point x="111" y="515" type="line"/>
+      <point x="151" y="747"/>
+      <point x="637" y="1049"/>
+      <point x="983" y="1049" type="qcurve"/>
+      <point x="1306" y="1049"/>
+      <point x="1698" y="737"/>
+      <point x="1658" y="509" type="qcurve"/>
+      <point x="1658" y="509" type="line"/>
+      <point x="1617" y="268"/>
+      <point x="1143" y="-39"/>
     </contour>
     <contour>
-      <point x="887" y="-9" type="qcurve" smooth="yes"/>
-      <point x="1208" y="-9"/>
-      <point x="1628" y="282"/>
-      <point x="1628" y="510" type="qcurve"/>
-      <point x="1628" y="510" type="line"/>
-      <point x="1628" y="728"/>
-      <point x="1202" y="1019"/>
-      <point x="887" y="1019" type="qcurve" smooth="yes"/>
-      <point x="569" y="1019"/>
-      <point x="142" y="736"/>
-      <point x="142" y="511" type="qcurve"/>
-      <point x="142" y="511" type="line"/>
-      <point x="142" y="282"/>
-      <point x="562" y="-9"/>
+      <point x="795" y="-9" type="qcurve" smooth="yes"/>
+      <point x="1120" y="-9"/>
+      <point x="1588" y="282"/>
+      <point x="1628" y="511" type="qcurve"/>
+      <point x="1628" y="511" type="line"/>
+      <point x="1666" y="728"/>
+      <point x="1292" y="1019"/>
+      <point x="977" y="1019" type="qcurve" smooth="yes"/>
+      <point x="655" y="1019"/>
+      <point x="181" y="734"/>
+      <point x="142" y="515" type="qcurve"/>
+      <point x="142" y="515" type="line"/>
+      <point x="101" y="284"/>
+      <point x="470" y="-9"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/fontinfo.plist
@@ -82,7 +82,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -90,7 +90,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="2449"/>
   <unicode hex="004F"/>
-  <guideline x="1224.5" y="0" angle="90" identifier="gl5Dx0G3oJ"/>
-  <anchor x="1225" y="0" name="bottom"/>
-  <anchor x="1224" y="706" name="center"/>
-  <anchor x="1597" y="0" name="ogonek"/>
-  <anchor x="1225" y="1432" name="top"/>
-  <anchor x="1380" y="1432" name="topright"/>
+  <guideline x="1224.5" y="0" angle="90" identifier="Y0FDKGrUkD"/>
+  <anchor x="1135" y="0" name="bottom"/>
+  <anchor x="1259" y="706" name="center"/>
+  <anchor x="1507" y="0" name="ogonek"/>
+  <anchor x="1388" y="1432" name="top"/>
+  <anchor x="1543" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1224" y="-37" type="qcurve" smooth="yes"/>
-      <point x="763" y="-37"/>
-      <point x="94" y="349"/>
-      <point x="94" y="716" type="qcurve"/>
-      <point x="94" y="716" type="line"/>
-      <point x="94" y="1083"/>
-      <point x="768" y="1469"/>
-      <point x="1224" y="1469" type="qcurve" smooth="yes"/>
-      <point x="1680" y="1469"/>
-      <point x="2355" y="1069"/>
-      <point x="2355" y="714" type="qcurve"/>
-      <point x="2355" y="714" type="line"/>
-      <point x="2355" y="363"/>
-      <point x="1685" y="-37"/>
+      <point x="1128" y="-37" type="qcurve" smooth="yes"/>
+      <point x="637" y="-37"/>
+      <point x="68" y="359"/>
+      <point x="130" y="716" type="qcurve"/>
+      <point x="130" y="716" type="line"/>
+      <point x="198" y="1102"/>
+      <point x="897" y="1469"/>
+      <point x="1393" y="1469" type="qcurve" smooth="yes"/>
+      <point x="1879" y="1469"/>
+      <point x="2452" y="1059"/>
+      <point x="2391" y="714" type="qcurve"/>
+      <point x="2391" y="714" type="line"/>
+      <point x="2326" y="344"/>
+      <point x="1629" y="-37"/>
     </contour>
     <contour>
-      <point x="1225" y="411" type="qcurve" smooth="yes"/>
-      <point x="1503" y="411"/>
-      <point x="1872" y="572"/>
-      <point x="1872" y="717" type="qcurve"/>
-      <point x="1872" y="717" type="line"/>
-      <point x="1872" y="864"/>
-      <point x="1501" y="1018"/>
-      <point x="1225" y="1018" type="qcurve" smooth="yes"/>
-      <point x="950" y="1018"/>
-      <point x="577" y="864"/>
-      <point x="577" y="719" type="qcurve"/>
-      <point x="577" y="719" type="line"/>
-      <point x="577" y="570"/>
-      <point x="947" y="411"/>
+      <point x="1208" y="411" type="qcurve" smooth="yes"/>
+      <point x="1486" y="411"/>
+      <point x="1883" y="572"/>
+      <point x="1909" y="717" type="qcurve"/>
+      <point x="1909" y="717" type="line"/>
+      <point x="1934" y="864"/>
+      <point x="1601" y="1018"/>
+      <point x="1315" y="1018" type="qcurve" smooth="yes"/>
+      <point x="1040" y="1018"/>
+      <point x="639" y="864"/>
+      <point x="614" y="719" type="qcurve"/>
+      <point x="614" y="719" type="line"/>
+      <point x="588" y="570"/>
+      <point x="910" y="411"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/O_slash-bar.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Oslash-bar" format="2">
   <advance width="1847"/>
-  <guideline x="-36" y="263" angle="301.383191056359" identifier="nL77pjbs62"/>
+  <guideline x="-36" y="263" angle="301.3832" identifier="nL77pjbs62"/>
   <guideline x="1208" y="187" angle="0" identifier="XqjQwin5Fi"/>
-  <guideline x="1857.0960324030204" y="1375.1570145641917" angle="0" identifier="AvYK6rw8G1"/>
+  <guideline x="1857.1" y="1375.16" angle="0" identifier="AvYK6rw8G1"/>
   <outline>
     <contour>
       <point x="817" y="866" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="2449"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="315" yOffset="-11"/>
+    <component base="O" identifier="43C2B2D2"/>
+    <component base="Oslash-bar" xOffset="315" yOffset="-11" identifier="9B33C8A7"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>43C2B2D2</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>9B33C8A7</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="2191"/>
   <outline>
-    <component base="nine" xOffset="131" yOffset="-1"/>
+    <component base="nine" xOffset="131" yOffset="-1" identifier="030A531B"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>030A531B</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1962"/>
   <unicode hex="006F"/>
-  <anchor x="979" y="0" name="bottom"/>
-  <anchor x="980" y="516" name="center"/>
-  <anchor x="1393" y="0" name="ogonek"/>
-  <anchor x="981" y="1020" name="top"/>
-  <anchor x="1402" y="1020" name="topright"/>
+  <anchor x="889" y="0" name="bottom"/>
+  <anchor x="981" y="516" name="center"/>
+  <anchor x="1303" y="0" name="ogonek"/>
+  <anchor x="1071" y="1020" name="top"/>
+  <anchor x="1492" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="981" y="-52" type="qcurve" smooth="yes"/>
-      <point x="568" y="-52"/>
-      <point x="88" y="270"/>
-      <point x="88" y="514" type="qcurve"/>
-      <point x="88" y="514" type="line"/>
-      <point x="88" y="765"/>
-      <point x="576" y="1088"/>
-      <point x="981" y="1088" type="qcurve"/>
-      <point x="1385" y="1088"/>
-      <point x="1874" y="757"/>
-      <point x="1874" y="515" type="qcurve"/>
-      <point x="1874" y="515" type="line"/>
-      <point x="1874" y="273"/>
-      <point x="1395" y="-52"/>
+      <point x="882" y="-52" type="qcurve" smooth="yes"/>
+      <point x="459" y="-52"/>
+      <point x="46" y="270"/>
+      <point x="89" y="514" type="qcurve"/>
+      <point x="89" y="514" type="line"/>
+      <point x="135" y="775"/>
+      <point x="658" y="1088"/>
+      <point x="1083" y="1088" type="qcurve" smooth="yes"/>
+      <point x="1497" y="1088"/>
+      <point x="1918" y="757"/>
+      <point x="1875" y="515" type="qcurve"/>
+      <point x="1875" y="515" type="line"/>
+      <point x="1830" y="263"/>
+      <point x="1316" y="-52"/>
     </contour>
     <contour>
-      <point x="983" y="334" type="qcurve" smooth="yes"/>
-      <point x="1178" y="334"/>
-      <point x="1414" y="434"/>
-      <point x="1414" y="516" type="qcurve"/>
-      <point x="1414" y="516" type="line"/>
-      <point x="1414" y="593"/>
-      <point x="1174" y="690"/>
-      <point x="983" y="690" type="qcurve" smooth="yes"/>
-      <point x="789" y="690"/>
-      <point x="550" y="593"/>
-      <point x="550" y="515" type="qcurve"/>
-      <point x="550" y="515" type="line"/>
-      <point x="550" y="438"/>
-      <point x="786" y="334"/>
+      <point x="952" y="334" type="qcurve" smooth="yes"/>
+      <point x="1147" y="334"/>
+      <point x="1401" y="434"/>
+      <point x="1415" y="516" type="qcurve"/>
+      <point x="1415" y="516" type="line"/>
+      <point x="1429" y="593"/>
+      <point x="1226" y="690"/>
+      <point x="1015" y="690" type="qcurve" smooth="yes"/>
+      <point x="821" y="690"/>
+      <point x="565" y="593"/>
+      <point x="551" y="515" type="qcurve"/>
+      <point x="551" y="515" type="line"/>
+      <point x="537" y="438"/>
+      <point x="735" y="334"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1962"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="135" yOffset="2"/>
+    <component base="o" identifier="A7D374C3"/>
+    <component base="oslash-bar" xOffset="135" yOffset="2" identifier="E6AA0D13"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>A7D374C3</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>E6AA0D13</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="2191"/>
   <outline>
-    <component base="six" xOffset="177" yOffset="2"/>
+    <component base="six" xOffset="177" yOffset="2" identifier="00DCE653"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>00DCE653</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/fontinfo.plist
@@ -78,7 +78,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -86,7 +86,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="2457"/>
   <unicode hex="004F"/>
-  <anchor x="1228" y="0" name="bottom"/>
-  <anchor x="1229" y="716" name="center"/>
-  <anchor x="1591" y="0" name="ogonek"/>
-  <anchor x="1233" y="1432" name="top"/>
-  <anchor x="1453" y="1432" name="topright"/>
+  <anchor x="1138" y="0" name="bottom"/>
+  <anchor x="1266" y="716" name="center"/>
+  <anchor x="1501" y="0" name="ogonek"/>
+  <anchor x="1396" y="1432" name="top"/>
+  <anchor x="1616" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1228" y="-37" type="qcurve" smooth="yes"/>
-      <point x="757" y="-37"/>
-      <point x="120" y="396"/>
-      <point x="120" y="720" type="qcurve"/>
-      <point x="120" y="720" type="line"/>
-      <point x="120" y="1042"/>
-      <point x="760" y="1469"/>
-      <point x="1228" y="1469" type="qcurve" smooth="yes"/>
-      <point x="1695" y="1469"/>
-      <point x="2337" y="1045"/>
-      <point x="2337" y="720" type="qcurve"/>
-      <point x="2337" y="720" type="line"/>
-      <point x="2337" y="396"/>
-      <point x="1699" y="-37"/>
+      <point x="1131" y="-37" type="qcurve" smooth="yes"/>
+      <point x="659" y="-38"/>
+      <point x="100" y="391"/>
+      <point x="156" y="716" type="qcurve"/>
+      <point x="156" y="716" type="line"/>
+      <point x="214" y="1053"/>
+      <point x="884" y="1468"/>
+      <point x="1397" y="1469" type="qcurve" smooth="yes"/>
+      <point x="1855" y="1470"/>
+      <point x="2431" y="1051"/>
+      <point x="2373" y="716" type="qcurve"/>
+      <point x="2373" y="716" type="line"/>
+      <point x="2317" y="390"/>
+      <point x="1632" y="-36"/>
     </contour>
     <contour>
-      <point x="1229" y="135" type="qcurve" smooth="yes"/>
-      <point x="1629" y="135"/>
-      <point x="2162" y="464"/>
-      <point x="2162" y="720" type="qcurve"/>
-      <point x="2162" y="720" type="line"/>
-      <point x="2162" y="975"/>
-      <point x="1624" y="1294"/>
-      <point x="1229" y="1294" type="qcurve" smooth="yes"/>
-      <point x="832" y="1294"/>
-      <point x="295" y="973"/>
-      <point x="295" y="720" type="qcurve"/>
-      <point x="295" y="720" type="line"/>
-      <point x="295" y="464"/>
-      <point x="829" y="135"/>
+      <point x="1163" y="135" type="qcurve" smooth="yes"/>
+      <point x="1563" y="136"/>
+      <point x="2154" y="464"/>
+      <point x="2198" y="716" type="qcurve"/>
+      <point x="2198" y="716" type="line"/>
+      <point x="2244" y="976"/>
+      <point x="1766" y="1298"/>
+      <point x="1367" y="1297" type="qcurve" smooth="yes"/>
+      <point x="970" y="1296"/>
+      <point x="377" y="975"/>
+      <point x="331" y="716" type="qcurve"/>
+      <point x="331" y="716" type="line"/>
+      <point x="287" y="464"/>
+      <point x="753" y="134"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/O_slash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Oslash-bar" format="2">
   <advance width="2357"/>
-  <guideline x="439" y="-157" angle="301.8907918018457" identifier="vwuCpxsvTS"/>
+  <guideline x="439" y="-157" angle="301.8908" identifier="vwuCpxsvTS"/>
   <outline>
     <contour>
       <point x="1162" y="782" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="2457"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="25" yOffset="4"/>
+    <component base="O" identifier="7F003BDC"/>
+    <component base="Oslash-bar" xOffset="25" yOffset="4" identifier="AFCEE468"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>7F003BDC</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>AFCEE468</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="2072"/>
   <outline>
-    <component base="nine" xOffset="139" yOffset="-1"/>
+    <component base="nine" xOffset="139" yOffset="-1" identifier="2C1E0A28"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>2C1E0A28</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1802"/>
   <unicode hex="006F"/>
-  <anchor x="900" y="0" name="bottom"/>
+  <anchor x="810" y="0" name="bottom"/>
   <anchor x="900" y="510" name="center"/>
-  <anchor x="1216" y="0" name="ogonek"/>
-  <anchor x="900" y="1020" name="top"/>
-  <anchor x="1087" y="1020" name="topright"/>
+  <anchor x="1126" y="0" name="ogonek"/>
+  <anchor x="990" y="1020" name="top"/>
+  <anchor x="1177" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="901" y="-40" type="qcurve" smooth="yes"/>
-      <point x="560" y="-40"/>
-      <point x="110" y="278"/>
+      <point x="804" y="-40" type="qcurve" smooth="yes"/>
+      <point x="458" y="-40"/>
+      <point x="68" y="273"/>
       <point x="110" y="512" type="qcurve"/>
       <point x="110" y="512" type="line"/>
-      <point x="110" y="752"/>
-      <point x="561" y="1060"/>
-      <point x="901" y="1060" type="qcurve" smooth="yes"/>
-      <point x="1239" y="1060"/>
-      <point x="1692" y="749"/>
+      <point x="153" y="755"/>
+      <point x="646" y="1060"/>
+      <point x="998" y="1060" type="qcurve" smooth="yes"/>
+      <point x="1341" y="1060"/>
+      <point x="1734" y="754"/>
       <point x="1692" y="513" type="qcurve"/>
       <point x="1692" y="513" type="line"/>
-      <point x="1692" y="274"/>
-      <point x="1243" y="-40"/>
+      <point x="1649" y="271"/>
+      <point x="1158" y="-40"/>
     </contour>
     <contour>
-      <point x="903" y="111" type="qcurve" smooth="yes"/>
-      <point x="1166" y="111"/>
-      <point x="1524" y="336"/>
+      <point x="833" y="111" type="qcurve" smooth="yes"/>
+      <point x="1096" y="111"/>
+      <point x="1492" y="336"/>
       <point x="1524" y="513" type="qcurve"/>
       <point x="1524" y="513" type="line"/>
-      <point x="1524" y="689"/>
-      <point x="1162" y="908"/>
-      <point x="903" y="908" type="qcurve" smooth="yes"/>
-      <point x="639" y="908"/>
-      <point x="278" y="688"/>
+      <point x="1556" y="694"/>
+      <point x="1247" y="908"/>
+      <point x="973" y="908" type="qcurve" smooth="yes"/>
+      <point x="709" y="908"/>
+      <point x="309" y="688"/>
       <point x="278" y="512" type="qcurve"/>
       <point x="278" y="512" type="line"/>
-      <point x="278" y="340"/>
-      <point x="636" y="111"/>
+      <point x="247" y="335"/>
+      <point x="551" y="111"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/oslash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="1705"/>
-  <guideline x="1583" y="749" angle="302.0053832080835" identifier="IZ2gBd8vPo"/>
+  <guideline x="1583" y="749" angle="302.0054" identifier="IZ2gBd8vPo"/>
   <outline>
     <contour>
       <point x="815" y="565" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1802"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="50" yOffset="7"/>
+    <component base="o" identifier="29454E64"/>
+    <component base="oslash-bar" xOffset="50" yOffset="7" identifier="64C74DF0"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>29454E64</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>64C74DF0</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="2072"/>
   <outline>
-    <component base="six" xOffset="224"/>
+    <component base="six" xOffset="224" identifier="FFFB1966"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>FFFB1966</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/fontinfo.plist
@@ -78,7 +78,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -86,7 +86,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="750"/>
   <unicode hex="004F"/>
-  <anchor x="376" y="0" name="bottom"/>
-  <anchor x="375" y="716" name="center"/>
-  <anchor x="479" y="0" name="ogonek"/>
-  <anchor x="376" y="1432" name="top"/>
-  <anchor x="596" y="1432" name="topright"/>
+  <anchor x="286" y="0" name="bottom"/>
+  <anchor x="411" y="716" name="center"/>
+  <anchor x="389" y="0" name="ogonek"/>
+  <anchor x="538" y="1432" name="top"/>
+  <anchor x="758" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="375" y="-18" type="qcurve" smooth="yes"/>
-      <point x="249" y="-18"/>
-      <point x="110" y="163"/>
-      <point x="110" y="416" type="qcurve"/>
-      <point x="110" y="1015" type="line"/>
-      <point x="110" y="1257"/>
-      <point x="247" y="1440"/>
-      <point x="373" y="1440" type="qcurve" smooth="yes"/>
-      <point x="503" y="1440"/>
-      <point x="640" y="1256"/>
-      <point x="640" y="1015" type="qcurve"/>
-      <point x="640" y="416" type="line"/>
-      <point x="640" y="166"/>
-      <point x="507" y="-18"/>
+      <point x="282" y="-18" type="qcurve" smooth="yes"/>
+      <point x="156" y="-18"/>
+      <point x="48" y="163"/>
+      <point x="93" y="416" type="qcurve" smooth="yes"/>
+      <point x="199" y="1015" type="line" smooth="yes"/>
+      <point x="242" y="1257"/>
+      <point x="411" y="1440"/>
+      <point x="537" y="1440" type="qcurve" smooth="yes"/>
+      <point x="667" y="1440"/>
+      <point x="772" y="1256"/>
+      <point x="729" y="1015" type="qcurve" smooth="yes"/>
+      <point x="623" y="416" type="line" smooth="yes"/>
+      <point x="579" y="166"/>
+      <point x="414" y="-18"/>
     </contour>
     <contour>
-      <point x="375" y="10" type="qcurve" smooth="yes"/>
-      <point x="488" y="10"/>
-      <point x="608" y="173"/>
-      <point x="608" y="439" type="qcurve"/>
-      <point x="608" y="992" type="line"/>
-      <point x="608" y="1244"/>
-      <point x="483" y="1410"/>
-      <point x="373" y="1410" type="qcurve" smooth="yes"/>
-      <point x="267" y="1410"/>
-      <point x="142" y="1245"/>
-      <point x="142" y="992" type="qcurve"/>
-      <point x="142" y="439" type="line"/>
-      <point x="142" y="173"/>
-      <point x="267" y="10"/>
+      <point x="287" y="10" type="qcurve" smooth="yes"/>
+      <point x="400" y="10"/>
+      <point x="548" y="173"/>
+      <point x="595" y="439" type="qcurve" smooth="yes"/>
+      <point x="693" y="992" type="line" smooth="yes"/>
+      <point x="739" y="1249"/>
+      <point x="645" y="1410"/>
+      <point x="531" y="1410" type="qcurve" smooth="yes"/>
+      <point x="425" y="1410"/>
+      <point x="272" y="1245"/>
+      <point x="227" y="992" type="qcurve" smooth="yes"/>
+      <point x="129" y="439" type="line" smooth="yes"/>
+      <point x="81" y="169"/>
+      <point x="176" y="10"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="750"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="40" yOffset="13"/>
+    <component base="O" identifier="6DBEADE7"/>
+    <component base="Oslash-bar" xOffset="40" yOffset="13" identifier="0A50B35E"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>0A50B35E</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>6DBEADE7</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="648"/>
   <outline>
-    <component base="nine" xOffset="-11" yOffset="-1"/>
+    <component base="nine" xOffset="-11" yOffset="-1" identifier="1CE66B6E"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>1CE66B6E</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="606"/>
   <unicode hex="006F"/>
-  <anchor x="304" y="0" name="bottom"/>
+  <anchor x="215" y="0" name="bottom"/>
   <anchor x="303" y="507" name="center"/>
-  <anchor x="392" y="0" name="ogonek"/>
-  <anchor x="306" y="1020" name="top"/>
-  <anchor x="372" y="1020" name="topright"/>
+  <anchor x="303" y="0" name="ogonek"/>
+  <anchor x="396" y="1020" name="top"/>
+  <anchor x="462" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="304" y="-16" type="qcurve" smooth="yes"/>
-      <point x="198" y="-16"/>
-      <point x="90" y="133"/>
-      <point x="90" y="304" type="qcurve"/>
-      <point x="90" y="712" type="line"/>
-      <point x="90" y="890"/>
-      <point x="196" y="1030"/>
-      <point x="306" y="1030" type="qcurve" smooth="yes"/>
-      <point x="412" y="1030"/>
-      <point x="516" y="882"/>
-      <point x="516" y="712" type="qcurve"/>
-      <point x="516" y="304" type="line"/>
-      <point x="516" y="135"/>
-      <point x="414" y="-16"/>
+      <point x="211" y="-16" type="qcurve" smooth="yes"/>
+      <point x="109" y="-16"/>
+      <point x="23" y="133"/>
+      <point x="54" y="304" type="qcurve"/>
+      <point x="126" y="712" type="line"/>
+      <point x="157" y="890"/>
+      <point x="289" y="1030"/>
+      <point x="398" y="1030" type="qcurve" smooth="yes"/>
+      <point x="500" y="1030"/>
+      <point x="582" y="882"/>
+      <point x="552" y="712" type="qcurve"/>
+      <point x="480" y="304" type="line"/>
+      <point x="450" y="135"/>
+      <point x="320" y="-16"/>
     </contour>
     <contour>
-      <point x="304" y="12" type="qcurve" smooth="yes"/>
-      <point x="396" y="12"/>
-      <point x="488" y="151"/>
-      <point x="488" y="319" type="qcurve"/>
-      <point x="488" y="694" type="line"/>
-      <point x="488" y="863"/>
-      <point x="400" y="1002"/>
-      <point x="306" y="1002" type="qcurve" smooth="yes"/>
-      <point x="210" y="1002"/>
-      <point x="118" y="869"/>
-      <point x="118" y="694" type="qcurve"/>
-      <point x="118" y="319" type="line"/>
-      <point x="118" y="153"/>
-      <point x="208" y="12"/>
+      <point x="216" y="12" type="qcurve" smooth="yes"/>
+      <point x="308" y="12"/>
+      <point x="425" y="151"/>
+      <point x="454" y="319" type="qcurve"/>
+      <point x="520" y="694" type="line"/>
+      <point x="550" y="863"/>
+      <point x="489" y="1002"/>
+      <point x="393" y="1002" type="qcurve" smooth="yes"/>
+      <point x="297" y="1002"/>
+      <point x="181" y="869"/>
+      <point x="150" y="694" type="qcurve"/>
+      <point x="84" y="319" type="line"/>
+      <point x="55" y="153"/>
+      <point x="120" y="12"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="606"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-61" yOffset="-1"/>
+    <component base="o" identifier="902F4BB7"/>
+    <component base="oslash-bar" xOffset="-61" yOffset="-1" identifier="DE91FB1C"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>902F4BB7</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>DE91FB1C</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="648"/>
   <outline>
-    <component base="six" xOffset="-9"/>
+    <component base="six" xOffset="-9" identifier="91E3F1AA"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>91E3F1AA</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/fontinfo.plist
@@ -82,7 +82,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -90,7 +90,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1360"/>
   <unicode hex="004F"/>
-  <anchor x="692" y="0" name="bottom"/>
-  <anchor x="688" y="706" name="center"/>
-  <anchor x="873" y="0" name="ogonek"/>
-  <anchor x="692" y="1432" name="top"/>
-  <anchor x="932" y="1432" name="topright"/>
+  <anchor x="602" y="0" name="bottom"/>
+  <anchor x="722.4868483801763" y="706" name="center"/>
+  <anchor x="783" y="0" name="ogonek"/>
+  <anchor x="854.5002363745218" y="1432" name="top"/>
+  <anchor x="1094.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="680" y="-28" type="qcurve" smooth="yes"/>
-      <point x="416" y="-28"/>
-      <point x="60" y="324"/>
-      <point x="60" y="716" type="qcurve"/>
-      <point x="60" y="716" type="line"/>
-      <point x="60" y="1108"/>
-      <point x="420" y="1458"/>
-      <point x="680" y="1458" type="qcurve" smooth="yes"/>
-      <point x="940" y="1458"/>
-      <point x="1300" y="1094"/>
-      <point x="1300" y="716" type="qcurve"/>
-      <point x="1300" y="716" type="line"/>
-      <point x="1300" y="340"/>
-      <point x="944" y="-28"/>
+      <point x="621" y="-28" type="qcurve"/>
+      <point x="340" y="-26"/>
+      <point x="36" y="326"/>
+      <point x="96" y="716" type="qcurve"/>
+      <point x="96.25011818726091" y="716" type="line"/>
+      <point x="165.37029462497918" y="1108"/>
+      <point x="521" y="1458"/>
+      <point x="807" y="1458" type="qcurve" smooth="yes"/>
+      <point x="1093" y="1458"/>
+      <point x="1402.9017168950606" y="1094"/>
+      <point x="1336.250118187261" y="716" type="qcurve"/>
+      <point x="1336.250118187261" y="716" type="line"/>
+      <point x="1269.9511734408782" y="340"/>
+      <point x="911" y="-28"/>
     </contour>
     <contour>
-      <point x="678" y="420" type="qcurve" smooth="yes"/>
-      <point x="748" y="420"/>
-      <point x="804" y="509"/>
-      <point x="804" y="578" type="qcurve"/>
-      <point x="804" y="852" type="line"/>
-      <point x="804" y="923"/>
-      <point x="748" y="1010"/>
-      <point x="678" y="1010" type="qcurve" smooth="yes"/>
-      <point x="608" y="1010"/>
-      <point x="556" y="923"/>
-      <point x="556" y="852" type="qcurve"/>
-      <point x="556" y="578" type="line"/>
-      <point x="556" y="509"/>
-      <point x="608" y="420"/>
+      <point x="668" y="420" type="qcurve"/>
+      <point x="738" y="420"/>
+      <point x="803.7504331806086" y="509"/>
+      <point x="815.9169948494928" y="578" type="qcurve"/>
+      <point x="864" y="853" type="line"/>
+      <point x="877" y="923"/>
+      <point x="830" y="1010"/>
+      <point x="763" y="1010" type="qcurve" smooth="yes"/>
+      <point x="693" y="1010"/>
+      <point x="628.7498031939132" y="923"/>
+      <point x="616.2305875636122" y="852" type="qcurve"/>
+      <point x="567.9169948494928" y="578" type="line"/>
+      <point x="555.7504331806086" y="509"/>
+      <point x="600" y="420"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="1360"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="31"/>
+    <component base="O" identifier="7EC29FC0"/>
+    <component base="Oslash-bar" xOffset="31" identifier="7936C9C3"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>7936C9C3</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>7EC29FC0</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1180"/>
   <outline>
-    <component base="nine" xOffset="48" yOffset="-1"/>
+    <component base="nine" xOffset="48" yOffset="-1" identifier="59667CB7"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>59667CB7</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1180"/>
   <unicode hex="006F"/>
-  <anchor x="604" y="0" name="bottom"/>
-  <anchor x="604" y="510" name="center"/>
-  <anchor x="824" y="0" name="ogonek"/>
-  <anchor x="604" y="1020" name="top"/>
-  <anchor x="788" y="1020" name="topright"/>
+  <anchor x="514" y="0" name="bottom"/>
+  <anchor x="603.9267601613171" y="510" name="center"/>
+  <anchor x="734" y="0" name="ogonek"/>
+  <anchor x="693.8535203226343" y="1020" name="top"/>
+  <anchor x="877.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="590" y="-38" type="qcurve" smooth="yes"/>
-      <point x="338" y="-38"/>
-      <point x="36" y="235"/>
-      <point x="36" y="464" type="qcurve"/>
-      <point x="36" y="573" type="line"/>
-      <point x="36" y="797"/>
-      <point x="348" y="1066"/>
-      <point x="590" y="1066" type="qcurve" smooth="yes"/>
-      <point x="832" y="1066"/>
-      <point x="1144" y="789"/>
-      <point x="1144" y="573" type="qcurve"/>
-      <point x="1144" y="464" type="line"/>
-      <point x="1144" y="244"/>
-      <point x="842" y="-38"/>
+      <point x="525" y="-38" type="qcurve" smooth="yes"/>
+      <point x="273" y="-38"/>
+      <point x="-7" y="256"/>
+      <point x="32" y="483" type="qcurve"/>
+      <point x="47.03535994595043" y="573" type="line"/>
+      <point x="86.53260362464658" y="797"/>
+      <point x="395" y="1066"/>
+      <point x="647" y="1066" type="qcurve" smooth="yes"/>
+      <point x="889" y="1066"/>
+      <point x="1189" y="760"/>
+      <point x="1149" y="539" type="qcurve"/>
+      <point x="1134" y="451" type="line"/>
+      <point x="1097" y="245"/>
+      <point x="787" y="-38"/>
     </contour>
     <contour>
-      <point x="590" y="342" type="qcurve" smooth="yes"/>
-      <point x="645" y="342"/>
-      <point x="684" y="401"/>
-      <point x="684" y="455" type="qcurve"/>
-      <point x="684" y="564" type="line"/>
-      <point x="684" y="615"/>
-      <point x="643" y="674"/>
-      <point x="590" y="674" type="qcurve" smooth="yes"/>
-      <point x="537" y="674"/>
-      <point x="496" y="615"/>
-      <point x="496" y="564" type="qcurve"/>
-      <point x="496" y="455" type="line"/>
-      <point x="496" y="403"/>
-      <point x="537" y="342"/>
+      <point x="564" y="342" type="qcurve" smooth="yes"/>
+      <point x="619" y="342"/>
+      <point x="664.7071192640944" y="401"/>
+      <point x="674.2287762223516" y="455" type="qcurve"/>
+      <point x="693.4484171195743" y="564" type="line"/>
+      <point x="702.441093135706" y="615"/>
+      <point x="668" y="674"/>
+      <point x="615" y="674" type="qcurve" smooth="yes"/>
+      <point x="562" y="674"/>
+      <point x="514.441093135706" y="615"/>
+      <point x="505.4484171195743" y="564" type="qcurve"/>
+      <point x="486.2287762223516" y="455" type="line"/>
+      <point x="477.05977322551144" y="403"/>
+      <point x="511" y="342"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1180"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="11" yOffset="-5"/>
+    <component base="o" identifier="583DCDB3"/>
+    <component base="oslash-bar" xOffset="11" yOffset="-5" identifier="5A7CE420"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>583DCDB3</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>5A7CE420</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1180"/>
   <outline>
-    <component base="six" xOffset="40"/>
+    <component base="six" xOffset="40" identifier="AAD5362B"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>AAD5362B</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/fontinfo.plist
@@ -101,7 +101,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -109,7 +109,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="692"/>
   <unicode hex="004F"/>
-  <anchor x="347" y="0" name="bottom"/>
-  <anchor x="346" y="711" name="center"/>
-  <anchor x="467" y="0" name="ogonek"/>
-  <anchor x="347" y="1432" name="top"/>
-  <anchor x="567" y="1432" name="topright"/>
+  <anchor x="264" y="0" name="bottom"/>
+  <anchor x="364" y="711" name="center"/>
+  <anchor x="422" y="0" name="ogonek"/>
+  <anchor x="515" y="1432" name="top"/>
+  <anchor x="648" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="346" y="-22" type="qcurve" smooth="yes"/>
-      <point x="212" y="-22"/>
-      <point x="70" y="144"/>
-      <point x="70" y="316" type="qcurve" smooth="yes"/>
-      <point x="70" y="1112" type="line" smooth="yes"/>
-      <point x="70" y="1276"/>
-      <point x="216" y="1444"/>
-      <point x="346" y="1444" type="qcurve" smooth="yes"/>
-      <point x="476" y="1444"/>
-      <point x="622" y="1276"/>
-      <point x="622" y="1112" type="qcurve" smooth="yes"/>
-      <point x="622" y="316" type="line" smooth="yes"/>
-      <point x="622" y="144"/>
-      <point x="480" y="-22"/>
+      <point x="279" y="-22" type="qcurve" smooth="yes"/>
+      <point x="145" y="-22"/>
+      <point x="5" y="144"/>
+      <point x="35" y="316" type="qcurve" smooth="yes"/>
+      <point x="175" y="1112" type="line" smooth="yes"/>
+      <point x="204" y="1276"/>
+      <point x="351" y="1444"/>
+      <point x="481" y="1444" type="qcurve" smooth="yes"/>
+      <point x="611" y="1444"/>
+      <point x="756" y="1276"/>
+      <point x="727" y="1112" type="qcurve" smooth="yes"/>
+      <point x="587" y="316" type="line" smooth="yes"/>
+      <point x="557" y="144"/>
+      <point x="413" y="-22"/>
     </contour>
     <contour>
-      <point x="346" y="120" type="qcurve" smooth="yes"/>
-      <point x="402" y="120"/>
-      <point x="462" y="194"/>
-      <point x="462" y="262" type="qcurve" smooth="yes"/>
-      <point x="462" y="1158" type="line" smooth="yes"/>
-      <point x="462" y="1222"/>
-      <point x="400" y="1296"/>
-      <point x="346" y="1296" type="qcurve" smooth="yes"/>
-      <point x="290" y="1296"/>
-      <point x="230" y="1222"/>
-      <point x="230" y="1158" type="qcurve" smooth="yes"/>
-      <point x="230" y="262" type="line" smooth="yes"/>
-      <point x="230" y="194"/>
-      <point x="290" y="120"/>
+      <point x="291" y="120" type="qcurve" smooth="yes"/>
+      <point x="347" y="120"/>
+      <point x="407" y="194"/>
+      <point x="419" y="262" type="qcurve" smooth="yes"/>
+      <point x="575" y="1158" type="line" smooth="yes"/>
+      <point x="586" y="1222"/>
+      <point x="523" y="1296"/>
+      <point x="469" y="1296" type="qcurve" smooth="yes"/>
+      <point x="413" y="1296"/>
+      <point x="354" y="1222"/>
+      <point x="343" y="1158" type="qcurve" smooth="yes"/>
+      <point x="187" y="262" type="line" smooth="yes"/>
+      <point x="175" y="194"/>
+      <point x="235" y="120"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="692"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="-123"/>
+    <component base="O" identifier="D5BC282C"/>
+    <component base="Oslash-bar" xOffset="-123" identifier="55994544"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>55994544</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>D5BC282C</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="604"/>
   <outline>
-    <component base="nine" xOffset="-3"/>
+    <component base="nine" xOffset="-3" identifier="37E74F9E"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>37E74F9E</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="598"/>
   <unicode hex="006F"/>
-  <anchor x="301" y="0" name="bottom"/>
+  <anchor x="211" y="0" name="bottom"/>
+  <anchor x="287" y="0" name="ogonek"/>
+  <anchor x="391" y="1020" name="top"/>
+  <anchor x="471" y="1020" name="topright"/>
   <anchor x="299" y="510" name="center"/>
-  <anchor x="377" y="0" name="ogonek"/>
-  <anchor x="301" y="1020" name="top"/>
-  <anchor x="381" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="300" y="-12" type="qcurve" smooth="yes"/>
-      <point x="186" y="-12"/>
-      <point x="56" y="144"/>
-      <point x="56" y="284" type="qcurve" smooth="yes"/>
-      <point x="56" y="756" type="line" smooth="yes"/>
-      <point x="56" y="890"/>
-      <point x="182" y="1032"/>
-      <point x="300" y="1032" type="qcurve" smooth="yes"/>
-      <point x="418" y="1032"/>
-      <point x="542" y="890"/>
-      <point x="542" y="756" type="qcurve" smooth="yes"/>
-      <point x="542" y="284" type="line" smooth="yes"/>
-      <point x="542" y="144"/>
-      <point x="414" y="-12"/>
+      <point x="223" y="-12" type="qcurve" smooth="yes"/>
+      <point x="106" y="-12"/>
+      <point x="-8" y="145"/>
+      <point x="16" y="284" type="qcurve" smooth="yes"/>
+      <point x="99" y="756" type="line" smooth="yes"/>
+      <point x="122" y="889"/>
+      <point x="252" y="1032"/>
+      <point x="370" y="1032" type="qcurve" smooth="yes"/>
+      <point x="488" y="1032"/>
+      <point x="608" y="889"/>
+      <point x="585" y="756" type="qcurve" smooth="yes"/>
+      <point x="501" y="276" type="line" smooth="yes"/>
+      <point x="477" y="140"/>
+      <point x="346" y="-12"/>
     </contour>
     <contour>
-      <point x="300" y="116" type="qcurve" smooth="yes"/>
-      <point x="348" y="116"/>
-      <point x="392" y="172"/>
-      <point x="392" y="216" type="qcurve" smooth="yes"/>
-      <point x="392" y="792" type="line" smooth="yes"/>
-      <point x="392" y="836"/>
-      <point x="350" y="892"/>
-      <point x="300" y="892" type="qcurve" smooth="yes"/>
-      <point x="248" y="892"/>
-      <point x="206" y="836"/>
-      <point x="206" y="792" type="qcurve" smooth="yes"/>
-      <point x="206" y="216" type="line" smooth="yes"/>
-      <point x="206" y="172"/>
-      <point x="250" y="116"/>
+      <point x="238" y="116" type="qcurve" smooth="yes"/>
+      <point x="283" y="116"/>
+      <point x="333" y="172"/>
+      <point x="341" y="216" type="qcurve" smooth="yes"/>
+      <point x="443" y="792" type="line" smooth="yes"/>
+      <point x="451" y="836"/>
+      <point x="412" y="892"/>
+      <point x="362" y="892" type="qcurve" smooth="yes"/>
+      <point x="312" y="892"/>
+      <point x="265" y="836"/>
+      <point x="257" y="792" type="qcurve" smooth="yes"/>
+      <point x="155" y="216" type="line" smooth="yes"/>
+      <point x="147" y="172"/>
+      <point x="188" y="116"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="598"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-152" yOffset="4"/>
+    <component base="o" identifier="27CFFB4F"/>
+    <component base="oslash-bar" xOffset="-152" yOffset="4" identifier="8383F78B"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>27CFFB4F</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>8383F78B</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="604"/>
   <outline>
-    <component base="six" xOffset="1"/>
+    <component base="six" xOffset="1" identifier="6148BABF"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>6148BABF</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo/fontinfo.plist
@@ -39,7 +39,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -47,7 +47,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1048"/>
   <unicode hex="004F"/>
-  <anchor x="435.2779661016949" y="0" name="bottom"/>
-  <anchor x="560.2779661016949" y="716" name="center"/>
-  <anchor x="589.2779661016949" y="0" name="ogonek"/>
-  <anchor x="688.2779661016949" y="1432" name="top"/>
-  <anchor x="909.2779661016949" y="1432" name="topright"/>
+  <anchor x="435.2779661017" y="0" name="bottom"/>
+  <anchor x="560.2779661017" y="716" name="center"/>
+  <anchor x="589.2779661017" y="0" name="ogonek"/>
+  <anchor x="688.2779661017" y="1432" name="top"/>
+  <anchor x="909.2779661017" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="445.2779661016949" y="-23" type="qcurve" smooth="yes"/>
-      <point x="258.2779661016949" y="-23"/>
-      <point x="61.277966101694915" y="201"/>
-      <point x="110.27796610169491" y="476" type="qcurve"/>
-      <point x="194.27796610169491" y="955" type="line"/>
-      <point x="241.27796610169491" y="1221"/>
-      <point x="486.2779661016949" y="1448"/>
-      <point x="674.2779661016949" y="1448" type="qcurve" smooth="yes"/>
-      <point x="864.2779661016949" y="1448"/>
-      <point x="1057.2779661016948" y="1221"/>
-      <point x="1010.2779661016948" y="955" type="qcurve"/>
-      <point x="926.2779661016949" y="476" type="line"/>
-      <point x="878.2779661016949" y="205"/>
-      <point x="636.2779661016949" y="-23"/>
+      <point x="445.2779661017" y="-23" type="qcurve" smooth="yes"/>
+      <point x="258.2779661017" y="-23"/>
+      <point x="61.2779661017" y="201"/>
+      <point x="110.2779661017" y="476" type="qcurve"/>
+      <point x="194.2779661017" y="955" type="line"/>
+      <point x="241.2779661017" y="1221"/>
+      <point x="486.2779661017" y="1448"/>
+      <point x="674.2779661017" y="1448" type="qcurve" smooth="yes"/>
+      <point x="864.2779661017" y="1448"/>
+      <point x="1057.2779661017" y="1221"/>
+      <point x="1010.2779661017" y="955" type="qcurve"/>
+      <point x="926.2779661017" y="476" type="line"/>
+      <point x="878.2779661017" y="205"/>
+      <point x="636.2779661017" y="-23"/>
     </contour>
     <contour>
-      <point x="445.2779661016949" y="8" type="qcurve" smooth="yes"/>
-      <point x="618.2779661016949" y="8"/>
-      <point x="848.2779661016949" y="217"/>
-      <point x="897.2779661016949" y="492" type="qcurve"/>
-      <point x="976.2779661016948" y="940" type="line"/>
-      <point x="1023.2779661016948" y="1209"/>
-      <point x="844.2779661016949" y="1418"/>
-      <point x="673.2779661016949" y="1418" type="qcurve" smooth="yes"/>
-      <point x="503.2779661016949" y="1418"/>
-      <point x="270.2779661016949" y="1205"/>
-      <point x="224.27796610169491" y="940" type="qcurve"/>
-      <point x="145.27796610169491" y="492" type="line"/>
-      <point x="96.27796610169491" y="214"/>
-      <point x="275.2779661016949" y="8"/>
+      <point x="445.2779661017" y="8" type="qcurve" smooth="yes"/>
+      <point x="618.2779661017" y="8"/>
+      <point x="848.2779661017" y="217"/>
+      <point x="897.2779661017" y="492" type="qcurve"/>
+      <point x="976.2779661017" y="940" type="line"/>
+      <point x="1023.2779661017" y="1209"/>
+      <point x="844.2779661017" y="1418"/>
+      <point x="673.2779661017" y="1418" type="qcurve" smooth="yes"/>
+      <point x="503.2779661017" y="1418"/>
+      <point x="270.2779661017" y="1205"/>
+      <point x="224.2779661017" y="940" type="qcurve"/>
+      <point x="145.2779661017" y="492" type="line"/>
+      <point x="96.2779661017" y="214"/>
+      <point x="275.2779661017" y="8"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1048"/>
   <unicode hex="004F"/>
-  <anchor x="525" y="0" name="bottom"/>
-  <anchor x="524" y="716" name="center"/>
-  <anchor x="679" y="0" name="ogonek"/>
-  <anchor x="525" y="1432" name="top"/>
-  <anchor x="746" y="1432" name="topright"/>
+  <anchor x="435.2779661016949" y="0" name="bottom"/>
+  <anchor x="560.2779661016949" y="716" name="center"/>
+  <anchor x="589.2779661016949" y="0" name="ogonek"/>
+  <anchor x="688.2779661016949" y="1432" name="top"/>
+  <anchor x="909.2779661016949" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="524" y="-23" type="qcurve" smooth="yes"/>
-      <point x="337" y="-23"/>
-      <point x="116" y="201"/>
-      <point x="116" y="476" type="qcurve"/>
-      <point x="116" y="955" type="line"/>
-      <point x="116" y="1221"/>
-      <point x="335" y="1448"/>
-      <point x="523" y="1448" type="qcurve" smooth="yes"/>
-      <point x="713" y="1448"/>
-      <point x="932" y="1221"/>
-      <point x="932" y="955" type="qcurve"/>
-      <point x="932" y="476" type="line"/>
-      <point x="932" y="205"/>
-      <point x="715" y="-23"/>
+      <point x="445.2779661016949" y="-23" type="qcurve" smooth="yes"/>
+      <point x="258.2779661016949" y="-23"/>
+      <point x="61.277966101694915" y="201"/>
+      <point x="110.27796610169491" y="476" type="qcurve"/>
+      <point x="194.27796610169491" y="955" type="line"/>
+      <point x="241.27796610169491" y="1221"/>
+      <point x="486.2779661016949" y="1448"/>
+      <point x="674.2779661016949" y="1448" type="qcurve" smooth="yes"/>
+      <point x="864.2779661016949" y="1448"/>
+      <point x="1057.2779661016948" y="1221"/>
+      <point x="1010.2779661016948" y="955" type="qcurve"/>
+      <point x="926.2779661016949" y="476" type="line"/>
+      <point x="878.2779661016949" y="205"/>
+      <point x="636.2779661016949" y="-23"/>
     </contour>
     <contour>
-      <point x="524" y="8" type="qcurve" smooth="yes"/>
-      <point x="697" y="8"/>
-      <point x="900" y="217"/>
-      <point x="900" y="492" type="qcurve"/>
-      <point x="900" y="940" type="line"/>
-      <point x="900" y="1209"/>
-      <point x="694" y="1418"/>
-      <point x="523" y="1418" type="qcurve" smooth="yes"/>
-      <point x="353" y="1418"/>
-      <point x="148" y="1205"/>
-      <point x="148" y="940" type="qcurve"/>
-      <point x="148" y="492" type="line"/>
-      <point x="148" y="214"/>
-      <point x="354" y="8"/>
+      <point x="445.2779661016949" y="8" type="qcurve" smooth="yes"/>
+      <point x="618.2779661016949" y="8"/>
+      <point x="848.2779661016949" y="217"/>
+      <point x="897.2779661016949" y="492" type="qcurve"/>
+      <point x="976.2779661016948" y="940" type="line"/>
+      <point x="1023.2779661016948" y="1209"/>
+      <point x="844.2779661016949" y="1418"/>
+      <point x="673.2779661016949" y="1418" type="qcurve" smooth="yes"/>
+      <point x="503.2779661016949" y="1418"/>
+      <point x="270.2779661016949" y="1205"/>
+      <point x="224.27796610169491" y="940" type="qcurve"/>
+      <point x="145.27796610169491" y="492" type="line"/>
+      <point x="96.27796610169491" y="214"/>
+      <point x="275.2779661016949" y="8"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="806"/>
   <unicode hex="006F"/>
-  <anchor x="314.3425925925926" y="0" name="bottom"/>
-  <anchor x="403.3425925925926" y="508" name="center"/>
-  <anchor x="439.3425925925926" y="0" name="ogonek"/>
-  <anchor x="495.3425925925926" y="1020" name="top"/>
-  <anchor x="587.3425925925926" y="1020" name="topright"/>
+  <anchor x="314.3425925926" y="0" name="bottom"/>
+  <anchor x="403.3425925926" y="508" name="center"/>
+  <anchor x="439.3425925926" y="0" name="ogonek"/>
+  <anchor x="495.3425925926" y="1020" name="top"/>
+  <anchor x="587.3425925926" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="323.3425925925926" y="-21" type="qcurve" smooth="yes"/>
-      <point x="177.3425925925926" y="-21"/>
+      <point x="323.3425925926" y="-21" type="qcurve" smooth="yes"/>
+      <point x="177.3425925926" y="-21"/>
       <point x="31" y="168"/>
-      <point x="66.34259259259261" y="361" type="qcurve"/>
-      <point x="117.34259259259261" y="653" type="line"/>
-      <point x="152.3425925925926" y="852"/>
-      <point x="336.3425925925926" y="1033"/>
-      <point x="486.3425925925926" y="1033" type="qcurve" smooth="yes"/>
-      <point x="633.3425925925926" y="1033"/>
+      <point x="66.3425925926" y="361" type="qcurve"/>
+      <point x="117.3425925926" y="653" type="line"/>
+      <point x="152.3425925926" y="852"/>
+      <point x="336.3425925926" y="1033"/>
+      <point x="486.3425925926" y="1033" type="qcurve" smooth="yes"/>
+      <point x="633.3425925926" y="1033"/>
       <point x="772" y="840"/>
-      <point x="739.3425925925926" y="653" type="qcurve"/>
-      <point x="688.3425925925926" y="361" type="line"/>
-      <point x="654.3425925925926" y="169"/>
-      <point x="473.3425925925926" y="-21"/>
+      <point x="739.3425925926" y="653" type="qcurve"/>
+      <point x="688.3425925926" y="361" type="line"/>
+      <point x="654.3425925926" y="169"/>
+      <point x="473.3425925926" y="-21"/>
     </contour>
     <contour>
-      <point x="325.3425925925926" y="7" type="qcurve" smooth="yes"/>
-      <point x="456.3425925925926" y="7"/>
-      <point x="627.3425925925926" y="182"/>
-      <point x="660.3425925925926" y="371" type="qcurve"/>
-      <point x="708.3425925925926" y="641" type="line"/>
-      <point x="741.3425925925926" y="828"/>
-      <point x="617.3425925925926" y="1005"/>
-      <point x="483.3425925925926" y="1005" type="qcurve" smooth="yes"/>
-      <point x="348.3425925925926" y="1005"/>
-      <point x="178.3425925925926" y="835"/>
-      <point x="144.3425925925926" y="641" type="qcurve"/>
-      <point x="96.34259259259261" y="371" type="line"/>
-      <point x="63.34259259259261" y="182"/>
-      <point x="192.3425925925926" y="7"/>
+      <point x="325.3425925926" y="7" type="qcurve" smooth="yes"/>
+      <point x="456.3425925926" y="7"/>
+      <point x="627.3425925926" y="182"/>
+      <point x="660.3425925926" y="371" type="qcurve"/>
+      <point x="708.3425925926" y="641" type="line"/>
+      <point x="741.3425925926" y="828"/>
+      <point x="617.3425925926" y="1005"/>
+      <point x="483.3425925926" y="1005" type="qcurve" smooth="yes"/>
+      <point x="348.3425925926" y="1005"/>
+      <point x="178.3425925926" y="835"/>
+      <point x="144.3425925926" y="641" type="qcurve"/>
+      <point x="96.3425925926" y="371" type="line"/>
+      <point x="63.3425925926" y="182"/>
+      <point x="192.3425925926" y="7"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="806"/>
   <unicode hex="006F"/>
-  <anchor x="404" y="0" name="bottom"/>
-  <anchor x="403" y="508" name="center"/>
-  <anchor x="529" y="0" name="ogonek"/>
-  <anchor x="405" y="1020" name="top"/>
-  <anchor x="497" y="1020" name="topright"/>
+  <anchor x="314.3425925925926" y="0" name="bottom"/>
+  <anchor x="403.3425925925926" y="508" name="center"/>
+  <anchor x="439.3425925925926" y="0" name="ogonek"/>
+  <anchor x="495.3425925925926" y="1020" name="top"/>
+  <anchor x="587.3425925925926" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="404" y="-21" type="qcurve" smooth="yes"/>
-      <point x="258" y="-21"/>
-      <point x="92" y="166"/>
-      <point x="92" y="361" type="qcurve"/>
-      <point x="92" y="653" type="line"/>
-      <point x="92" y="852"/>
-      <point x="256" y="1033"/>
-      <point x="406" y="1033" type="qcurve" smooth="yes"/>
-      <point x="553" y="1033"/>
-      <point x="714" y="844"/>
-      <point x="714" y="653" type="qcurve"/>
-      <point x="714" y="361" type="line"/>
-      <point x="714" y="169"/>
-      <point x="554" y="-21"/>
+      <point x="323.3425925925926" y="-21" type="qcurve" smooth="yes"/>
+      <point x="177.3425925925926" y="-21"/>
+      <point x="31" y="168"/>
+      <point x="66.34259259259261" y="361" type="qcurve"/>
+      <point x="117.34259259259261" y="653" type="line"/>
+      <point x="152.3425925925926" y="852"/>
+      <point x="336.3425925925926" y="1033"/>
+      <point x="486.3425925925926" y="1033" type="qcurve" smooth="yes"/>
+      <point x="633.3425925925926" y="1033"/>
+      <point x="772" y="840"/>
+      <point x="739.3425925925926" y="653" type="qcurve"/>
+      <point x="688.3425925925926" y="361" type="line"/>
+      <point x="654.3425925925926" y="169"/>
+      <point x="473.3425925925926" y="-21"/>
     </contour>
     <contour>
-      <point x="404" y="7" type="qcurve" smooth="yes"/>
-      <point x="535" y="7"/>
-      <point x="685" y="182"/>
-      <point x="685" y="371" type="qcurve"/>
-      <point x="685" y="641" type="line"/>
-      <point x="685" y="828"/>
-      <point x="540" y="1005"/>
-      <point x="406" y="1005" type="qcurve" smooth="yes"/>
-      <point x="271" y="1005"/>
-      <point x="121" y="835"/>
-      <point x="121" y="641" type="qcurve"/>
-      <point x="121" y="371" type="line"/>
-      <point x="121" y="182"/>
-      <point x="271" y="7"/>
+      <point x="325.3425925925926" y="7" type="qcurve" smooth="yes"/>
+      <point x="456.3425925925926" y="7"/>
+      <point x="627.3425925925926" y="182"/>
+      <point x="660.3425925925926" y="371" type="qcurve"/>
+      <point x="708.3425925925926" y="641" type="line"/>
+      <point x="741.3425925925926" y="828"/>
+      <point x="617.3425925925926" y="1005"/>
+      <point x="483.3425925925926" y="1005" type="qcurve" smooth="yes"/>
+      <point x="348.3425925925926" y="1005"/>
+      <point x="178.3425925925926" y="835"/>
+      <point x="144.3425925925926" y="641" type="qcurve"/>
+      <point x="96.34259259259261" y="371" type="line"/>
+      <point x="63.34259259259261" y="182"/>
+      <point x="192.3425925925926" y="7"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo/glyphs/oslash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="834"/>
-  <guideline x="673" y="1045" angle="334.4400348281762" identifier="HpORYVLdin"/>
+  <guideline x="673" y="1045" angle="334.4400348282" identifier="HpORYVLdin"/>
   <outline>
     <contour>
       <point x="408" y="510" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND0.ufo/fontinfo.plist
@@ -47,7 +47,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -55,7 +55,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1422"/>
   <unicode hex="004F"/>
-  <guideline x="711" y="864" angle="90" identifier="hgfweufCu5"/>
-  <anchor x="735" y="0" name="bottom"/>
-  <anchor x="711" y="708" name="center"/>
-  <anchor x="921" y="0" name="ogonek"/>
-  <anchor x="735" y="1432" name="top"/>
-  <anchor x="969" y="1432" name="topright"/>
+  <guideline x="773.3465113321" y="864" angle="100" identifier="hgfweufCu5"/>
+  <anchor x="645" y="0" name="bottom"/>
+  <anchor x="745.8395023416" y="708" name="center"/>
+  <anchor x="831" y="0" name="ogonek"/>
+  <anchor x="897.5002363745" y="1432" name="top"/>
+  <anchor x="1131.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="712" y="-29" type="qcurve" smooth="yes"/>
-      <point x="429" y="-29" name="inserted"/>
-      <point x="61" y="321"/>
-      <point x="61" y="686" type="qcurve"/>
-      <point x="61" y="746" type="line"/>
-      <point x="61" y="1111" name="inserted"/>
-      <point x="433" y="1460"/>
-      <point x="712" y="1460" type="qcurve" smooth="yes"/>
-      <point x="990" y="1460" name="inserted"/>
-      <point x="1361" y="1097"/>
-      <point x="1361" y="746" type="qcurve"/>
-      <point x="1361" y="686" type="line"/>
-      <point x="1361" y="336" name="inserted"/>
-      <point x="994" y="-29"/>
+      <point x="667" y="-29" type="qcurve" smooth="yes"/>
+      <point x="355" y="-29" name="inserted"/>
+      <point x="19" y="323"/>
+      <point x="92" y="686" type="qcurve"/>
+      <point x="116" y="805" type="line"/>
+      <point x="183" y="1135" name="inserted"/>
+      <point x="515" y="1460"/>
+      <point x="827" y="1460" type="qcurve" smooth="yes"/>
+      <point x="1138" y="1460" name="inserted"/>
+      <point x="1473" y="1095"/>
+      <point x="1402" y="746" type="qcurve"/>
+      <point x="1373" y="604" type="line"/>
+      <point x="1310" y="296" name="inserted"/>
+      <point x="964" y="-29"/>
     </contour>
     <contour>
-      <point x="710" y="425" type="qcurve" smooth="yes"/>
-      <point x="788" y="425" name="inserted"/>
-      <point x="870" y="527"/>
-      <point x="870" y="614" type="qcurve"/>
-      <point x="870" y="817" type="line"/>
-      <point x="870" y="905" name="inserted"/>
-      <point x="788" y="1005"/>
-      <point x="710" y="1005" type="qcurve" smooth="yes"/>
-      <point x="632" y="1005" name="inserted"/>
-      <point x="552" y="905"/>
-      <point x="552" y="817" type="qcurve"/>
-      <point x="552" y="614" type="line"/>
-      <point x="552" y="527" name="inserted"/>
-      <point x="631" y="425"/>
+      <point x="700" y="425" type="qcurve" smooth="yes"/>
+      <point x="778" y="425" name="inserted"/>
+      <point x="872.9243188334" y="527"/>
+      <point x="888.264766155" y="614" type="qcurve"/>
+      <point x="924.0591432388" y="817" type="line"/>
+      <point x="939.5759175412" y="905" name="inserted"/>
+      <point x="870" y="1005"/>
+      <point x="792" y="1005" type="qcurve" smooth="yes"/>
+      <point x="714" y="1005" name="inserted"/>
+      <point x="621.5759175412" y="905"/>
+      <point x="606.0591432388" y="817" type="qcurve"/>
+      <point x="570.264766155" y="614" type="line"/>
+      <point x="554.9243188334" y="527" name="inserted"/>
+      <point x="621" y="425"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND0.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1238"/>
   <unicode hex="006F"/>
-  <guideline x="617" y="606" angle="90" identifier="eAPGUvlpdg"/>
-  <anchor x="628" y="0" name="bottom"/>
-  <anchor x="617" y="510" name="center"/>
-  <anchor x="868" y="0" name="ogonek"/>
-  <anchor x="628" y="1020" name="top"/>
-  <anchor x="847" y="1020" name="topright"/>
+  <guideline x="633.8541503093" y="606" angle="100" identifier="eAPGUvlpdg"/>
+  <anchor x="538" y="0" name="bottom"/>
+  <anchor x="616.9267601613" y="510" name="center"/>
+  <anchor x="778" y="0" name="ogonek"/>
+  <anchor x="717.8535203226" y="1020" name="top"/>
+  <anchor x="936.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="619" y="-40" type="qcurve"/>
-      <point x="352" y="-40" name="inserted"/>
-      <point x="41" y="244"/>
-      <point x="41" y="482" type="qcurve"/>
-      <point x="41" y="559" type="line"/>
-      <point x="41" y="793" name="inserted"/>
-      <point x="361" y="1076"/>
-      <point x="619" y="1076" type="qcurve"/>
-      <point x="877" y="1076" name="inserted"/>
-      <point x="1197" y="785"/>
-      <point x="1197" y="559" type="qcurve"/>
-      <point x="1197" y="482" type="line"/>
-      <point x="1197" y="252" name="inserted"/>
-      <point x="887" y="-40"/>
+      <point x="551" y="-40" type="qcurve"/>
+      <point x="295" y="-40" name="inserted"/>
+      <point x="-5" y="250"/>
+      <point x="40" y="504" type="qcurve" smooth="yes"/>
+      <point x="56" y="594" type="line"/>
+      <point x="92" y="795" name="inserted"/>
+      <point x="422" y="1076"/>
+      <point x="680" y="1076" type="qcurve"/>
+      <point x="938" y="1076" name="inserted"/>
+      <point x="1245" y="785"/>
+      <point x="1206" y="559" type="qcurve"/>
+      <point x="1192" y="482" type="line"/>
+      <point x="1150" y="239" name="inserted"/>
+      <point x="819" y="-40"/>
     </contour>
     <contour>
-      <point x="619" y="342" type="qcurve" smooth="yes"/>
-      <point x="683" y="342" name="inserted"/>
-      <point x="737" y="408"/>
-      <point x="737" y="468" type="qcurve"/>
-      <point x="737" y="559" type="line"/>
-      <point x="737" y="615" name="inserted"/>
-      <point x="681" y="682"/>
-      <point x="619" y="682" type="qcurve" smooth="yes"/>
-      <point x="557" y="682" name="inserted"/>
-      <point x="502" y="616"/>
-      <point x="502" y="559" type="qcurve"/>
-      <point x="502" y="468" type="line"/>
-      <point x="502" y="409" name="inserted"/>
-      <point x="557" y="342"/>
+      <point x="589" y="354" type="qcurve" smooth="yes"/>
+      <point x="653" y="354" name="inserted"/>
+      <point x="719" y="420"/>
+      <point x="730" y="480" type="qcurve"/>
+      <point x="746" y="571" type="line"/>
+      <point x="755" y="627" name="inserted"/>
+      <point x="711" y="694"/>
+      <point x="649" y="694" type="qcurve" smooth="yes"/>
+      <point x="587" y="694" name="inserted"/>
+      <point x="521" y="628"/>
+      <point x="511" y="571" type="qcurve"/>
+      <point x="495" y="480" type="line"/>
+      <point x="484" y="421" name="inserted"/>
+      <point x="527" y="354"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND0.ufo/fontinfo.plist
@@ -43,7 +43,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -51,7 +51,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1011"/>
   <unicode hex="004F"/>
-  <anchor x="506" y="1" name="bottom"/>
-  <anchor x="505" y="713" name="center"/>
-  <anchor x="655" y="1" name="ogonek"/>
-  <anchor x="517" y="1432" name="top"/>
-  <anchor x="737" y="1432" name="topright"/>
+  <anchor x="416.1763269807" y="1" name="bottom"/>
+  <anchor x="540.7211372451" y="713" name="center"/>
+  <anchor x="565.1763269807" y="1" name="ogonek"/>
+  <anchor x="679.5002363745" y="1432" name="top"/>
+  <anchor x="899.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="506" y="-25" type="qcurve"/>
-      <point x="304" y="-25"/>
-      <point x="87" y="211"/>
-      <point x="87" y="431" type="qcurve"/>
-      <point x="87" y="1002" type="line"/>
-      <point x="87" y="1217"/>
-      <point x="307" y="1451"/>
-      <point x="506" y="1451" type="qcurve" smooth="yes"/>
-      <point x="704" y="1451"/>
-      <point x="924" y="1218"/>
-      <point x="924" y="1002" type="qcurve"/>
-      <point x="924" y="431" type="line"/>
-      <point x="924" y="211"/>
-      <point x="707" y="-25"/>
+      <point x="421" y="-25" type="qcurve"/>
+      <point x="219" y="-25"/>
+      <point x="34.2049929295" y="211"/>
+      <point x="72.9969286853" y="431" type="qcurve"/>
+      <point x="173.6796346699" y="1002" type="line"/>
+      <point x="211.5899355222" y="1217"/>
+      <point x="459" y="1451"/>
+      <point x="658" y="1451" type="qcurve" smooth="yes"/>
+      <point x="856" y="1451"/>
+      <point x="1048.7662625029" y="1218"/>
+      <point x="1010.6796346699" y="1002" type="qcurve"/>
+      <point x="909.9969286853" y="431" type="line"/>
+      <point x="871.2049929295" y="211"/>
+      <point x="622" y="-25"/>
     </contour>
     <contour>
-      <point x="506" y="124" type="qcurve"/>
-      <point x="631" y="124"/>
-      <point x="761" y="265"/>
-      <point x="761" y="396" type="qcurve"/>
-      <point x="761" y="1033" type="line"/>
-      <point x="761" y="1161"/>
-      <point x="629" y="1299"/>
-      <point x="506" y="1299" type="qcurve" smooth="yes"/>
-      <point x="380" y="1299"/>
-      <point x="250" y="1160"/>
-      <point x="250" y="1033" type="qcurve"/>
-      <point x="250" y="396" type="line"/>
-      <point x="250" y="265"/>
-      <point x="380" y="124"/>
+      <point x="442" y="124" type="qcurve"/>
+      <point x="567" y="124"/>
+      <point x="717.7266498877" y="265"/>
+      <point x="740.8254843606" y="396" type="qcurve"/>
+      <point x="853.1457710718" y="1033" type="line"/>
+      <point x="875.7156246025" y="1161"/>
+      <point x="764" y="1299"/>
+      <point x="641" y="1299" type="qcurve" smooth="yes"/>
+      <point x="515" y="1299"/>
+      <point x="364.5392976218" y="1160"/>
+      <point x="342.1457710718" y="1033" type="qcurve"/>
+      <point x="229.8254843606" y="396" type="line"/>
+      <point x="206.7266498877" y="265"/>
+      <point x="316" y="124"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="796"/>
   <unicode hex="006F"/>
-  <anchor x="399" y="0" name="bottom"/>
-  <anchor x="398" y="510" name="center"/>
-  <anchor x="515" y="0" name="ogonek"/>
-  <anchor x="399" y="1020" name="top"/>
-  <anchor x="514" y="1020" name="topright"/>
+  <anchor x="309" y="0" name="bottom"/>
+  <anchor x="397.9267601613" y="510" name="center"/>
+  <anchor x="425" y="0" name="ogonek"/>
+  <anchor x="488.8535203226" y="1020" name="top"/>
+  <anchor x="603.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="399" y="-19" type="qcurve"/>
-      <point x="247" y="-19"/>
-      <point x="61" y="160"/>
-      <point x="61" y="340" type="qcurve"/>
-      <point x="61" y="684" type="line"/>
-      <point x="61" y="861"/>
-      <point x="245" y="1039"/>
-      <point x="399" y="1039" type="qcurve"/>
-      <point x="552" y="1039"/>
-      <point x="735" y="860"/>
-      <point x="735" y="684" type="qcurve"/>
-      <point x="735" y="340" type="line"/>
-      <point x="735" y="160"/>
-      <point x="550" y="-19"/>
+      <point x="321" y="-19" type="qcurve"/>
+      <point x="169" y="-19"/>
+      <point x="-0.7876830866" y="160"/>
+      <point x="30.9511734409" y="340" type="qcurve"/>
+      <point x="91.6076548046" y="684" type="line"/>
+      <point x="122.81753039" y="861"/>
+      <point x="322" y="1039"/>
+      <point x="476" y="1039" type="qcurve"/>
+      <point x="629" y="1039"/>
+      <point x="796.6412034093" y="860"/>
+      <point x="765.6076548046" y="684" type="qcurve"/>
+      <point x="704.9511734409" y="340" type="line"/>
+      <point x="673.2123169134" y="160"/>
+      <point x="472" y="-19"/>
     </contour>
     <contour>
-      <point x="399" y="124" type="qcurve"/>
-      <point x="481" y="124"/>
-      <point x="578" y="220"/>
-      <point x="578" y="310" type="qcurve"/>
-      <point x="578" y="709" type="line"/>
-      <point x="578" y="793"/>
-      <point x="481" y="896"/>
-      <point x="399" y="896" type="qcurve"/>
-      <point x="314" y="896"/>
-      <point x="217" y="796"/>
-      <point x="217" y="709" type="qcurve"/>
-      <point x="217" y="310" type="line"/>
-      <point x="217" y="220"/>
-      <point x="315" y="124"/>
+      <point x="335" y="124" type="qcurve"/>
+      <point x="417" y="124"/>
+      <point x="526.7919357559" y="220"/>
+      <point x="542.6613640196" y="310" type="qcurve"/>
+      <point x="613.0158293223" y="709" type="line"/>
+      <point x="627.8272957018" y="793"/>
+      <point x="545" y="896"/>
+      <point x="463" y="896" type="qcurve"/>
+      <point x="378" y="896"/>
+      <point x="267.3562766439" y="796"/>
+      <point x="252.0158293223" y="709" type="qcurve"/>
+      <point x="181.6613640196" y="310" type="line"/>
+      <point x="165.7919357559" y="220"/>
+      <point x="251" y="124"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo/fontinfo.plist
@@ -47,7 +47,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -55,7 +55,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1465"/>
   <unicode hex="004F"/>
-  <guideline x="732" y="865" angle="90" identifier="4vX9fVINMR"/>
-  <anchor x="733" y="0" name="bottom"/>
-  <anchor x="732" y="716" name="center"/>
-  <anchor x="930" y="0" name="ogonek"/>
-  <anchor x="733" y="1432" name="top"/>
-  <anchor x="956" y="1432" name="topright"/>
+  <guideline x="794.5228383128222" y="865" angle="100" identifier="4vX9fVINMR"/>
+  <anchor x="643" y="0" name="bottom"/>
+  <anchor x="768.2501181872609" y="716" name="center"/>
+  <anchor x="840" y="0" name="ogonek"/>
+  <anchor x="895.5002363745218" y="1432" name="top"/>
+  <anchor x="1118.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="733" y="-29" type="qcurve"/>
-      <point x="459" y="-29"/>
-      <point x="101" y="349"/>
-      <point x="101" y="656" type="qcurve"/>
-      <point x="101" y="776" type="line"/>
-      <point x="101" y="1075"/>
-      <point x="457" y="1459"/>
-      <point x="732" y="1459" type="qcurve"/>
-      <point x="1008" y="1459"/>
-      <point x="1364" y="1075"/>
-      <point x="1364" y="776" type="qcurve"/>
-      <point x="1364" y="656" type="line"/>
-      <point x="1364" y="355"/>
-      <point x="1005" y="-29"/>
+      <point x="637.8865175594545" y="-29" type="qcurve"/>
+      <point x="367" y="-29"/>
+      <point x="72.53811626725428" y="349"/>
+      <point x="126.67049934475301" y="656" type="qcurve"/>
+      <point x="147.8297370297688" y="776" type="line"/>
+      <point x="200.55150426159986" y="1075"/>
+      <point x="624.2610648536504" y="1459"/>
+      <point x="899.2610648536504" y="1459" type="qcurve"/>
+      <point x="1172" y="1459"/>
+      <point x="1463.5515042615998" y="1075"/>
+      <point x="1410.8297370297687" y="776" type="qcurve"/>
+      <point x="1389.6704993447531" y="656" type="line"/>
+      <point x="1336.596078151505" y="355"/>
+      <point x="909.8865175594545" y="-29"/>
     </contour>
     <contour>
-      <point x="733" y="0" type="qcurve"/>
-      <point x="989" y="0"/>
-      <point x="1332" y="363"/>
-      <point x="1332" y="661" type="qcurve"/>
-      <point x="1332" y="771" type="line"/>
-      <point x="1332" y="1065"/>
-      <point x="989" y="1429"/>
-      <point x="732" y="1429" type="qcurve"/>
-      <point x="474" y="1429"/>
-      <point x="133" y="1067"/>
-      <point x="133" y="771" type="qcurve"/>
-      <point x="133" y="661" type="line"/>
-      <point x="133" y="361"/>
-      <point x="476" y="0"/>
+      <point x="643" y="0" type="qcurve"/>
+      <point x="899" y="0"/>
+      <point x="1306.0066939971728" y="363"/>
+      <point x="1358.5521342482953" y="661" type="qcurve"/>
+      <point x="1377.9481021262266" y="771" type="line"/>
+      <point x="1429.788234454515" y="1065"/>
+      <point x="1150.9712554323964" y="1429"/>
+      <point x="893.9712554323964" y="1429" type="qcurve"/>
+      <point x="635.9712554323964" y="1429"/>
+      <point x="231.14088841593212" y="1067"/>
+      <point x="178.9481021262265" y="771" type="qcurve"/>
+      <point x="159.55213424829535" y="661" type="line"/>
+      <point x="106.65404003575586" y="361"/>
+      <point x="386" y="0"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1465"/>
   <unicode hex="004F"/>
-  <guideline x="794.5228383128222" y="865" angle="100" identifier="4vX9fVINMR"/>
+  <guideline x="794.5228383128" y="865" angle="100" identifier="4vX9fVINMR"/>
   <anchor x="643" y="0" name="bottom"/>
-  <anchor x="768.2501181872609" y="716" name="center"/>
+  <anchor x="768.2501181873" y="716" name="center"/>
   <anchor x="840" y="0" name="ogonek"/>
-  <anchor x="895.5002363745218" y="1432" name="top"/>
-  <anchor x="1118.5002363745218" y="1432" name="topright"/>
+  <anchor x="895.5002363745" y="1432" name="top"/>
+  <anchor x="1118.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="637.8865175594545" y="-29" type="qcurve"/>
+      <point x="637.8865175595" y="-29" type="qcurve"/>
       <point x="367" y="-29"/>
-      <point x="72.53811626725428" y="349"/>
-      <point x="126.67049934475301" y="656" type="qcurve"/>
-      <point x="147.8297370297688" y="776" type="line"/>
-      <point x="200.55150426159986" y="1075"/>
-      <point x="624.2610648536504" y="1459"/>
-      <point x="899.2610648536504" y="1459" type="qcurve"/>
+      <point x="72.5381162673" y="349"/>
+      <point x="126.6704993448" y="656" type="qcurve"/>
+      <point x="147.8297370298" y="776" type="line"/>
+      <point x="200.5515042616" y="1075"/>
+      <point x="624.2610648537" y="1459"/>
+      <point x="899.2610648537" y="1459" type="qcurve"/>
       <point x="1172" y="1459"/>
-      <point x="1463.5515042615998" y="1075"/>
-      <point x="1410.8297370297687" y="776" type="qcurve"/>
-      <point x="1389.6704993447531" y="656" type="line"/>
-      <point x="1336.596078151505" y="355"/>
-      <point x="909.8865175594545" y="-29"/>
+      <point x="1463.5515042616" y="1075"/>
+      <point x="1410.8297370298" y="776" type="qcurve"/>
+      <point x="1389.6704993448" y="656" type="line"/>
+      <point x="1336.5960781515" y="355"/>
+      <point x="909.8865175595" y="-29"/>
     </contour>
     <contour>
       <point x="643" y="0" type="qcurve"/>
       <point x="899" y="0"/>
-      <point x="1306.0066939971728" y="363"/>
-      <point x="1358.5521342482953" y="661" type="qcurve"/>
-      <point x="1377.9481021262266" y="771" type="line"/>
-      <point x="1429.788234454515" y="1065"/>
-      <point x="1150.9712554323964" y="1429"/>
-      <point x="893.9712554323964" y="1429" type="qcurve"/>
-      <point x="635.9712554323964" y="1429"/>
-      <point x="231.14088841593212" y="1067"/>
-      <point x="178.9481021262265" y="771" type="qcurve"/>
-      <point x="159.55213424829535" y="661" type="line"/>
-      <point x="106.65404003575586" y="361"/>
+      <point x="1306.0066939972" y="363"/>
+      <point x="1358.5521342483" y="661" type="qcurve"/>
+      <point x="1377.9481021262" y="771" type="line"/>
+      <point x="1429.7882344545" y="1065"/>
+      <point x="1150.9712554324" y="1429"/>
+      <point x="893.9712554324" y="1429" type="qcurve"/>
+      <point x="635.9712554324" y="1429"/>
+      <point x="231.1408884159" y="1067"/>
+      <point x="178.9481021262" y="771" type="qcurve"/>
+      <point x="159.5521342483" y="661" type="line"/>
+      <point x="106.6540400358" y="361"/>
       <point x="386" y="0"/>
     </contour>
   </outline>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1086"/>
   <unicode hex="006F"/>
-  <guideline x="510.77851597105496" y="319.7235114510744" angle="100" identifier="iUYiktZs51"/>
+  <guideline x="510.7785159711" y="319.7235114511" angle="100" identifier="iUYiktZs51"/>
   <anchor x="454" y="0" name="bottom"/>
-  <anchor x="542.7504331806086" y="509" name="center"/>
+  <anchor x="542.7504331806" y="509" name="center"/>
   <anchor x="626" y="0" name="ogonek"/>
-  <anchor x="634.8535203226343" y="1020" name="top"/>
-  <anchor x="760.8535203226343" y="1020" name="topright"/>
+  <anchor x="634.8535203226" y="1020" name="top"/>
+  <anchor x="760.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="448.88651755945455" y="-29" type="qcurve"/>
+      <point x="448.8865175595" y="-29" type="qcurve"/>
       <point x="250" y="-29"/>
-      <point x="46.613167447197725" y="236"/>
-      <point x="86.81571904872774" y="464" type="qcurve"/>
-      <point x="101.27453146682188" y="546" type="line"/>
-      <point x="141.4770830683519" y="774"/>
-      <point x="433.67475201396974" y="1036"/>
-      <point x="637.6747520139697" y="1036" type="qcurve"/>
+      <point x="46.6131674472" y="236"/>
+      <point x="86.8157190487" y="464" type="qcurve"/>
+      <point x="101.2745314668" y="546" type="line"/>
+      <point x="141.4770830684" y="774"/>
+      <point x="433.674752014" y="1036"/>
+      <point x="637.674752014" y="1036" type="qcurve"/>
       <point x="840" y="1036"/>
-      <point x="1036.2427942033926" y="767"/>
-      <point x="997.2745314668218" y="546" type="qcurve"/>
-      <point x="982.8157190487277" y="464" type="line"/>
-      <point x="943.49480235074" y="241"/>
-      <point x="654.8865175594545" y="-29"/>
+      <point x="1036.2427942034" y="767"/>
+      <point x="997.2745314668" y="546" type="qcurve"/>
+      <point x="982.8157190487" y="464" type="line"/>
+      <point x="943.4948023507" y="241"/>
+      <point x="654.8865175595" y="-29"/>
     </contour>
     <contour>
-      <point x="454.1763269807085" y="1" type="qcurve"/>
-      <point x="639.1763269807085" y="1"/>
-      <point x="913.9054181964078" y="249"/>
-      <point x="952.3446999908531" y="467" type="qcurve"/>
-      <point x="965.5692235439881" y="542" type="line"/>
-      <point x="1003.1268704348911" y="755"/>
-      <point x="823.7375965541327" y="1008"/>
-      <point x="632.7375965541327" y="1008" type="qcurve"/>
-      <point x="444.73759655413267" y="1008"/>
-      <point x="170.53748628055877" y="763"/>
-      <point x="131.56922354398802" y="542" type="qcurve"/>
-      <point x="118.34469999085314" y="467" type="line"/>
-      <point x="79.3764372542824" y="246"/>
-      <point x="269.17632698070844" y="1"/>
+      <point x="454.1763269807" y="1" type="qcurve"/>
+      <point x="639.1763269807" y="1"/>
+      <point x="913.9054181964" y="249"/>
+      <point x="952.3446999909" y="467" type="qcurve"/>
+      <point x="965.569223544" y="542" type="line"/>
+      <point x="1003.1268704349" y="755"/>
+      <point x="823.7375965541" y="1008"/>
+      <point x="632.7375965541" y="1008" type="qcurve"/>
+      <point x="444.7375965541" y="1008"/>
+      <point x="170.5374862806" y="763"/>
+      <point x="131.569223544" y="542" type="qcurve"/>
+      <point x="118.3446999909" y="467" type="line"/>
+      <point x="79.3764372543" y="246"/>
+      <point x="269.1763269807" y="1"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1086"/>
   <unicode hex="006F"/>
-  <guideline x="544.4026345353786" y="319.7235114510744" angle="90" identifier="iUYiktZs51"/>
-  <anchor x="544" y="0" name="bottom"/>
-  <anchor x="543" y="509" name="center"/>
-  <anchor x="716" y="0" name="ogonek"/>
-  <anchor x="545" y="1020" name="top"/>
-  <anchor x="671" y="1020" name="topright"/>
+  <guideline x="510.77851597105496" y="319.7235114510744" angle="100" identifier="iUYiktZs51"/>
+  <anchor x="454" y="0" name="bottom"/>
+  <anchor x="542.7504331806086" y="509" name="center"/>
+  <anchor x="626" y="0" name="ogonek"/>
+  <anchor x="634.8535203226343" y="1020" name="top"/>
+  <anchor x="760.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="544" y="-29" type="qcurve"/>
-      <point x="341" y="-29"/>
-      <point x="95" y="236"/>
-      <point x="95" y="464" type="qcurve"/>
-      <point x="95" y="546" type="line"/>
-      <point x="95" y="774"/>
-      <point x="341" y="1036"/>
-      <point x="545" y="1036" type="qcurve"/>
-      <point x="751" y="1036"/>
-      <point x="991" y="767"/>
-      <point x="991" y="546" type="qcurve"/>
-      <point x="991" y="464" type="line"/>
-      <point x="991" y="241"/>
-      <point x="750" y="-29"/>
+      <point x="448.88651755945455" y="-29" type="qcurve"/>
+      <point x="250" y="-29"/>
+      <point x="46.613167447197725" y="236"/>
+      <point x="86.81571904872774" y="464" type="qcurve"/>
+      <point x="101.27453146682188" y="546" type="line"/>
+      <point x="141.4770830683519" y="774"/>
+      <point x="433.67475201396974" y="1036"/>
+      <point x="637.6747520139697" y="1036" type="qcurve"/>
+      <point x="840" y="1036"/>
+      <point x="1036.2427942033926" y="767"/>
+      <point x="997.2745314668218" y="546" type="qcurve"/>
+      <point x="982.8157190487277" y="464" type="line"/>
+      <point x="943.49480235074" y="241"/>
+      <point x="654.8865175594545" y="-29"/>
     </contour>
     <contour>
-      <point x="544" y="1" type="qcurve"/>
-      <point x="729" y="1"/>
-      <point x="960" y="249"/>
-      <point x="960" y="467" type="qcurve"/>
-      <point x="960" y="542" type="line"/>
-      <point x="960" y="755"/>
-      <point x="736" y="1008"/>
-      <point x="545" y="1008" type="qcurve"/>
-      <point x="357" y="1008"/>
-      <point x="126" y="763"/>
-      <point x="126" y="542" type="qcurve"/>
-      <point x="126" y="467" type="line"/>
-      <point x="126" y="246"/>
-      <point x="359" y="1"/>
+      <point x="454.1763269807085" y="1" type="qcurve"/>
+      <point x="639.1763269807085" y="1"/>
+      <point x="913.9054181964078" y="249"/>
+      <point x="952.3446999908531" y="467" type="qcurve"/>
+      <point x="965.5692235439881" y="542" type="line"/>
+      <point x="1003.1268704348911" y="755"/>
+      <point x="823.7375965541327" y="1008"/>
+      <point x="632.7375965541327" y="1008" type="qcurve"/>
+      <point x="444.73759655413267" y="1008"/>
+      <point x="170.53748628055877" y="763"/>
+      <point x="131.56922354398802" y="542" type="qcurve"/>
+      <point x="118.34469999085314" y="467" type="line"/>
+      <point x="79.3764372542824" y="246"/>
+      <point x="269.17632698070844" y="1"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo/glyphs/oslash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="996"/>
-  <guideline x="534" y="462" angle="331.3895403340348" identifier="HpTBW3Ocar"/>
+  <guideline x="534" y="462" angle="331.389540334" identifier="HpTBW3Ocar"/>
   <outline>
     <contour>
       <point x="520" y="499" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND0.ufo/fontinfo.plist
@@ -47,7 +47,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -55,7 +55,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -2,44 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1584"/>
   <unicode hex="004F"/>
-  <guideline x="791" y="833" angle="90" identifier="nlPUYFZkyP"/>
-  <anchor x="794" y="0" name="bottom"/>
-  <anchor x="791" y="712" name="center"/>
-  <anchor x="1028" y="0" name="ogonek"/>
-  <anchor x="794" y="1432" name="top"/>
-  <anchor x="1020" y="1432" name="topright"/>
+  <anchor x="704" y="0" name="bottom"/>
+  <anchor x="826.544810264427" y="712" name="center"/>
+  <anchor x="938" y="0" name="ogonek"/>
+  <anchor x="956.5002363745218" y="1432" name="top"/>
+  <anchor x="1182.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="792" y="-31" type="qcurve" smooth="yes"/>
-      <point x="468" y="-31" name="inserted"/>
-      <point x="63" y="353"/>
-      <point x="63" y="716" type="qcurve"/>
-      <point x="63" y="716" type="line"/>
-      <point x="63" y="1079" name="inserted"/>
-      <point x="472" y="1463"/>
-      <point x="792" y="1463" type="qcurve" smooth="yes"/>
-      <point x="1112" y="1463" name="inserted"/>
-      <point x="1521" y="1065"/>
-      <point x="1521" y="716" type="qcurve"/>
-      <point x="1521" y="716" type="line"/>
-      <point x="1521" y="367" name="inserted"/>
-      <point x="1116" y="-31"/>
+      <point x="743" y="-31" type="qcurve"/>
+      <point x="419" y="-31" name="inserted"/>
+      <point x="36" y="353"/>
+      <point x="100" y="722" type="qcurve"/>
+      <point x="100" y="722" type="line"/>
+      <point x="164" y="1079" name="inserted"/>
+      <point x="589" y="1463"/>
+      <point x="909" y="1463" type="qcurve" smooth="yes"/>
+      <point x="1229" y="1463" name="inserted"/>
+      <point x="1618" y="1065"/>
+      <point x="1556" y="709" type="qcurve"/>
+      <point x="1556" y="709" type="line"/>
+      <point x="1495" y="367" name="inserted"/>
+      <point x="1067" y="-31"/>
     </contour>
     <contour>
-      <point x="791" y="433" type="qcurve" smooth="yes"/>
-      <point x="900" y="433" name="inserted"/>
-      <point x="1037" y="577"/>
-      <point x="1037" y="688" type="qcurve"/>
-      <point x="1037" y="743" type="line"/>
-      <point x="1037" y="857" name="inserted"/>
-      <point x="900" y="999"/>
-      <point x="791" y="999" type="qcurve" smooth="yes"/>
-      <point x="685" y="999" name="inserted"/>
-      <point x="546" y="857"/>
-      <point x="546" y="743" type="qcurve"/>
-      <point x="546" y="688" type="line"/>
-      <point x="546" y="575" name="inserted"/>
-      <point x="683" y="433"/>
+      <point x="777.3495826467654" y="433" type="qcurve" smooth="yes"/>
+      <point x="886.3495826467654" y="433" name="inserted"/>
+      <point x="1048.7406678687844" y="577"/>
+      <point x="1068.3129627274238" y="688" type="qcurve"/>
+      <point x="1078.0109466663894" y="743" type="line"/>
+      <point x="1098.1122224671544" y="857" name="inserted"/>
+      <point x="986.1506537277564" y="999"/>
+      <point x="877.1506537277565" y="999" type="qcurve" smooth="yes"/>
+      <point x="771.1506537277565" y="999" name="inserted"/>
+      <point x="607.1122224671544" y="857"/>
+      <point x="587.0109466663895" y="743" type="qcurve"/>
+      <point x="577.312962727424" y="688" type="line"/>
+      <point x="557.3880139073674" y="575" name="inserted"/>
+      <point x="669.3495826467654" y="433"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -3,10 +3,10 @@
   <advance width="1584"/>
   <unicode hex="004F"/>
   <anchor x="704" y="0" name="bottom"/>
-  <anchor x="826.544810264427" y="712" name="center"/>
+  <anchor x="826.5448102644" y="712" name="center"/>
   <anchor x="938" y="0" name="ogonek"/>
-  <anchor x="956.5002363745218" y="1432" name="top"/>
-  <anchor x="1182.5002363745218" y="1432" name="topright"/>
+  <anchor x="956.5002363745" y="1432" name="top"/>
+  <anchor x="1182.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
       <point x="743" y="-31" type="qcurve"/>
@@ -25,20 +25,20 @@
       <point x="1067" y="-31"/>
     </contour>
     <contour>
-      <point x="777.3495826467654" y="433" type="qcurve" smooth="yes"/>
-      <point x="886.3495826467654" y="433" name="inserted"/>
-      <point x="1048.7406678687844" y="577"/>
-      <point x="1068.3129627274238" y="688" type="qcurve"/>
-      <point x="1078.0109466663894" y="743" type="line"/>
-      <point x="1098.1122224671544" y="857" name="inserted"/>
-      <point x="986.1506537277564" y="999"/>
-      <point x="877.1506537277565" y="999" type="qcurve" smooth="yes"/>
-      <point x="771.1506537277565" y="999" name="inserted"/>
-      <point x="607.1122224671544" y="857"/>
-      <point x="587.0109466663895" y="743" type="qcurve"/>
-      <point x="577.312962727424" y="688" type="line"/>
-      <point x="557.3880139073674" y="575" name="inserted"/>
-      <point x="669.3495826467654" y="433"/>
+      <point x="777.3495826468" y="433" type="qcurve" smooth="yes"/>
+      <point x="886.3495826468" y="433" name="inserted"/>
+      <point x="1048.7406678688" y="577"/>
+      <point x="1068.3129627274" y="688" type="qcurve"/>
+      <point x="1078.0109466664" y="743" type="line"/>
+      <point x="1098.1122224672" y="857" name="inserted"/>
+      <point x="986.1506537278" y="999"/>
+      <point x="877.1506537278" y="999" type="qcurve" smooth="yes"/>
+      <point x="771.1506537278" y="999" name="inserted"/>
+      <point x="607.1122224672" y="857"/>
+      <point x="587.0109466664" y="743" type="qcurve"/>
+      <point x="577.3129627274" y="688" type="line"/>
+      <point x="557.3880139074" y="575" name="inserted"/>
+      <point x="669.3495826468" y="433"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND0.ufo/glyphs/o.glif
@@ -3,40 +3,40 @@
   <advance width="1318"/>
   <unicode hex="006F"/>
   <anchor x="570" y="0" name="bottom"/>
-  <anchor x="661.1030871420256" y="511" name="center"/>
+  <anchor x="661.103087142" y="511" name="center"/>
   <anchor x="839" y="0" name="ogonek"/>
-  <anchor x="751.8535203226343" y="1020" name="top"/>
-  <anchor x="1018.8535203226343" y="1020" name="topright"/>
+  <anchor x="751.8535203226" y="1020" name="top"/>
+  <anchor x="1018.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
       <point x="601" y="-43" type="qcurve" smooth="yes"/>
       <point x="312" y="-43" name="inserted"/>
-      <point x="2.1397070613670337" y="256"/>
-      <point x="46.221452238483266" y="506" type="qcurve"/>
-      <point x="50.276972794777976" y="529" type="line"/>
+      <point x="2.1397070614" y="256"/>
+      <point x="46.2214522385" y="506" type="qcurve"/>
+      <point x="50.2769727948" y="529" type="line"/>
       <point x="94" y="782" name="inserted"/>
       <point x="438" y="1079"/>
       <point x="719" y="1079" type="qcurve" smooth="yes"/>
       <point x="999" y="1079" name="inserted"/>
-      <point x="1315.5954481648096" y="769"/>
-      <point x="1273.276972794778" y="529" type="qcurve"/>
-      <point x="1269.2214522384834" y="506" type="line"/>
+      <point x="1315.5954481648" y="769"/>
+      <point x="1273.2769727948" y="529" type="qcurve"/>
+      <point x="1269.2214522385" y="506" type="line"/>
       <point x="1227" y="257" name="inserted"/>
       <point x="890" y="-43"/>
     </contour>
     <contour>
       <point x="632" y="342" type="qcurve" smooth="yes"/>
       <point x="708" y="342" name="inserted"/>
-      <point x="792.5283509554299" y="417"/>
-      <point x="804.5185856436055" y="485" type="qcurve"/>
-      <point x="814.2165695825711" y="540" type="line"/>
+      <point x="792.5283509554" y="417"/>
+      <point x="804.5185856436" y="485" type="qcurve"/>
+      <point x="814.2165695826" y="540" type="line"/>
       <point x="823" y="603" name="inserted"/>
       <point x="760" y="682"/>
       <point x="686" y="682" type="qcurve" smooth="yes"/>
       <point x="611" y="682" name="inserted"/>
       <point x="526" y="603"/>
-      <point x="514.2165695825711" y="540" type="qcurve"/>
-      <point x="504.51858564360555" y="485" type="line"/>
+      <point x="514.2165695826" y="540" type="qcurve"/>
+      <point x="504.5185856436" y="485" type="line"/>
       <point x="495" y="418" name="inserted"/>
       <point x="558" y="342"/>
     </contour>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1318"/>
   <unicode hex="006F"/>
-  <anchor x="660" y="0" name="bottom"/>
-  <anchor x="661" y="511" name="center"/>
-  <anchor x="929" y="0" name="ogonek"/>
-  <anchor x="662" y="1020" name="top"/>
-  <anchor x="929" y="1020" name="topright"/>
+  <anchor x="570" y="0" name="bottom"/>
+  <anchor x="661.1030871420256" y="511" name="center"/>
+  <anchor x="839" y="0" name="ogonek"/>
+  <anchor x="751.8535203226343" y="1020" name="top"/>
+  <anchor x="1018.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="659" y="-43" type="qcurve" smooth="yes"/>
-      <point x="370" y="-43" name="inserted"/>
-      <point x="47" y="256"/>
-      <point x="47" y="506" type="qcurve"/>
-      <point x="47" y="529" type="line"/>
-      <point x="47" y="777" name="inserted"/>
-      <point x="378" y="1079"/>
-      <point x="659" y="1079" type="qcurve" smooth="yes"/>
-      <point x="939" y="1079" name="inserted"/>
-      <point x="1270" y="769"/>
-      <point x="1270" y="529" type="qcurve"/>
-      <point x="1270" y="506" type="line"/>
-      <point x="1270" y="264" name="inserted"/>
-      <point x="948" y="-43"/>
+      <point x="601" y="-43" type="qcurve" smooth="yes"/>
+      <point x="312" y="-43" name="inserted"/>
+      <point x="2.1397070613670337" y="256"/>
+      <point x="46.221452238483266" y="506" type="qcurve"/>
+      <point x="50.276972794777976" y="529" type="line"/>
+      <point x="94" y="782" name="inserted"/>
+      <point x="438" y="1079"/>
+      <point x="719" y="1079" type="qcurve" smooth="yes"/>
+      <point x="999" y="1079" name="inserted"/>
+      <point x="1315.5954481648096" y="769"/>
+      <point x="1273.276972794778" y="529" type="qcurve"/>
+      <point x="1269.2214522384834" y="506" type="line"/>
+      <point x="1227" y="257" name="inserted"/>
+      <point x="890" y="-43"/>
     </contour>
     <contour>
-      <point x="659" y="342" type="qcurve" smooth="yes"/>
-      <point x="735" y="342" name="inserted"/>
-      <point x="809" y="417"/>
-      <point x="809" y="485" type="qcurve"/>
-      <point x="809" y="540" type="line"/>
-      <point x="809" y="604" name="inserted"/>
-      <point x="733" y="682"/>
-      <point x="659" y="682" type="qcurve" smooth="yes"/>
-      <point x="584" y="682" name="inserted"/>
-      <point x="509" y="605"/>
-      <point x="509" y="540" type="qcurve"/>
-      <point x="509" y="485" type="line"/>
-      <point x="509" y="418" name="inserted"/>
-      <point x="583" y="342"/>
+      <point x="632" y="342" type="qcurve" smooth="yes"/>
+      <point x="708" y="342" name="inserted"/>
+      <point x="792.5283509554299" y="417"/>
+      <point x="804.5185856436055" y="485" type="qcurve"/>
+      <point x="814.2165695825711" y="540" type="line"/>
+      <point x="823" y="603" name="inserted"/>
+      <point x="760" y="682"/>
+      <point x="686" y="682" type="qcurve" smooth="yes"/>
+      <point x="611" y="682" name="inserted"/>
+      <point x="526" y="603"/>
+      <point x="514.2165695825711" y="540" type="qcurve"/>
+      <point x="504.51858564360555" y="485" type="line"/>
+      <point x="495" y="418" name="inserted"/>
+      <point x="558" y="342"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND0.ufo/fontinfo.plist
@@ -47,7 +47,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -55,7 +55,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1457"/>
   <unicode hex="004F"/>
-  <anchor x="729" y="2" name="bottom"/>
-  <anchor x="728" y="715" name="center"/>
-  <anchor x="944" y="0" name="ogonek"/>
-  <anchor x="756" y="1432" name="top"/>
-  <anchor x="976" y="1432" name="topright"/>
+  <anchor x="639.3526539614" y="2" name="bottom"/>
+  <anchor x="764.0737912066" y="715" name="center"/>
+  <anchor x="854" y="0" name="ogonek"/>
+  <anchor x="918.5002363745" y="1432" name="top"/>
+  <anchor x="1138.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="729" y="-30" type="qcurve"/>
-      <point x="432" y="-30"/>
-      <point x="86" y="350"/>
-      <point x="86" y="638" type="qcurve"/>
-      <point x="86" y="798" type="line"/>
-      <point x="86" y="1084"/>
-      <point x="435" y="1460"/>
-      <point x="729" y="1460" type="qcurve"/>
-      <point x="1022" y="1460"/>
-      <point x="1371" y="1086"/>
-      <point x="1371" y="798" type="qcurve"/>
-      <point x="1371" y="638" type="line"/>
-      <point x="1371" y="350"/>
-      <point x="1025" y="-30"/>
+      <point x="657" y="-30" type="qcurve"/>
+      <point x="360" y="-30"/>
+      <point x="57.714443248" y="350"/>
+      <point x="108.496613692" y="638" type="qcurve"/>
+      <point x="136.7089306054" y="798" type="line"/>
+      <point x="187.138447088" y="1084"/>
+      <point x="579" y="1460"/>
+      <point x="873" y="1460" type="qcurve"/>
+      <point x="1166" y="1460"/>
+      <point x="1472.4911010494" y="1086"/>
+      <point x="1421.7089306054" y="798" type="qcurve"/>
+      <point x="1393.496613692" y="638" type="line"/>
+      <point x="1342.714443248" y="350"/>
+      <point x="953" y="-30"/>
     </contour>
     <contour>
-      <point x="729" y="128" type="qcurve"/>
-      <point x="952" y="128"/>
-      <point x="1201" y="410"/>
-      <point x="1201" y="628" type="qcurve"/>
-      <point x="1201" y="807" type="line"/>
-      <point x="1201" y="1024"/>
-      <point x="949" y="1301"/>
-      <point x="729" y="1301" type="qcurve"/>
-      <point x="507" y="1301"/>
-      <point x="256" y="1023"/>
-      <point x="256" y="807" type="qcurve"/>
-      <point x="256" y="628" type="line"/>
-      <point x="256" y="410"/>
-      <point x="505" y="128"/>
+      <point x="666" y="128" type="qcurve"/>
+      <point x="889" y="128"/>
+      <point x="1183.2940620905" y="410"/>
+      <point x="1221.7333438849" y="628" type="qcurve"/>
+      <point x="1253.2958734317" y="807" type="line"/>
+      <point x="1291.5588282455" y="1024"/>
+      <point x="1085" y="1301"/>
+      <point x="865" y="1301" type="qcurve"/>
+      <point x="643" y="1301"/>
+      <point x="346.3825012648" y="1023"/>
+      <point x="308.2958734317" y="807" type="qcurve"/>
+      <point x="276.7333438849" y="628" type="line"/>
+      <point x="238.2940620905" y="410"/>
+      <point x="442" y="128"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND0.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND0.ufo/glyphs/O_slash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Oslash-bar" format="2">
   <advance width="1271"/>
-  <guideline x="1121" y="1397" angle="330.751173663453" identifier="4Md523Ddk8"/>
+  <guideline x="1121" y="1397" angle="330.7511736635" identifier="4Md523Ddk8"/>
   <outline>
     <contour>
       <point x="585" y="785" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1073"/>
   <unicode hex="006F"/>
-  <anchor x="537" y="0" name="bottom"/>
-  <anchor x="537" y="510" name="center"/>
-  <anchor x="705" y="0" name="ogonek"/>
-  <anchor x="537" y="1020" name="top"/>
-  <anchor x="700" y="1020" name="topright"/>
+  <anchor x="447" y="0" name="bottom"/>
+  <anchor x="536.9267601613" y="510" name="center"/>
+  <anchor x="615" y="0" name="ogonek"/>
+  <anchor x="626.8535203226" y="1020" name="top"/>
+  <anchor x="789.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="537" y="-28" type="qcurve"/>
-      <point x="333" y="-28"/>
-      <point x="69" y="251"/>
-      <point x="69" y="466" type="qcurve"/>
-      <point x="69" y="560" type="line"/>
-      <point x="69" y="776"/>
-      <point x="333" y="1048"/>
-      <point x="537" y="1048" type="qcurve"/>
-      <point x="740" y="1048"/>
-      <point x="1005" y="774"/>
-      <point x="1005" y="560" type="qcurve"/>
-      <point x="1005" y="466" type="line"/>
-      <point x="1005" y="251"/>
-      <point x="741" y="-28"/>
+      <point x="457" y="-28" type="qcurve"/>
+      <point x="253" y="-28"/>
+      <point x="23.2580721578" y="251"/>
+      <point x="61.1683730101" y="466" type="qcurve"/>
+      <point x="77.7431091967" y="560" type="line"/>
+      <point x="115.8297370298" y="776"/>
+      <point x="410" y="1048"/>
+      <point x="614" y="1048" type="qcurve"/>
+      <point x="817" y="1048"/>
+      <point x="1051.4770830684" y="774"/>
+      <point x="1013.7431091967" y="560" type="qcurve"/>
+      <point x="997.1683730101" y="466" type="line"/>
+      <point x="959.2580721578" y="251"/>
+      <point x="661" y="-28"/>
     </contour>
     <contour>
-      <point x="537" y="121" type="qcurve"/>
-      <point x="667" y="121"/>
-      <point x="839" y="306"/>
-      <point x="839" y="452" type="qcurve"/>
-      <point x="839" y="567" type="line"/>
-      <point x="839" y="715"/>
-      <point x="665" y="897"/>
-      <point x="537" y="897" type="qcurve"/>
-      <point x="407" y="897"/>
-      <point x="233" y="714"/>
-      <point x="233" y="567" type="qcurve"/>
-      <point x="233" y="452" type="line"/>
-      <point x="233" y="306"/>
-      <point x="405" y="121"/>
+      <point x="468.3355646657" y="121" type="qcurve"/>
+      <point x="598.3355646657" y="121"/>
+      <point x="802.9560560968" y="306"/>
+      <point x="828.6997952802" y="452" type="qcurve"/>
+      <point x="848.9773980617" y="567" type="line"/>
+      <point x="875.0737912066" y="715"/>
+      <point x="733.1653016955" y="897"/>
+      <point x="605.1653016955" y="897" type="qcurve"/>
+      <point x="475.1653016955" y="897"/>
+      <point x="268.8974642258" y="714"/>
+      <point x="242.9773980617" y="567" type="qcurve"/>
+      <point x="222.6997952802" y="452" type="line"/>
+      <point x="196.9560560968" y="306"/>
+      <point x="336.3355646657" y="121"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND0.ufo/fontinfo.plist
@@ -144,7 +144,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -152,7 +152,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1722"/>
   <unicode hex="004F"/>
-  <anchor x="861" y="0" name="bottom"/>
-  <anchor x="861" y="716" name="center"/>
-  <anchor x="1108" y="0" name="ogonek"/>
-  <anchor x="861" y="1432" name="top"/>
-  <anchor x="1060" y="1432" name="topright"/>
+  <anchor x="764.7952286282" y="0" name="bottom"/>
+  <anchor x="890.7952286282" y="716" name="center"/>
+  <anchor x="1011.7952286282" y="0" name="ogonek"/>
+  <anchor x="1017.7952286282" y="1432" name="top"/>
+  <anchor x="1216.7952286282" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="862" y="-38" type="qcurve" smooth="yes"/>
-      <point x="544" y="-38"/>
-      <point x="112" y="374"/>
-      <point x="112" y="718" type="qcurve"/>
-      <point x="112" y="718" type="line"/>
-      <point x="112" y="1038"/>
-      <point x="542" y="1474"/>
-      <point x="862" y="1474" type="qcurve" smooth="yes"/>
-      <point x="1180" y="1474"/>
-      <point x="1610" y="1044"/>
-      <point x="1610" y="718" type="qcurve"/>
-      <point x="1610" y="718" type="line"/>
-      <point x="1610" y="396"/>
-      <point x="1178" y="-38"/>
+      <point x="782.7952286282" y="-38" type="qcurve" smooth="yes"/>
+      <point x="462.7952286282" y="-39"/>
+      <point x="81.7952286282" y="374"/>
+      <point x="142.7952286282" y="718" type="qcurve"/>
+      <point x="142.7952286282" y="718" type="line"/>
+      <point x="198.7952286282" y="1044"/>
+      <point x="685.7952286282" y="1474"/>
+      <point x="1005.7952286282" y="1474" type="qcurve" smooth="yes"/>
+      <point x="1323.7952286282" y="1474"/>
+      <point x="1697.7952286282" y="1044"/>
+      <point x="1640.7952286282" y="718" type="qcurve"/>
+      <point x="1640.7952286282" y="718" type="line"/>
+      <point x="1576.7952286282" y="373"/>
+      <point x="1098.7952286282" y="-37"/>
     </contour>
     <contour>
-      <point x="862" y="32" type="qcurve" smooth="yes"/>
-      <point x="1142" y="32"/>
-      <point x="1522" y="406"/>
-      <point x="1522" y="716" type="qcurve"/>
-      <point x="1522" y="716" type="line"/>
-      <point x="1522" y="1016"/>
-      <point x="1136" y="1398"/>
-      <point x="862" y="1398" type="qcurve" smooth="yes"/>
-      <point x="582" y="1398"/>
-      <point x="200" y="1030"/>
-      <point x="200" y="716" type="qcurve"/>
-      <point x="200" y="716" type="line"/>
-      <point x="200" y="402"/>
-      <point x="588" y="32"/>
+      <point x="781.7952286282" y="32" type="qcurve" smooth="yes"/>
+      <point x="1061.7952286282" y="32"/>
+      <point x="1497.7952286282" y="406"/>
+      <point x="1551.7952286282" y="716" type="qcurve"/>
+      <point x="1551.7952286282" y="716" type="line"/>
+      <point x="1604.7952286282" y="1016"/>
+      <point x="1280.7952286282" y="1398"/>
+      <point x="1006.7952286282" y="1398" type="qcurve" smooth="yes"/>
+      <point x="726.7952286282" y="1398"/>
+      <point x="285.7952286282" y="1030"/>
+      <point x="229.7952286282" y="716" type="qcurve"/>
+      <point x="229.7952286282" y="716" type="line"/>
+      <point x="174.7952286282" y="402"/>
+      <point x="507.7952286282" y="32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1364"/>
   <unicode hex="006F"/>
-  <anchor x="681" y="0" name="bottom"/>
-  <anchor x="682" y="542" name="center"/>
-  <anchor x="899" y="0" name="ogonek"/>
-  <anchor x="681" y="1086" name="top"/>
-  <anchor x="1061" y="1086" name="topright"/>
+  <anchor x="585.6264367816" y="0" name="bottom"/>
+  <anchor x="682.6264367816" y="542" name="center"/>
+  <anchor x="803.6264367816" y="0" name="ogonek"/>
+  <anchor x="776.6264367816" y="1086" name="top"/>
+  <anchor x="1156.6264367816" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="681" y="-36" type="qcurve" smooth="yes"/>
-      <point x="422" y="-36"/>
-      <point x="106" y="296"/>
-      <point x="106" y="541" type="qcurve"/>
-      <point x="106" y="541" type="line"/>
-      <point x="106" y="786"/>
-      <point x="430" y="1116"/>
-      <point x="681" y="1116" type="qcurve" smooth="yes"/>
-      <point x="934" y="1116"/>
-      <point x="1258" y="780"/>
-      <point x="1258" y="541" type="qcurve"/>
-      <point x="1258" y="541" type="line"/>
-      <point x="1258" y="300"/>
-      <point x="940" y="-36"/>
+      <point x="583.6264367816" y="-36" type="qcurve" smooth="yes"/>
+      <point x="324.6264367816" y="-36"/>
+      <point x="62.6264367816" y="296"/>
+      <point x="105.6264367816" y="541" type="qcurve"/>
+      <point x="105.6264367816" y="541" type="line"/>
+      <point x="149.6264367816" y="786"/>
+      <point x="525.6264367816" y="1116"/>
+      <point x="776.6264367816" y="1116" type="qcurve" smooth="yes"/>
+      <point x="1029.6264367816" y="1116"/>
+      <point x="1300.6264367816" y="780"/>
+      <point x="1257.6264367816" y="541" type="qcurve"/>
+      <point x="1257.6264367816" y="541" type="line"/>
+      <point x="1215.6264367816" y="300"/>
+      <point x="842.6264367816" y="-36"/>
     </contour>
     <contour>
-      <point x="681" y="36" type="qcurve" smooth="yes"/>
-      <point x="890" y="36"/>
-      <point x="1170" y="318"/>
-      <point x="1170" y="541" type="qcurve"/>
-      <point x="1170" y="541" type="line"/>
-      <point x="1170" y="758"/>
-      <point x="886" y="1046"/>
-      <point x="681" y="1046" type="qcurve" smooth="yes"/>
-      <point x="476" y="1046"/>
-      <point x="190" y="766"/>
-      <point x="191" y="541" type="qcurve"/>
-      <point x="191" y="541" type="line"/>
-      <point x="190" y="316"/>
-      <point x="472" y="36"/>
+      <point x="591.6264367816" y="36" type="qcurve" smooth="yes"/>
+      <point x="800.6264367816" y="36"/>
+      <point x="1130.6264367816" y="318"/>
+      <point x="1169.6264367816" y="541" type="qcurve"/>
+      <point x="1169.6264367816" y="541" type="line"/>
+      <point x="1208.6264367816" y="758"/>
+      <point x="974.6264367816" y="1046"/>
+      <point x="769.6264367816" y="1046" type="qcurve" smooth="yes"/>
+      <point x="564.6264367816" y="1046"/>
+      <point x="229.6264367816" y="766"/>
+      <point x="190.6264367816" y="541" type="qcurve"/>
+      <point x="190.6264367816" y="541" type="line"/>
+      <point x="150.6264367816" y="316"/>
+      <point x="382.6264367816" y="36"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND0.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND0.ufo/glyphs/oslash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="1180"/>
-  <guideline x="719" y="487" angle="327.90740867126584" identifier="HUt16g0QPR"/>
+  <guideline x="719" y="487" angle="327.9074086713" identifier="HUt16g0QPR"/>
   <outline>
     <contour>
       <point x="586" y="584" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -134,7 +134,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1662"/>
   <unicode hex="004F"/>
-  <guideline x="831" y="0" angle="90" identifier="RDXGhNGcxd"/>
-  <anchor x="828" y="0" name="bottom"/>
-  <anchor x="832" y="710" name="center"/>
-  <anchor x="1082" y="0" name="ogonek"/>
-  <anchor x="832" y="1432" name="top"/>
-  <anchor x="1041" y="1432" name="topright"/>
+  <guideline x="735" y="0" angle="100" identifier="RDXGhNGcxd"/>
+  <anchor x="732" y="0" name="bottom"/>
+  <anchor x="861.19216" y="710" name="center"/>
+  <anchor x="986" y="0" name="ogonek"/>
+  <anchor x="988.50024" y="1432" name="top"/>
+  <anchor x="1197.50024" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="831" y="-38" type="qcurve" smooth="yes"/>
-      <point x="520" y="-38"/>
-      <point x="66" y="348"/>
-      <point x="67" y="718" type="qcurve"/>
-      <point x="67" y="718" type="line"/>
-      <point x="66" y="1068"/>
-      <point x="522" y="1474"/>
-      <point x="831" y="1474" type="qcurve" smooth="yes"/>
-      <point x="1140" y="1474"/>
-      <point x="1596" y="1064"/>
-      <point x="1596" y="718" type="qcurve"/>
-      <point x="1596" y="718" type="line"/>
-      <point x="1596" y="376"/>
-      <point x="1142" y="-38"/>
+      <point x="765" y="-38" type="qcurve" smooth="yes"/>
+      <point x="433" y="-38"/>
+      <point x="31" y="360"/>
+      <point x="98" y="730" type="qcurve"/>
+      <point x="98" y="730" type="line"/>
+      <point x="158" y="1080"/>
+      <point x="621" y="1474"/>
+      <point x="970" y="1474" type="qcurve" smooth="yes"/>
+      <point x="1287" y="1474"/>
+      <point x="1684" y="1044"/>
+      <point x="1626.60277" y="718" type="qcurve"/>
+      <point x="1626.60277" y="718" type="line"/>
+      <point x="1566.29894" y="376"/>
+      <point x="1064" y="-38"/>
     </contour>
     <contour>
-      <point x="831" y="360" type="qcurve" smooth="yes"/>
-      <point x="978" y="360"/>
-      <point x="1170" y="544"/>
-      <point x="1171" y="716" type="qcurve"/>
-      <point x="1171" y="716" type="line"/>
-      <point x="1170" y="880"/>
-      <point x="972" y="1070"/>
-      <point x="831" y="1071" type="qcurve" smooth="yes"/>
-      <point x="686" y="1070"/>
-      <point x="492" y="892"/>
-      <point x="492" y="716" type="qcurve"/>
-      <point x="492" y="716" type="line"/>
-      <point x="492" y="542"/>
-      <point x="690" y="360"/>
+      <point x="798.47771" y="360" type="qcurve" smooth="yes"/>
+      <point x="945.47771" y="360"/>
+      <point x="1169.92188" y="544"/>
+      <point x="1201.25012" y="716" type="qcurve"/>
+      <point x="1201.25012" y="716" type="line"/>
+      <point x="1229.16774" y="880"/>
+      <point x="1064.66987" y="1070"/>
+      <point x="923.8462" y="1071" type="qcurve" smooth="yes"/>
+      <point x="778.66987" y="1070"/>
+      <point x="553.28367" y="892"/>
+      <point x="522.25012" y="716" type="qcurve"/>
+      <point x="522.25012" y="716" type="line"/>
+      <point x="491.56922" y="542"/>
+      <point x="657.47771" y="360"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="1662"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="73" yOffset="-23"/>
+    <component base="O" identifier="9AECC0C5"/>
+    <component base="Oslash-bar" xOffset="73" yOffset="-23" identifier="9AD4BB36"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>9AD4BB36</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>9AECC0C5</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1424"/>
   <outline>
-    <component base="nine" xOffset="64"/>
+    <component base="nine" xOffset="64" identifier="4C5E65A0"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>4C5E65A0</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1444"/>
   <unicode hex="006F"/>
-  <guideline x="722" y="0" angle="90" identifier="U9jrCVUjIo"/>
-  <anchor x="723" y="0" name="bottom"/>
-  <anchor x="720" y="549" name="center"/>
-  <anchor x="993" y="0" name="ogonek"/>
-  <anchor x="722" y="1086" name="top"/>
-  <anchor x="1001" y="1086" name="topright"/>
+  <guideline x="626" y="0" angle="100" identifier="U9jrCVUjIo"/>
+  <anchor x="627" y="0" name="bottom"/>
+  <anchor x="720.80351" y="549" name="center"/>
+  <anchor x="897" y="0" name="ogonek"/>
+  <anchor x="817.4911" y="1086" name="top"/>
+  <anchor x="1096.4911" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="722" y="-44" type="qcurve" smooth="yes"/>
-      <point x="424" y="-44"/>
-      <point x="72" y="296"/>
-      <point x="72" y="550" type="qcurve"/>
-      <point x="72" y="550" type="line"/>
-      <point x="72" y="806"/>
-      <point x="430" y="1148"/>
-      <point x="722" y="1148" type="qcurve" smooth="yes"/>
-      <point x="1014" y="1148"/>
-      <point x="1374" y="798"/>
-      <point x="1374" y="550" type="qcurve"/>
-      <point x="1374" y="550" type="line"/>
-      <point x="1374" y="302"/>
-      <point x="1022" y="-44"/>
+      <point x="624" y="-44" type="qcurve" smooth="yes"/>
+      <point x="340" y="-44"/>
+      <point x="28.19279" y="296"/>
+      <point x="72.97984" y="550" type="qcurve"/>
+      <point x="72.97984" y="550" type="line"/>
+      <point x="118.11955" y="806"/>
+      <point x="515" y="1148"/>
+      <point x="814" y="1148" type="qcurve" smooth="yes"/>
+      <point x="1110" y="1148"/>
+      <point x="1418.70893" y="798"/>
+      <point x="1374.97984" y="550" type="qcurve"/>
+      <point x="1374.97984" y="550" type="line"/>
+      <point x="1331.25075" y="302"/>
+      <point x="944" y="-44"/>
     </contour>
     <contour>
-      <point x="722" y="296" type="qcurve" smooth="yes"/>
-      <point x="836" y="296"/>
-      <point x="978" y="434"/>
-      <point x="978" y="548" type="qcurve"/>
-      <point x="978" y="548" type="line"/>
-      <point x="978" y="660"/>
-      <point x="834" y="800"/>
-      <point x="722" y="800" type="qcurve" smooth="yes"/>
-      <point x="610" y="800"/>
-      <point x="466" y="660"/>
-      <point x="466" y="548" type="qcurve"/>
-      <point x="466" y="548" type="line"/>
-      <point x="466" y="434"/>
-      <point x="608" y="296"/>
+      <point x="678.19279" y="296" type="qcurve" smooth="yes"/>
+      <point x="792.19279" y="296"/>
+      <point x="958.52591" y="434"/>
+      <point x="978.62719" y="548" type="qcurve"/>
+      <point x="978.62719" y="548" type="line"/>
+      <point x="998.37581" y="660"/>
+      <point x="879" y="800"/>
+      <point x="767.06158" y="800" type="qcurve" smooth="yes"/>
+      <point x="644" y="800"/>
+      <point x="486.37581" y="660"/>
+      <point x="466.62719" y="548" type="qcurve"/>
+      <point x="466.62719" y="548" type="line"/>
+      <point x="446.52591" y="434"/>
+      <point x="564.19279" y="296"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/oslash-bar.glif
@@ -2,7 +2,7 @@
 <glyph name="oslash-bar" format="2">
   <advance width="1383"/>
   <guideline x="1211" y="515" angle="0" identifier="99Udo8Tf5Q"/>
-  <guideline x="911" y="391" angle="328.28163144569197" identifier="cxPe5eMeMA"/>
+  <guideline x="911" y="391" angle="328.2816" identifier="cxPe5eMeMA"/>
   <guideline x="731" y="105" angle="0" identifier="iPc0eUyl9n"/>
   <outline>
     <contour>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1444"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="28" yOffset="26"/>
+    <component base="o" identifier="80D64E04"/>
+    <component base="oslash-bar" xOffset="28" yOffset="26" identifier="81921421"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>80D64E04</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>81921421</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1424"/>
   <outline>
-    <component base="six" xOffset="43"/>
+    <component base="six" xOffset="43" identifier="559F89C1"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>559F89C1</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND0.ufo/fontinfo.plist
@@ -164,7 +164,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -172,7 +172,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND0.ufo/glyphs/O_.glif
@@ -1,44 +1,48 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="O" format="2">
-  <advance width="1672"/>
+  <advance width="1673"/>
   <unicode hex="004F"/>
-  <anchor x="838" y="0" name="bottom"/>
-  <anchor x="836" y="720" name="center"/>
-  <anchor x="1087" y="0" name="ogonek"/>
-  <anchor x="836" y="1432" name="top"/>
-  <anchor x="1058" y="1432" name="topright"/>
+  <guideline x="1653" y="1109" angle="80" identifier="yRrmG6phu3"/>
+  <guideline x="1446" y="1036" angle="80" identifier="GvEgeRoy6z"/>
+  <guideline x="178" y="1229" angle="80" identifier="qGa5ONEdWt"/>
+  <guideline x="368" y="1207" angle="80" identifier="Enj6pzyxsA"/>
+  <anchor x="742.6260504201681" y="0" name="bottom"/>
+  <anchor x="867.6260504201681" y="720" name="center"/>
+  <anchor x="991.6260504201681" y="0" name="ogonek"/>
+  <anchor x="993.6260504201681" y="1432" name="top"/>
+  <anchor x="1215.626050420168" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="836" y="-38" type="qcurve" smooth="yes"/>
-      <point x="510" y="-38"/>
-      <point x="88" y="386"/>
-      <point x="88" y="718" type="qcurve"/>
-      <point x="88" y="718" type="line"/>
-      <point x="88" y="1038"/>
-      <point x="518" y="1474"/>
-      <point x="836" y="1474" type="qcurve" smooth="yes"/>
-      <point x="1156" y="1474"/>
-      <point x="1584" y="1042"/>
-      <point x="1584" y="718" type="qcurve"/>
-      <point x="1584" y="718" type="line"/>
-      <point x="1584" y="396"/>
-      <point x="1156" y="-38"/>
+      <point x="747.6260504201681" y="-38" type="qcurve" smooth="yes"/>
+      <point x="421.6260504201681" y="-38"/>
+      <point x="63.62605042016807" y="399"/>
+      <point x="122.62605042016807" y="741" type="qcurve"/>
+      <point x="122.62605042016807" y="741" type="line"/>
+      <point x="178.62605042016807" y="1061"/>
+      <point x="676.6260504201681" y="1474"/>
+      <point x="993.6260504201681" y="1474" type="qcurve" smooth="yes"/>
+      <point x="1302.626050420168" y="1474"/>
+      <point x="1672.626050420168" y="1035"/>
+      <point x="1610.626050420168" y="691" type="qcurve"/>
+      <point x="1610.626050420168" y="691" type="line"/>
+      <point x="1559.626050420168" y="394"/>
+      <point x="1078.626050420168" y="-38"/>
     </contour>
     <contour>
-      <point x="836" y="130" type="qcurve" smooth="yes"/>
-      <point x="1082" y="130"/>
-      <point x="1390" y="452"/>
-      <point x="1390" y="716" type="qcurve"/>
-      <point x="1390" y="716" type="line"/>
-      <point x="1390" y="972"/>
-      <point x="1074" y="1300"/>
-      <point x="836" y="1300" type="qcurve" smooth="yes"/>
-      <point x="590" y="1300"/>
-      <point x="282" y="980"/>
-      <point x="282" y="716" type="qcurve"/>
-      <point x="282" y="716" type="line"/>
-      <point x="282" y="454"/>
-      <point x="594" y="130"/>
+      <point x="763.6260504201681" y="130" type="qcurve" smooth="yes"/>
+      <point x="1009.6260504201681" y="130"/>
+      <point x="1374.626050420168" y="452"/>
+      <point x="1421.626050420168" y="716" type="qcurve"/>
+      <point x="1421.626050420168" y="716" type="line"/>
+      <point x="1467.626050420168" y="980"/>
+      <point x="1218.626050420168" y="1300"/>
+      <point x="970.6260504201681" y="1300" type="qcurve" smooth="yes"/>
+      <point x="724.6260504201681" y="1300"/>
+      <point x="359.6260504201681" y="990"/>
+      <point x="313.6260504201681" y="716" type="qcurve"/>
+      <point x="313.6260504201681" y="716" type="line"/>
+      <point x="266.6260504201681" y="454"/>
+      <point x="521.6260504201681" y="130"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND0.ufo/glyphs/o.glif
@@ -1,44 +1,48 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o" format="2">
-  <advance width="1354"/>
+  <advance width="1356"/>
   <unicode hex="006F"/>
-  <anchor x="674" y="0" name="bottom"/>
-  <anchor x="677" y="541" name="center"/>
-  <anchor x="895" y="0" name="ogonek"/>
-  <anchor x="676" y="1086" name="top"/>
-  <anchor x="900" y="1084" name="topright"/>
+  <guideline x="1357" y="1062" angle="80" identifier="jeVJCmkYtC"/>
+  <guideline x="1177" y="1127" angle="80" identifier="4qJcJKaSQQ"/>
+  <guideline x="191" y="1134" angle="80" identifier="LuMfENZh2Q"/>
+  <guideline x="380" y="1135" angle="80" identifier="gYxo4LJmMe"/>
+  <anchor x="675.4070080862534" y="0" name="bottom"/>
+  <anchor x="678.4070080862534" y="541" name="center"/>
+  <anchor x="896.4070080862534" y="0" name="ogonek"/>
+  <anchor x="677.4070080862534" y="1086" name="top"/>
+  <anchor x="901.4070080862534" y="1084" name="topright"/>
   <outline>
     <contour>
-      <point x="676" y="-36" type="qcurve" smooth="yes"/>
-      <point x="422" y="-36"/>
-      <point x="88" y="296"/>
-      <point x="88" y="546" type="qcurve"/>
-      <point x="88" y="546" type="line"/>
-      <point x="88" y="796"/>
-      <point x="422" y="1126"/>
-      <point x="676" y="1126" type="qcurve" smooth="yes"/>
-      <point x="930" y="1126"/>
-      <point x="1266" y="794"/>
-      <point x="1266" y="546" type="qcurve"/>
-      <point x="1266" y="546" type="line"/>
-      <point x="1266" y="296"/>
-      <point x="932" y="-36"/>
+      <point x="586.4070080862534" y="-36" type="qcurve" smooth="yes"/>
+      <point x="324.40700808625337" y="-36"/>
+      <point x="45.40700808625337" y="293"/>
+      <point x="91.40700808625337" y="564" type="qcurve"/>
+      <point x="91.40700808625337" y="564" type="line"/>
+      <point x="135.40700808625337" y="813"/>
+      <point x="503.40700808625337" y="1126"/>
+      <point x="770.4070080862534" y="1126" type="qcurve" smooth="yes"/>
+      <point x="1024.4070080862534" y="1126"/>
+      <point x="1308.4070080862534" y="788"/>
+      <point x="1264.4070080862534" y="526" type="qcurve"/>
+      <point x="1264.4070080862534" y="526" type="line"/>
+      <point x="1220.4070080862534" y="276"/>
+      <point x="842.4070080862534" y="-36"/>
     </contour>
     <contour>
-      <point x="676" y="130" type="qcurve" smooth="yes"/>
-      <point x="846" y="130"/>
-      <point x="1074" y="362"/>
-      <point x="1074" y="546" type="qcurve"/>
-      <point x="1074" y="546" type="line"/>
-      <point x="1074" y="730"/>
-      <point x="846" y="962"/>
-      <point x="676" y="962" type="qcurve" smooth="yes"/>
-      <point x="506" y="962"/>
-      <point x="276" y="728"/>
-      <point x="276" y="546" type="qcurve"/>
-      <point x="276" y="546" type="line"/>
-      <point x="276" y="364"/>
-      <point x="506" y="130"/>
+      <point x="604.4070080862534" y="130" type="qcurve" smooth="yes"/>
+      <point x="774.4070080862534" y="130"/>
+      <point x="1042.4070080862534" y="355"/>
+      <point x="1074.4070080862534" y="539" type="qcurve"/>
+      <point x="1074.4070080862534" y="539" type="line"/>
+      <point x="1107.4070080862534" y="723"/>
+      <point x="921.4070080862534" y="962"/>
+      <point x="751.4070080862534" y="962" type="qcurve" smooth="yes"/>
+      <point x="581.4070080862534" y="962"/>
+      <point x="309.40700808625337" y="728"/>
+      <point x="277.40700808625337" y="546" type="qcurve"/>
+      <point x="277.40700808625337" y="546" type="line"/>
+      <point x="245.40700808625337" y="364"/>
+      <point x="434.40700808625337" y="130"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND0.ufo/fontinfo.plist
@@ -114,7 +114,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -122,7 +122,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND0.ufo/glyphs/O_.glif
@@ -2,44 +2,45 @@
 <glyph name="O" format="2">
   <advance width="2108"/>
   <unicode hex="004F"/>
-  <guideline x="799" y="918" angle="90" identifier="vAQBnndVqv"/>
-  <anchor x="1057" y="0" name="bottom"/>
-  <anchor x="1055" y="716" name="center"/>
-  <anchor x="1390" y="0" name="ogonek"/>
-  <anchor x="1057" y="1432" name="top"/>
-  <anchor x="1277" y="1432" name="topright"/>
+  <guideline x="2052" y="1256" angle="80" identifier="vAQBnndVqv"/>
+  <guideline x="400" y="1261" angle="80" identifier="6bc2u6FqfV"/>
+  <anchor x="961" y="0" name="bottom"/>
+  <anchor x="1086" y="716" name="center"/>
+  <anchor x="1294" y="0" name="ogonek"/>
+  <anchor x="1214" y="1432" name="top"/>
+  <anchor x="1434" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1054" y="-50" type="qcurve" smooth="yes"/>
-      <point x="672" y="-50"/>
-      <point x="179" y="383"/>
-      <point x="180" y="718" type="qcurve"/>
-      <point x="180" y="718" type="line"/>
-      <point x="179" y="1053"/>
-      <point x="672" y="1486"/>
-      <point x="1054" y="1486" type="qcurve" smooth="yes"/>
-      <point x="1436" y="1486"/>
-      <point x="1929" y="1053"/>
-      <point x="1928" y="718" type="qcurve"/>
-      <point x="1928" y="718" type="line"/>
-      <point x="1929" y="383"/>
-      <point x="1437" y="-50"/>
+      <point x="949" y="-50" type="qcurve"/>
+      <point x="579" y="-50"/>
+      <point x="152" y="395"/>
+      <point x="210" y="718" type="qcurve"/>
+      <point x="210" y="718" type="line"/>
+      <point x="269" y="1053"/>
+      <point x="837" y="1486"/>
+      <point x="1218" y="1486" type="qcurve"/>
+      <point x="1596" y="1486"/>
+      <point x="2015" y="1048"/>
+      <point x="1957" y="718" type="qcurve"/>
+      <point x="1958" y="718" type="line"/>
+      <point x="1901" y="383"/>
+      <point x="1333" y="-50"/>
     </contour>
     <contour>
-      <point x="1054" y="34" type="qcurve" smooth="yes"/>
-      <point x="1395" y="35"/>
-      <point x="1835" y="417"/>
-      <point x="1835" y="716" type="qcurve"/>
-      <point x="1835" y="716" type="line"/>
-      <point x="1835" y="1014"/>
-      <point x="1395" y="1401"/>
-      <point x="1054" y="1402" type="qcurve" smooth="yes"/>
-      <point x="713" y="1401"/>
-      <point x="273" y="1015"/>
-      <point x="273" y="718" type="qcurve"/>
-      <point x="273" y="718" type="line"/>
-      <point x="273" y="418"/>
-      <point x="713" y="35"/>
+      <point x="963" y="34" type="qcurve"/>
+      <point x="1306" y="35"/>
+      <point x="1813" y="417"/>
+      <point x="1865" y="716" type="qcurve"/>
+      <point x="1865" y="716" type="line"/>
+      <point x="1923" y="1015"/>
+      <point x="1563" y="1402"/>
+      <point x="1205" y="1402" type="qcurve"/>
+      <point x="864" y="1401"/>
+      <point x="360" y="1032"/>
+      <point x="303" y="718" type="qcurve"/>
+      <point x="303" y="718" type="line"/>
+      <point x="249" y="415"/>
+      <point x="614" y="34"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND0.ufo/glyphs/o.glif
@@ -2,44 +2,47 @@
 <glyph name="o" format="2">
   <advance width="1748"/>
   <unicode hex="006F"/>
-  <guideline x="769" y="620" angle="90" identifier="4jR7yfcmiK"/>
-  <anchor x="877" y="0" name="bottom"/>
-  <anchor x="871" y="534" name="center"/>
-  <anchor x="1189" y="0" name="ogonek"/>
-  <anchor x="874" y="1086" name="top"/>
-  <anchor x="1174" y="1086" name="topright"/>
+  <guideline x="1483" y="-45" angle="80" identifier="4jR7yfcmiK"/>
+  <guideline x="1405" y="30" angle="80" identifier="S1PPhALBtK"/>
+  <guideline x="90" y="143" angle="80" identifier="jwwoQ9YMZV"/>
+  <guideline x="170" y="76" angle="80" identifier="g6CFW4giXf"/>
+  <anchor x="781" y="0" name="bottom"/>
+  <anchor x="869" y="534" name="center"/>
+  <anchor x="1093" y="0" name="ogonek"/>
+  <anchor x="969" y="1086" name="top"/>
+  <anchor x="1269" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="874" y="-52" type="qcurve" smooth="yes"/>
-      <point x="562" y="-52"/>
-      <point x="160" y="279"/>
-      <point x="160" y="535" type="qcurve"/>
-      <point x="160" y="535" type="line"/>
-      <point x="160" y="791"/>
-      <point x="562" y="1122"/>
-      <point x="874" y="1122" type="qcurve" smooth="yes"/>
-      <point x="1186" y="1122"/>
-      <point x="1588" y="791"/>
-      <point x="1588" y="535" type="qcurve"/>
-      <point x="1588" y="535" type="line"/>
-      <point x="1588" y="279"/>
-      <point x="1187" y="-52"/>
+      <point x="784" y="-52" type="qcurve" smooth="yes"/>
+      <point x="472" y="-52"/>
+      <point x="114" y="281"/>
+      <point x="160" y="548" type="qcurve"/>
+      <point x="160" y="548" type="line"/>
+      <point x="205" y="804"/>
+      <point x="646" y="1122"/>
+      <point x="970" y="1122" type="qcurve" smooth="yes"/>
+      <point x="1305" y="1122"/>
+      <point x="1628" y="781"/>
+      <point x="1584" y="528" type="qcurve"/>
+      <point x="1584" y="528" type="line"/>
+      <point x="1539" y="272"/>
+      <point x="1105" y="-52"/>
     </contour>
     <contour>
-      <point x="874" y="24" type="qcurve" smooth="yes"/>
-      <point x="1145" y="24"/>
-      <point x="1495" y="312"/>
-      <point x="1495" y="535" type="qcurve"/>
-      <point x="1495" y="535" type="line"/>
-      <point x="1495" y="758"/>
-      <point x="1145" y="1046"/>
-      <point x="874" y="1046" type="qcurve" smooth="yes"/>
-      <point x="602" y="1046"/>
-      <point x="252" y="758"/>
-      <point x="253" y="535" type="qcurve"/>
-      <point x="253" y="535" type="line"/>
-      <point x="252" y="312"/>
-      <point x="602" y="24"/>
+      <point x="790" y="24" type="qcurve" smooth="yes"/>
+      <point x="1077" y="24"/>
+      <point x="1452" y="292"/>
+      <point x="1493" y="532" type="qcurve"/>
+      <point x="1493" y="532" type="line"/>
+      <point x="1536" y="767"/>
+      <point x="1248" y="1046"/>
+      <point x="962" y="1046" type="qcurve" smooth="yes"/>
+      <point x="690" y="1046"/>
+      <point x="294" y="779"/>
+      <point x="251" y="535" type="qcurve"/>
+      <point x="251" y="535" type="line"/>
+      <point x="209" y="300"/>
+      <point x="518" y="24"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/fontinfo.plist
@@ -114,7 +114,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -122,7 +122,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,47 @@
 <glyph name="O" format="2">
   <advance width="2084"/>
   <unicode hex="004F"/>
-  <anchor x="1041" y="0" name="bottom"/>
-  <anchor x="1041" y="709" name="center"/>
-  <anchor x="1434" y="0" name="ogonek"/>
-  <anchor x="1041" y="1432" name="top"/>
-  <anchor x="1276" y="1432" name="topright"/>
+  <guideline x="1467" y="307" angle="80" identifier="HEQt3zMECI"/>
+  <guideline x="44" y="0" angle="80" identifier="ehzHj5yHAt"/>
+  <guideline x="530" y="282" angle="80" identifier="1a2gOQsyBq"/>
+  <guideline x="1849" y="0" angle="80" identifier="h2jOsBBf1h"/>
+  <anchor x="945" y="0" name="bottom"/>
+  <anchor x="1070" y="709" name="center"/>
+  <anchor x="1338" y="0" name="ogonek"/>
+  <anchor x="1198" y="1432" name="top"/>
+  <anchor x="1433" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1042" y="-67" type="qcurve" smooth="yes"/>
-      <point x="647" y="-67"/>
-      <point x="139" y="370"/>
-      <point x="140" y="708" type="qcurve"/>
-      <point x="140" y="708" type="line"/>
-      <point x="139" y="1049"/>
-      <point x="647" y="1489"/>
-      <point x="1042" y="1489" type="qcurve" smooth="yes"/>
-      <point x="1435" y="1489"/>
-      <point x="1944" y="1049"/>
-      <point x="1944" y="708" type="qcurve"/>
-      <point x="1944" y="708" type="line"/>
-      <point x="1944" y="370"/>
-      <point x="1435" y="-67"/>
+      <point x="975" y="-67" type="qcurve" smooth="yes"/>
+      <point x="545" y="-67"/>
+      <point x="114" y="396"/>
+      <point x="174" y="734" type="qcurve"/>
+      <point x="174" y="734" type="line"/>
+      <point x="233" y="1075"/>
+      <point x="803" y="1489"/>
+      <point x="1176" y="1489" type="qcurve" smooth="yes"/>
+      <point x="1591" y="1489"/>
+      <point x="2033" y="1046"/>
+      <point x="1969" y="682" type="qcurve"/>
+      <point x="1969" y="682" type="line"/>
+      <point x="1912" y="356"/>
+      <point x="1368" y="-67"/>
     </contour>
     <contour>
-      <point x="1040" y="346" type="qcurve" smooth="yes"/>
-      <point x="1244" y="346"/>
-      <point x="1507" y="549"/>
-      <point x="1508" y="706" type="qcurve"/>
-      <point x="1508" y="706" type="line"/>
-      <point x="1507" y="864"/>
-      <point x="1244" y="1070"/>
-      <point x="1040" y="1071" type="qcurve" smooth="yes"/>
-      <point x="837" y="1070"/>
-      <point x="575" y="864"/>
-      <point x="575" y="706" type="qcurve"/>
-      <point x="575" y="706" type="line"/>
-      <point x="575" y="549"/>
-      <point x="837" y="346"/>
+      <point x="1016" y="346" type="qcurve" smooth="yes"/>
+      <point x="1225" y="346"/>
+      <point x="1508" y="540"/>
+      <point x="1537" y="697" type="qcurve"/>
+      <point x="1537" y="697" type="line"/>
+      <point x="1564" y="855"/>
+      <point x="1332" y="1070"/>
+      <point x="1128" y="1071" type="qcurve" smooth="yes"/>
+      <point x="913" y="1072"/>
+      <point x="635" y="873"/>
+      <point x="607" y="715" type="qcurve"/>
+      <point x="607" y="715" type="line"/>
+      <point x="579" y="558"/>
+      <point x="813" y="346"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="2084"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="287" yOffset="-42"/>
+    <component base="O" identifier="CDF0B5BE"/>
+    <component base="Oslash-bar" xOffset="287" yOffset="-42" identifier="94D58BC4"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>94D58BC4</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>CDF0B5BE</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1760"/>
   <outline>
-    <component base="nine" xOffset="-30"/>
+    <component base="nine" xOffset="-30" identifier="BC32B806"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>BC32B806</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,47 @@
 <glyph name="o" format="2">
   <advance width="1760"/>
   <unicode hex="006F"/>
-  <anchor x="881" y="0" name="bottom"/>
+  <guideline x="1534" y="0" angle="79.9765" identifier="1SjVzdANgF"/>
+  <guideline x="34" y="0" angle="79.9765" identifier="67nxylOcaC"/>
+  <guideline x="1162" y="122" angle="79.9765" identifier="kdH6L98d2c"/>
+  <guideline x="454" y="144" angle="79.9765" identifier="Sn0XzYeAnu"/>
+  <anchor x="785" y="0" name="bottom"/>
   <anchor x="880" y="548" name="center"/>
-  <anchor x="1241" y="0" name="ogonek"/>
-  <anchor x="880" y="1086" name="top"/>
-  <anchor x="1159" y="1086" name="topright"/>
+  <anchor x="1145" y="0" name="ogonek"/>
+  <anchor x="975" y="1086" name="top"/>
+  <anchor x="1254" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="880" y="-67" type="qcurve" smooth="yes"/>
-      <point x="553" y="-67"/>
-      <point x="130" y="281"/>
-      <point x="130" y="550" type="qcurve"/>
-      <point x="130" y="550" type="line"/>
-      <point x="130" y="814"/>
-      <point x="553" y="1154"/>
-      <point x="880" y="1154" type="qcurve" smooth="yes"/>
-      <point x="1207" y="1154"/>
-      <point x="1630" y="814"/>
-      <point x="1630" y="550" type="qcurve"/>
-      <point x="1630" y="550" type="line"/>
-      <point x="1630" y="281"/>
-      <point x="1207" y="-67"/>
+      <point x="801" y="-67" type="qcurve" smooth="yes"/>
+      <point x="472" y="-67"/>
+      <point x="86" y="299"/>
+      <point x="134" y="568" type="qcurve"/>
+      <point x="134" y="568" type="line"/>
+      <point x="180" y="832"/>
+      <point x="618" y="1154"/>
+      <point x="965" y="1154" type="qcurve" smooth="yes"/>
+      <point x="1303" y="1154"/>
+      <point x="1672" y="786"/>
+      <point x="1626" y="522" type="qcurve"/>
+      <point x="1626" y="522" type="line"/>
+      <point x="1578" y="253"/>
+      <point x="1146" y="-67"/>
     </contour>
     <contour>
-      <point x="880" y="273" type="qcurve" smooth="yes"/>
-      <point x="1035" y="273"/>
-      <point x="1236" y="431"/>
-      <point x="1236" y="552" type="qcurve"/>
-      <point x="1236" y="552" type="line"/>
-      <point x="1236" y="666"/>
-      <point x="1035" y="814"/>
-      <point x="880" y="814" type="qcurve" smooth="yes"/>
-      <point x="725" y="814"/>
-      <point x="524" y="666"/>
-      <point x="524" y="552" type="qcurve"/>
-      <point x="524" y="552" type="line"/>
-      <point x="524" y="431"/>
-      <point x="725" y="273"/>
+      <point x="837" y="273" type="qcurve" smooth="yes"/>
+      <point x="1000" y="273"/>
+      <point x="1213" y="421"/>
+      <point x="1234" y="542" type="qcurve"/>
+      <point x="1234" y="542" type="line"/>
+      <point x="1254" y="656"/>
+      <point x="1078" y="814"/>
+      <point x="926" y="814" type="qcurve" smooth="yes"/>
+      <point x="766" y="814"/>
+      <point x="545" y="665"/>
+      <point x="525" y="551" type="qcurve"/>
+      <point x="525" y="551" type="line"/>
+      <point x="505" y="426"/>
+      <point x="688" y="273"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1760"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="179" yOffset="29"/>
+    <component base="o" identifier="7BD9F402"/>
+    <component base="oslash-bar" xOffset="179" yOffset="29" identifier="74839B4D"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>74839B4D</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>7BD9F402</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1760"/>
   <outline>
-    <component base="six" xOffset="-10"/>
+    <component base="six" xOffset="-10" identifier="38F99D4E"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>38F99D4E</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/fontinfo.plist
@@ -108,7 +108,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -116,7 +116,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/glyphs/O_.glif
@@ -2,43 +2,45 @@
 <glyph name="O" format="2">
   <advance width="2072"/>
   <unicode hex="004F"/>
-  <anchor x="1036" y="0" name="bottom"/>
-  <anchor x="1048" y="718" name="center"/>
-  <anchor x="1371" y="0" name="ogonek"/>
-  <anchor x="1056" y="1432" name="top"/>
-  <anchor x="1266" y="1432" name="topright"/>
+  <guideline x="1862" y="377" angle="79.9661" identifier="DGu7dGYzqD"/>
+  <guideline x="123" y="215" angle="79.9661" identifier="30wxDxhCYL"/>
+  <anchor x="940" y="0" name="bottom"/>
+  <anchor x="1079" y="718" name="center"/>
+  <anchor x="1275" y="0" name="ogonek"/>
+  <anchor x="1213" y="1432" name="top"/>
+  <anchor x="1423" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1043" y="-62" type="qcurve" smooth="yes"/>
-      <point x="667" y="-62"/>
-      <point x="181" y="377"/>
-      <point x="181" y="718" type="qcurve"/>
-      <point x="181" y="718" type="line"/>
-      <point x="181" y="1059"/>
-      <point x="667" y="1498"/>
-      <point x="1043" y="1498" type="qcurve" smooth="yes"/>
-      <point x="1413" y="1498"/>
-      <point x="1891" y="1059"/>
-      <point x="1891" y="718" type="qcurve"/>
-      <point x="1891" y="718" type="line"/>
-      <point x="1891" y="377"/>
-      <point x="1413" y="-62"/>
+      <point x="959" y="-62" type="qcurve" smooth="yes"/>
+      <point x="568" y="-62"/>
+      <point x="154" y="388"/>
+      <point x="214" y="729" type="qcurve"/>
+      <point x="214" y="729" type="line"/>
+      <point x="274" y="1070"/>
+      <point x="805" y="1498"/>
+      <point x="1193" y="1498" type="qcurve" smooth="yes"/>
+      <point x="1576" y="1498"/>
+      <point x="1981" y="1048"/>
+      <point x="1921" y="707" type="qcurve"/>
+      <point x="1921" y="707" type="line"/>
+      <point x="1861" y="366"/>
+      <point x="1330" y="-62"/>
     </contour>
     <contour>
-      <point x="1039" y="123" type="qcurve" smooth="yes"/>
-      <point x="1323" y="123"/>
-      <point x="1689" y="458"/>
-      <point x="1689" y="716" type="qcurve"/>
-      <point x="1689" y="716" type="line"/>
-      <point x="1689" y="974"/>
-      <point x="1323" y="1307"/>
-      <point x="1039" y="1307" type="qcurve" smooth="yes"/>
-      <point x="753" y="1307"/>
-      <point x="383" y="974"/>
-      <point x="383" y="716" type="qcurve"/>
-      <point x="383" y="716" type="line"/>
-      <point x="383" y="458"/>
-      <point x="753" y="123"/>
+      <point x="965" y="123" type="qcurve" smooth="yes"/>
+      <point x="1249" y="123"/>
+      <point x="1674" y="458"/>
+      <point x="1720" y="716" type="qcurve"/>
+      <point x="1720" y="716" type="line"/>
+      <point x="1765" y="974"/>
+      <point x="1473" y="1307"/>
+      <point x="1174" y="1307" type="qcurve" smooth="yes"/>
+      <point x="888" y="1307"/>
+      <point x="459" y="974"/>
+      <point x="414" y="716" type="qcurve"/>
+      <point x="414" y="716" type="line"/>
+      <point x="368" y="458"/>
+      <point x="677" y="123"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="2072"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="369" yOffset="-34"/>
+    <component base="O" identifier="965481C9"/>
+    <component base="Oslash-bar" xOffset="369" yOffset="-34" identifier="23E8D30A"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>23E8D30A</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>965481C9</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1991"/>
   <outline>
-    <component base="nine" xOffset="232"/>
+    <component base="nine" xOffset="232" identifier="F6866929"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>F6866929</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1681"/>
   <unicode hex="006F"/>
-  <anchor x="838" y="0" name="bottom"/>
+  <guideline x="1508" y="546" angle="79.9284" identifier="dooXMhCbFK"/>
+  <anchor x="743" y="0" name="bottom"/>
   <anchor x="838" y="538" name="center"/>
-  <anchor x="1146" y="0" name="ogonek"/>
-  <anchor x="839" y="1086" name="top"/>
-  <anchor x="1153" y="1086" name="topright"/>
+  <anchor x="1051" y="0" name="ogonek"/>
+  <anchor x="935" y="1086" name="top"/>
+  <anchor x="1249" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="835" y="-56" type="qcurve" smooth="yes"/>
-      <point x="546" y="-56"/>
-      <point x="174" y="283"/>
-      <point x="174" y="546" type="qcurve"/>
-      <point x="174" y="546" type="line"/>
-      <point x="174" y="810"/>
-      <point x="546" y="1150"/>
-      <point x="835" y="1150" type="qcurve" smooth="yes"/>
-      <point x="1128" y="1150"/>
-      <point x="1507" y="810"/>
-      <point x="1507" y="546" type="qcurve"/>
-      <point x="1507" y="546" type="line"/>
-      <point x="1507" y="283"/>
-      <point x="1128" y="-56"/>
+      <point x="750" y="-56" type="qcurve" smooth="yes"/>
+      <point x="461" y="-56"/>
+      <point x="129" y="283"/>
+      <point x="175" y="546" type="qcurve"/>
+      <point x="175" y="546" type="line"/>
+      <point x="224" y="820"/>
+      <point x="637" y="1150"/>
+      <point x="939" y="1150" type="qcurve" smooth="yes"/>
+      <point x="1228" y="1150"/>
+      <point x="1555" y="810"/>
+      <point x="1506" y="537" type="qcurve"/>
+      <point x="1506" y="537" type="line"/>
+      <point x="1460" y="274"/>
+      <point x="1045" y="-56"/>
     </contour>
     <contour>
-      <point x="835" y="118" type="qcurve" smooth="yes"/>
-      <point x="1039" y="118"/>
-      <point x="1304" y="359"/>
-      <point x="1304" y="546" type="qcurve"/>
-      <point x="1304" y="546" type="line"/>
-      <point x="1304" y="733"/>
-      <point x="1039" y="974"/>
-      <point x="835" y="974" type="qcurve" smooth="yes"/>
-      <point x="636" y="974"/>
-      <point x="376" y="733"/>
-      <point x="376" y="546" type="qcurve"/>
-      <point x="376" y="546" type="line"/>
-      <point x="376" y="359"/>
-      <point x="636" y="118"/>
+      <point x="761" y="118" type="qcurve" smooth="yes"/>
+      <point x="967" y="118"/>
+      <point x="1272" y="359"/>
+      <point x="1305" y="546" type="qcurve"/>
+      <point x="1305" y="546" type="line"/>
+      <point x="1338" y="733"/>
+      <point x="1121" y="974"/>
+      <point x="912" y="974" type="qcurve" smooth="yes"/>
+      <point x="706" y="974"/>
+      <point x="411" y="738"/>
+      <point x="377" y="546" type="qcurve"/>
+      <point x="377" y="546" type="line"/>
+      <point x="344" y="359"/>
+      <point x="559" y="118"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1681"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="214" yOffset="17"/>
+    <component base="o" identifier="596BEFAD"/>
+    <component base="oslash-bar" xOffset="214" yOffset="17" identifier="253C1E24"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>253C1E24</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>596BEFAD</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1991"/>
   <outline>
-    <component base="six" xOffset="206"/>
+    <component base="six" xOffset="206" identifier="AE2178AC"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>AE2178AC</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/fontinfo.plist
@@ -106,7 +106,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -114,7 +114,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="1060"/>
   <unicode hex="004F"/>
   <guideline x="523" y="877" angle="90" identifier="hCn79dkbgY"/>
-  <anchor x="504" y="0" name="bottom"/>
-  <anchor x="523" y="727" name="center"/>
-  <anchor x="664" y="0" name="ogonek"/>
-  <anchor x="521" y="1431" name="top"/>
-  <anchor x="724" y="1432" name="topright"/>
+  <anchor x="409" y="0" name="bottom"/>
+  <anchor x="556" y="727" name="center"/>
+  <anchor x="569" y="0" name="ogonek"/>
+  <anchor x="678" y="1431" name="top"/>
+  <anchor x="881" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="530" y="-26" type="qcurve" smooth="yes"/>
-      <point x="344" y="-26"/>
-      <point x="96" y="304"/>
-      <point x="96" y="718" type="qcurve"/>
-      <point x="96" y="718" type="line"/>
-      <point x="96" y="1120"/>
-      <point x="346" y="1460"/>
-      <point x="530" y="1460" type="qcurve" smooth="yes"/>
-      <point x="714" y="1460"/>
-      <point x="964" y="1122"/>
-      <point x="964" y="718" type="qcurve"/>
-      <point x="964" y="718" type="line"/>
-      <point x="964" y="326"/>
-      <point x="716" y="-26"/>
+      <point x="444" y="-26" type="qcurve" smooth="yes"/>
+      <point x="256" y="-26"/>
+      <point x="56" y="304"/>
+      <point x="129" y="732" type="qcurve"/>
+      <point x="129" y="732" type="line"/>
+      <point x="200" y="1120"/>
+      <point x="495" y="1460"/>
+      <point x="679" y="1460" type="qcurve" smooth="yes"/>
+      <point x="870" y="1460"/>
+      <point x="1063" y="1122"/>
+      <point x="992" y="704" type="qcurve"/>
+      <point x="992" y="704" type="line"/>
+      <point x="923" y="326"/>
+      <point x="637" y="-26"/>
     </contour>
     <contour>
-      <point x="528" y="48" type="qcurve" smooth="yes"/>
-      <point x="686" y="48"/>
-      <point x="876" y="360"/>
-      <point x="876" y="716" type="qcurve"/>
-      <point x="876" y="716" type="line"/>
-      <point x="876" y="1072"/>
-      <point x="682" y="1384"/>
-      <point x="528" y="1384" type="qcurve" smooth="yes"/>
-      <point x="368" y="1384"/>
-      <point x="184" y="1084"/>
-      <point x="184" y="716" type="qcurve"/>
-      <point x="184" y="716" type="line"/>
-      <point x="184" y="358"/>
-      <point x="376" y="48"/>
+      <point x="441" y="48" type="qcurve" smooth="yes"/>
+      <point x="599" y="48"/>
+      <point x="844" y="360"/>
+      <point x="907" y="716" type="qcurve"/>
+      <point x="907" y="716" type="line"/>
+      <point x="970" y="1072"/>
+      <point x="831" y="1384"/>
+      <point x="677" y="1384" type="qcurve" smooth="yes"/>
+      <point x="517" y="1384"/>
+      <point x="280" y="1084"/>
+      <point x="215" y="716" type="qcurve"/>
+      <point x="215" y="716" type="line"/>
+      <point x="152" y="358"/>
+      <point x="289" y="48"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/O_slash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Oslash-bar" format="2">
   <advance width="1286"/>
-  <guideline x="991" y="1446" angle="336.3706222693432" identifier="s271xkKS2H"/>
+  <guideline x="991" y="1446" angle="336.3706" identifier="s271xkKS2H"/>
   <outline>
     <contour>
       <point x="628" y="756" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="1060"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="-131" yOffset="7"/>
+    <component base="O" identifier="1EE53835"/>
+    <component base="Oslash-bar" xOffset="-131" yOffset="7" identifier="C7C1AD24"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>1EE53835</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>C7C1AD24</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1034"/>
   <outline>
-    <component base="nine" xOffset="89"/>
+    <component base="nine" xOffset="89" identifier="5D3ED66D"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>5D3ED66D</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/o.glif
@@ -3,43 +3,44 @@
   <advance width="948"/>
   <unicode hex="006F"/>
   <guideline x="473" y="618" angle="90" identifier="575UkyT4Po"/>
-  <anchor x="472" y="0" name="bottom"/>
+  <guideline x="874" y="552" angle="79.9617" identifier="sQiZLEnMeU"/>
+  <anchor x="376" y="0" name="bottom"/>
   <anchor x="473" y="540" name="center"/>
-  <anchor x="582" y="0" name="ogonek"/>
-  <anchor x="473" y="1086" name="top"/>
-  <anchor x="708" y="1086" name="topright"/>
+  <anchor x="486" y="0" name="ogonek"/>
+  <anchor x="569" y="1086" name="top"/>
+  <anchor x="804" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="472" y="-16" type="qcurve" smooth="yes"/>
-      <point x="296" y="-16"/>
-      <point x="76" y="284"/>
-      <point x="76" y="552" type="qcurve"/>
-      <point x="76" y="552" type="line"/>
-      <point x="76" y="822"/>
-      <point x="300" y="1112"/>
-      <point x="472" y="1112" type="qcurve" smooth="yes"/>
-      <point x="646" y="1112"/>
-      <point x="872" y="814"/>
-      <point x="872" y="552" type="qcurve"/>
-      <point x="872" y="552" type="line"/>
-      <point x="872" y="288"/>
-      <point x="654" y="-16"/>
+      <point x="388" y="-16" type="qcurve" smooth="yes"/>
+      <point x="202" y="-16"/>
+      <point x="30" y="283"/>
+      <point x="78" y="552" type="qcurve"/>
+      <point x="78" y="552" type="line"/>
+      <point x="124" y="814"/>
+      <point x="386" y="1112"/>
+      <point x="568" y="1112" type="qcurve" smooth="yes"/>
+      <point x="742" y="1112"/>
+      <point x="923" y="826"/>
+      <point x="873" y="541" type="qcurve"/>
+      <point x="873" y="541" type="line"/>
+      <point x="828" y="290"/>
+      <point x="573" y="-16"/>
     </contour>
     <contour>
-      <point x="474" y="60" type="qcurve" smooth="yes"/>
-      <point x="642" y="60"/>
-      <point x="788" y="330"/>
-      <point x="788" y="552" type="qcurve"/>
-      <point x="788" y="552" type="line"/>
-      <point x="788" y="772"/>
-      <point x="630" y="1036"/>
-      <point x="474" y="1036" type="qcurve" smooth="yes"/>
-      <point x="322" y="1036"/>
-      <point x="160" y="778"/>
-      <point x="160" y="552" type="qcurve"/>
-      <point x="160" y="552" type="line"/>
-      <point x="160" y="326"/>
-      <point x="310" y="60"/>
+      <point x="389" y="60" type="qcurve" smooth="yes"/>
+      <point x="548" y="60"/>
+      <point x="751" y="330"/>
+      <point x="790" y="552" type="qcurve"/>
+      <point x="790" y="552" type="line"/>
+      <point x="829" y="772"/>
+      <point x="724" y="1036"/>
+      <point x="561" y="1036" type="qcurve" smooth="yes"/>
+      <point x="400" y="1036"/>
+      <point x="202" y="778"/>
+      <point x="162" y="552" type="qcurve"/>
+      <point x="162" y="552" type="line"/>
+      <point x="122" y="326"/>
+      <point x="233" y="60"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="948"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-84" yOffset="-10"/>
+    <component base="o" identifier="A30D0D37"/>
+    <component base="oslash-bar" xOffset="-84" yOffset="-10" identifier="B07532F1"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>A30D0D37</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>B07532F1</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1034"/>
   <outline>
-    <component base="six" xOffset="61"/>
+    <component base="six" xOffset="61" identifier="32126B95"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>32126B95</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/fontinfo.plist
@@ -128,7 +128,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -136,7 +136,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="1264"/>
   <unicode hex="004F"/>
   <guideline x="632" y="845" angle="90" identifier="AkOzOIbi01"/>
-  <anchor x="630" y="0" name="bottom"/>
-  <anchor x="634" y="718" name="center"/>
-  <anchor x="809" y="0" name="ogonek"/>
-  <anchor x="632" y="1432" name="top"/>
-  <anchor x="826" y="1432" name="topright"/>
+  <anchor x="535" y="0" name="bottom"/>
+  <anchor x="665" y="718" name="center"/>
+  <anchor x="714" y="0" name="ogonek"/>
+  <anchor x="789" y="1432" name="top"/>
+  <anchor x="983" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="632" y="-30" type="qcurve" smooth="yes"/>
-      <point x="406" y="-30"/>
-      <point x="66" y="294"/>
-      <point x="66" y="718" type="qcurve"/>
-      <point x="66" y="718" type="line"/>
-      <point x="66" y="1132"/>
-      <point x="412" y="1464"/>
-      <point x="632" y="1464" type="qcurve" smooth="yes"/>
-      <point x="852" y="1464"/>
-      <point x="1198" y="1126"/>
-      <point x="1198" y="718" type="qcurve"/>
-      <point x="1198" y="718" type="line"/>
-      <point x="1198" y="322"/>
-      <point x="858" y="-30"/>
+      <point x="552" y="-30" type="qcurve" smooth="yes"/>
+      <point x="308" y="-30"/>
+      <point x="32" y="326"/>
+      <point x="101" y="751" type="qcurve"/>
+      <point x="101" y="751" type="line"/>
+      <point x="174" y="1130"/>
+      <point x="530" y="1464"/>
+      <point x="776" y="1464" type="qcurve" smooth="yes"/>
+      <point x="1006" y="1464"/>
+      <point x="1298" y="1126"/>
+      <point x="1226" y="692" type="qcurve"/>
+      <point x="1226" y="692" type="line"/>
+      <point x="1156" y="322"/>
+      <point x="816" y="-30"/>
     </contour>
     <contour>
-      <point x="632" y="368" type="qcurve" smooth="yes"/>
-      <point x="702" y="368"/>
-      <point x="774" y="508"/>
-      <point x="774" y="716" type="qcurve"/>
-      <point x="774" y="716" type="line"/>
-      <point x="774" y="924"/>
-      <point x="698" y="1062"/>
-      <point x="632" y="1062" type="qcurve" smooth="yes"/>
-      <point x="560" y="1062"/>
-      <point x="490" y="936"/>
-      <point x="490" y="716" type="qcurve"/>
-      <point x="490" y="716" type="line"/>
-      <point x="490" y="508"/>
-      <point x="566" y="368"/>
+      <point x="609" y="368" type="qcurve" smooth="yes"/>
+      <point x="679" y="368"/>
+      <point x="768" y="508"/>
+      <point x="805" y="716" type="qcurve"/>
+      <point x="805" y="716" type="line"/>
+      <point x="841" y="924"/>
+      <point x="787" y="1062"/>
+      <point x="717" y="1062" type="qcurve" smooth="yes"/>
+      <point x="644" y="1062"/>
+      <point x="560" y="936"/>
+      <point x="521" y="716" type="qcurve"/>
+      <point x="521" y="716" type="line"/>
+      <point x="484" y="508"/>
+      <point x="538" y="368"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/O_slash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Oslash-bar" format="2">
   <advance width="1492"/>
-  <guideline x="1230" y="1488" angle="336.8857920166732" identifier="507i0lbHVs"/>
+  <guideline x="1230" y="1488" angle="336.8858" identifier="507i0lbHVs"/>
   <outline>
     <contour>
       <point x="587" y="801" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="1264"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="-60" yOffset="-39"/>
+    <component base="O" identifier="94556DD7"/>
+    <component base="Oslash-bar" xOffset="-60" yOffset="-39" identifier="D4AF1006"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>94556DD7</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>D4AF1006</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1168"/>
   <outline>
-    <component base="nine" xOffset="60"/>
+    <component base="nine" xOffset="60" identifier="1D8A9FD8"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>1D8A9FD8</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/o.glif
@@ -3,43 +3,43 @@
   <advance width="1184"/>
   <unicode hex="006F"/>
   <guideline x="591" y="641" angle="90" identifier="zm9FAH9zGL"/>
-  <anchor x="592" y="0" name="bottom"/>
-  <anchor x="591" y="552" name="center"/>
-  <anchor x="801" y="0" name="ogonek"/>
-  <anchor x="592" y="1086" name="top"/>
-  <anchor x="872" y="1086" name="topright"/>
+  <anchor x="497" y="0" name="bottom"/>
+  <anchor x="593" y="552" name="center"/>
+  <anchor x="706" y="0" name="ogonek"/>
+  <anchor x="688" y="1086" name="top"/>
+  <anchor x="968" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="592" y="-36" type="qcurve" smooth="yes"/>
-      <point x="348" y="-36"/>
-      <point x="66" y="280"/>
-      <point x="66" y="553" type="qcurve"/>
-      <point x="66" y="553" type="line"/>
-      <point x="66" y="826"/>
-      <point x="356" y="1138"/>
-      <point x="592" y="1138" type="qcurve" smooth="yes"/>
-      <point x="830" y="1138"/>
-      <point x="1118" y="818"/>
-      <point x="1118" y="553" type="qcurve"/>
-      <point x="1118" y="553" type="line"/>
-      <point x="1118" y="286"/>
-      <point x="838" y="-36"/>
+      <point x="502" y="-36" type="qcurve" smooth="yes"/>
+      <point x="270" y="-36"/>
+      <point x="20" y="280"/>
+      <point x="68" y="553" type="qcurve"/>
+      <point x="68" y="553" type="line"/>
+      <point x="118" y="837"/>
+      <point x="418" y="1138"/>
+      <point x="689" y="1138" type="qcurve" smooth="yes"/>
+      <point x="921" y="1138"/>
+      <point x="1168" y="826"/>
+      <point x="1120" y="553" type="qcurve"/>
+      <point x="1120" y="553" type="line"/>
+      <point x="1072" y="282"/>
+      <point x="778" y="-36"/>
     </contour>
     <contour>
-      <point x="593" y="295" type="qcurve" smooth="yes"/>
-      <point x="678" y="296"/>
-      <point x="724" y="430"/>
-      <point x="725" y="550" type="qcurve"/>
-      <point x="725" y="550" type="line"/>
-      <point x="724" y="672"/>
-      <point x="672" y="800"/>
-      <point x="593" y="800" type="qcurve" smooth="yes"/>
-      <point x="516" y="800"/>
-      <point x="460" y="672"/>
-      <point x="460" y="550" type="qcurve"/>
-      <point x="460" y="550" type="line"/>
-      <point x="460" y="430"/>
-      <point x="508" y="296"/>
+      <point x="550" y="295" type="qcurve" smooth="yes"/>
+      <point x="627" y="296"/>
+      <point x="701" y="411"/>
+      <point x="727" y="550" type="qcurve"/>
+      <point x="727" y="550" type="line"/>
+      <point x="747" y="672"/>
+      <point x="712" y="800"/>
+      <point x="639" y="800" type="qcurve" smooth="yes"/>
+      <point x="562" y="800"/>
+      <point x="486" y="689"/>
+      <point x="462" y="550" type="qcurve"/>
+      <point x="462" y="550" type="line"/>
+      <point x="440" y="430"/>
+      <point x="465" y="294"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/oslash-bar.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="1307"/>
-  <guideline x="504" y="-275" angle="336.3706222693432" identifier="ZjiBHta0Qs"/>
+  <guideline x="504" y="-275" angle="336.3706" identifier="ZjiBHta0Qs"/>
   <guideline x="727" y="130" angle="0" identifier="cKpo9yq9g0"/>
-  <guideline x="553" y="-17" angle="337.4329909221254" identifier="UKzm8VEeQM"/>
+  <guideline x="553" y="-17" angle="337.433" identifier="UKzm8VEeQM"/>
   <outline>
     <contour>
       <point x="543" y="575" type="line"/>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1184"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-39" yOffset="10"/>
+    <component base="o" identifier="FC4B13B7"/>
+    <component base="oslash-bar" xOffset="-39" yOffset="10" identifier="0DE6E2FA"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>0DE6E2FA</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>FC4B13B7</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1168"/>
   <outline>
-    <component base="six" xOffset="75"/>
+    <component base="six" xOffset="75" identifier="38B71929"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>38B71929</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND0.ufo/fontinfo.plist
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND0.ufo/fontinfo.plist
@@ -60,7 +60,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -68,7 +68,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND0.ufo/glyphs/O_.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND0.ufo/glyphs/O_.glif
@@ -3,43 +3,47 @@
   <advance width="1070"/>
   <unicode hex="004F"/>
   <guideline x="535" y="1047" angle="90" identifier="tLfkLAtCfI"/>
-  <anchor x="512" y="0" name="bottom"/>
-  <anchor x="534" y="707" name="center"/>
-  <anchor x="681" y="0" name="ogonek"/>
-  <anchor x="536" y="1432" name="top"/>
-  <anchor x="732" y="1432" name="topright"/>
+  <guideline x="1076" y="1229" angle="80" identifier="nzUH3hO6JK"/>
+  <guideline x="885" y="1245" angle="80" identifier="GjPGo5tBJj"/>
+  <guideline x="181" y="1270" angle="80" identifier="b2LPYr4uif"/>
+  <guideline x="368" y="1229" angle="80" identifier="PonpmlqOWY"/>
+  <anchor x="416.93835616438355" y="0" name="bottom"/>
+  <anchor x="562.9383561643835" y="707" name="center"/>
+  <anchor x="585.9383561643835" y="0" name="ogonek"/>
+  <anchor x="692.9383561643835" y="1432" name="top"/>
+  <anchor x="888.9383561643835" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="536" y="-26" type="qcurve" smooth="yes"/>
-      <point x="312" y="-26"/>
-      <point x="84" y="348"/>
-      <point x="84" y="718" type="qcurve"/>
-      <point x="84" y="718" type="line"/>
-      <point x="84" y="1084"/>
-      <point x="315" y="1460"/>
-      <point x="536" y="1460" type="qcurve" smooth="yes"/>
-      <point x="757" y="1460"/>
-      <point x="986" y="1085"/>
-      <point x="986" y="718" type="qcurve"/>
-      <point x="986" y="718" type="line"/>
-      <point x="986" y="358"/>
-      <point x="751" y="-26"/>
+      <point x="449.93835616438355" y="-26" type="qcurve" smooth="yes"/>
+      <point x="214.93835616438355" y="-26"/>
+      <point x="52.93835616438356" y="368"/>
+      <point x="117.93835616438356" y="738" type="qcurve"/>
+      <point x="117.93835616438356" y="738" type="line"/>
+      <point x="182.93835616438355" y="1104"/>
+      <point x="465.93835616438355" y="1460"/>
+      <point x="690.9383561643835" y="1460" type="qcurve" smooth="yes"/>
+      <point x="911.9383561643835" y="1460"/>
+      <point x="1078.9383561643835" y="1079"/>
+      <point x="1012.9383561643835" y="703" type="qcurve"/>
+      <point x="1012.9383561643835" y="703" type="line"/>
+      <point x="950.9383561643835" y="337"/>
+      <point x="682.9383561643835" y="-26"/>
     </contour>
     <contour>
-      <point x="534" y="142" type="qcurve" smooth="yes"/>
-      <point x="668" y="142"/>
-      <point x="792" y="421"/>
-      <point x="792" y="716" type="qcurve"/>
-      <point x="792" y="716" type="line"/>
-      <point x="792" y="1007"/>
-      <point x="667" y="1286"/>
-      <point x="534" y="1286" type="qcurve" smooth="yes"/>
-      <point x="404" y="1286"/>
-      <point x="278" y="1013"/>
-      <point x="278" y="716" type="qcurve"/>
-      <point x="278" y="716" type="line"/>
-      <point x="278" y="425"/>
-      <point x="403" y="142"/>
+      <point x="463.93835616438355" y="142" type="qcurve" smooth="yes"/>
+      <point x="597.9383561643835" y="142"/>
+      <point x="769.9383561643835" y="417"/>
+      <point x="824.9383561643835" y="723" type="qcurve"/>
+      <point x="824.9383561643835" y="723" type="line"/>
+      <point x="875.9383561643835" y="1014"/>
+      <point x="797.9383561643835" y="1286"/>
+      <point x="664.9383561643835" y="1286" type="qcurve" smooth="yes"/>
+      <point x="528.9383561643835" y="1286"/>
+      <point x="358.93835616438355" y="1013"/>
+      <point x="306.93835616438355" y="716" type="qcurve"/>
+      <point x="306.93835616438355" y="716" type="line"/>
+      <point x="255.93835616438355" y="425"/>
+      <point x="332.93835616438355" y="142"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND0.ufo/glyphs/o.glif
+++ b/sources/italic/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND0.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="964"/>
   <unicode hex="006F"/>
-  <anchor x="481" y="0" name="bottom"/>
-  <anchor x="482" y="536" name="center"/>
-  <anchor x="621" y="0" name="ogonek"/>
-  <anchor x="482" y="1086" name="top"/>
-  <anchor x="555" y="1086" name="topright"/>
+  <anchor x="385.5468164794007" y="0" name="bottom"/>
+  <anchor x="480.5468164794007" y="536" name="center"/>
+  <anchor x="525.5468164794007" y="0" name="ogonek"/>
+  <anchor x="577.5468164794007" y="1086" name="top"/>
+  <anchor x="650.5468164794007" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="482" y="-26" type="qcurve" smooth="yes"/>
-      <point x="299" y="-26"/>
-      <point x="80" y="283"/>
-      <point x="80" y="546" type="qcurve"/>
-      <point x="80" y="546" type="line"/>
-      <point x="80" y="807"/>
-      <point x="297" y="1108"/>
-      <point x="482" y="1108" type="qcurve" smooth="yes"/>
-      <point x="667" y="1108"/>
-      <point x="884" y="806"/>
-      <point x="884" y="546" type="qcurve"/>
-      <point x="884" y="546" type="line"/>
-      <point x="884" y="282"/>
-      <point x="667" y="-26"/>
+      <point x="395.5468164794007" y="-26" type="qcurve" smooth="yes"/>
+      <point x="206.54681647940075" y="-26"/>
+      <point x="33.546816479400746" y="267"/>
+      <point x="80.54681647940075" y="546" type="qcurve"/>
+      <point x="80.54681647940075" y="546" type="line"/>
+      <point x="126.54681647940075" y="807"/>
+      <point x="386.5468164794007" y="1108"/>
+      <point x="571.5468164794007" y="1108" type="qcurve" smooth="yes"/>
+      <point x="756.5468164794007" y="1108"/>
+      <point x="929.5468164794007" y="817"/>
+      <point x="884.5468164794007" y="546" type="qcurve"/>
+      <point x="884.5468164794007" y="546" type="line"/>
+      <point x="837.5468164794007" y="273"/>
+      <point x="589.5468164794007" y="-26"/>
     </contour>
     <contour>
-      <point x="484" y="146" type="qcurve" smooth="yes"/>
-      <point x="596" y="146"/>
-      <point x="696" y="334"/>
-      <point x="696" y="546" type="qcurve"/>
-      <point x="696" y="546" type="line"/>
-      <point x="696" y="747"/>
-      <point x="593" y="938"/>
-      <point x="484" y="938" type="qcurve" smooth="yes"/>
-      <point x="374" y="938"/>
-      <point x="268" y="745"/>
-      <point x="268" y="546" type="qcurve"/>
-      <point x="268" y="546" type="line"/>
-      <point x="268" y="337"/>
-      <point x="371" y="146"/>
+      <point x="413.5468164794007" y="146" type="qcurve" smooth="yes"/>
+      <point x="525.5468164794007" y="146"/>
+      <point x="659.5468164794007" y="334"/>
+      <point x="696.5468164794007" y="546" type="qcurve"/>
+      <point x="696.5468164794007" y="546" type="line"/>
+      <point x="731.5468164794007" y="747"/>
+      <point x="662.5468164794007" y="938"/>
+      <point x="553.5468164794007" y="938" type="qcurve" smooth="yes"/>
+      <point x="443.5468164794007" y="938"/>
+      <point x="303.5468164794007" y="745"/>
+      <point x="268.5468164794007" y="546" type="qcurve"/>
+      <point x="268.5468164794007" y="546" type="line"/>
+      <point x="231.54681647940075" y="337"/>
+      <point x="300.5468164794007" y="146"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND100.ufo/fontinfo.plist
@@ -58,7 +58,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -66,7 +66,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1712"/>
   <unicode hex="004F"/>
-  <guideline x="856" y="0" angle="90" identifier="f2nbMxCHci"/>
-  <anchor x="856" y="0" name="bottom"/>
-  <anchor x="856" y="716" name="center"/>
-  <anchor x="1088" y="0" name="ogonek"/>
-  <anchor x="856" y="1432" name="top"/>
-  <anchor x="1076" y="1432" name="topright"/>
+  <guideline x="766" y="0" angle="100" identifier="f2nbMxCHci"/>
+  <anchor x="766" y="0" name="bottom"/>
+  <anchor x="892.2501181872609" y="716" name="center"/>
+  <anchor x="998" y="0" name="ogonek"/>
+  <anchor x="1018.5002363745218" y="1432" name="top"/>
+  <anchor x="1238.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="856" y="-32" type="qcurve" smooth="yes"/>
-      <point x="535" y="-32" name="inserted"/>
-      <point x="120" y="390"/>
-      <point x="120" y="716" type="qcurve"/>
-      <point x="120" y="716" type="line"/>
-      <point x="120" y="1042" name="inserted"/>
-      <point x="535" y="1464"/>
-      <point x="856" y="1464" type="qcurve" smooth="yes"/>
-      <point x="1177" y="1464" name="inserted"/>
-      <point x="1592" y="1042"/>
-      <point x="1592" y="716" type="qcurve"/>
-      <point x="1592" y="716" type="line"/>
-      <point x="1592" y="390" name="inserted"/>
-      <point x="1177" y="-32"/>
+      <point x="761" y="-32" type="qcurve" smooth="yes"/>
+      <point x="440" y="-32" name="inserted"/>
+      <point x="99" y="390"/>
+      <point x="156" y="716" type="qcurve"/>
+      <point x="156" y="716" type="line"/>
+      <point x="214" y="1042" name="inserted"/>
+      <point x="703" y="1464"/>
+      <point x="1024" y="1464" type="qcurve" smooth="yes"/>
+      <point x="1345" y="1464" name="inserted"/>
+      <point x="1686" y="1042"/>
+      <point x="1628" y="716" type="qcurve"/>
+      <point x="1628" y="716" type="line"/>
+      <point x="1571" y="390" name="inserted"/>
+      <point x="1082" y="-32"/>
     </contour>
     <contour>
-      <point x="856" y="-28" type="qcurve" smooth="yes"/>
-      <point x="1175" y="-28" name="inserted"/>
-      <point x="1588" y="391"/>
-      <point x="1588" y="716" type="qcurve"/>
-      <point x="1588" y="716" type="line"/>
-      <point x="1588" y="1041" name="inserted"/>
-      <point x="1175" y="1460"/>
-      <point x="856" y="1460" type="qcurve" smooth="yes"/>
-      <point x="537" y="1460" name="inserted"/>
-      <point x="124" y="1041"/>
-      <point x="124" y="716" type="qcurve"/>
-      <point x="124" y="716" type="line"/>
-      <point x="124" y="391" name="inserted"/>
-      <point x="537" y="-28"/>
+      <point x="761" y="-28" type="qcurve" smooth="yes"/>
+      <point x="1080" y="-28" name="inserted"/>
+      <point x="1567" y="391"/>
+      <point x="1624" y="716" type="qcurve"/>
+      <point x="1624" y="716" type="line"/>
+      <point x="1682" y="1041" name="inserted"/>
+      <point x="1343" y="1460"/>
+      <point x="1024" y="1460" type="qcurve" smooth="yes"/>
+      <point x="705" y="1460" name="inserted"/>
+      <point x="218" y="1041"/>
+      <point x="160" y="716" type="qcurve"/>
+      <point x="160" y="716" type="line"/>
+      <point x="103" y="391" name="inserted"/>
+      <point x="442" y="-28"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND100.ufo/glyphs/o.glif
@@ -10,36 +10,36 @@
   <anchor x="770" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="604" y="-22" type="qcurve" smooth="yes"/>
-      <point x="384" y="-22" name="inserted"/>
-      <point x="100" y="279"/>
+      <point x="510" y="-22" type="qcurve" smooth="yes"/>
+      <point x="290" y="-22" name="inserted"/>
+      <point x="59" y="279"/>
       <point x="100" y="512" type="qcurve"/>
       <point x="100" y="512" type="line"/>
-      <point x="100" y="745" name="inserted"/>
-      <point x="384" y="1046"/>
-      <point x="604" y="1046" type="qcurve" smooth="yes"/>
-      <point x="824" y="1046" name="inserted"/>
-      <point x="1108" y="745"/>
+      <point x="142" y="745" name="inserted"/>
+      <point x="479" y="1046"/>
+      <point x="699" y="1046" type="qcurve" smooth="yes"/>
+      <point x="919" y="1046" name="inserted"/>
+      <point x="1150" y="745"/>
       <point x="1108" y="512" type="qcurve"/>
       <point x="1108" y="512" type="line"/>
-      <point x="1108" y="279" name="inserted"/>
-      <point x="824" y="-22"/>
+      <point x="1067" y="279" name="inserted"/>
+      <point x="730" y="-22"/>
     </contour>
     <contour>
-      <point x="604" y="-18" type="qcurve" smooth="yes"/>
-      <point x="822" y="-18" name="inserted"/>
-      <point x="1104" y="281"/>
+      <point x="511" y="-18" type="qcurve" smooth="yes"/>
+      <point x="729" y="-18" name="inserted"/>
+      <point x="1064" y="281"/>
       <point x="1104" y="512" type="qcurve"/>
       <point x="1104" y="512" type="line"/>
-      <point x="1104" y="743" name="inserted"/>
-      <point x="822" y="1042"/>
-      <point x="604" y="1042" type="qcurve" smooth="yes"/>
-      <point x="386" y="1042" name="inserted"/>
-      <point x="104" y="743"/>
+      <point x="1145" y="743" name="inserted"/>
+      <point x="916" y="1042"/>
+      <point x="698" y="1042" type="qcurve" smooth="yes"/>
+      <point x="480" y="1042" name="inserted"/>
+      <point x="145" y="743"/>
       <point x="104" y="512" type="qcurve"/>
       <point x="104" y="512" type="line"/>
-      <point x="104" y="281" name="inserted"/>
-      <point x="386" y="-18"/>
+      <point x="64" y="281" name="inserted"/>
+      <point x="293" y="-18"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND100.ufo/fontinfo.plist
@@ -154,7 +154,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -162,7 +162,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1592"/>
   <unicode hex="004F"/>
-  <anchor x="791" y="0" name="bottom"/>
-  <anchor x="791" y="716" name="center"/>
-  <anchor x="1019" y="0" name="ogonek"/>
-  <anchor x="791" y="1432" name="top"/>
-  <anchor x="1011" y="1432" name="topright"/>
+  <guideline x="926" y="296" angle="80" identifier="p8u2AswqXD"/>
+  <anchor x="827.4401544402" y="0" name="bottom"/>
+  <anchor x="827.4401544402" y="716" name="center"/>
+  <anchor x="1055.4401544402" y="0" name="ogonek"/>
+  <anchor x="827.4401544402" y="1432" name="top"/>
+  <anchor x="1047.4401544402" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="796" y="-32" type="qcurve" smooth="yes"/>
-      <point x="494" y="-32" name="inserted"/>
-      <point x="40" y="382"/>
-      <point x="40" y="716" type="qcurve"/>
-      <point x="40" y="716" type="line"/>
-      <point x="40" y="1050" name="inserted"/>
-      <point x="484" y="1464"/>
-      <point x="796" y="1464" type="qcurve" smooth="yes"/>
-      <point x="1108" y="1464" name="inserted"/>
-      <point x="1552" y="1038"/>
-      <point x="1552" y="716" type="qcurve"/>
-      <point x="1552" y="716" type="line"/>
-      <point x="1552" y="394" name="inserted"/>
-      <point x="1099" y="-32"/>
+      <point x="721.4401544402" y="-32" type="qcurve" smooth="yes"/>
+      <point x="419.4401544402" y="-32" name="inserted"/>
+      <point x="19.4401544402" y="396"/>
+      <point x="78.4401544402" y="730" type="qcurve"/>
+      <point x="78.4401544402" y="730" type="line"/>
+      <point x="137.4401544402" y="1064" name="inserted"/>
+      <point x="628.4401544402" y="1464"/>
+      <point x="944.4401544402" y="1464" type="qcurve" smooth="yes"/>
+      <point x="1266.4401544402" y="1464" name="inserted"/>
+      <point x="1643.4401544402" y="1029"/>
+      <point x="1586.4401544402" y="707" type="qcurve"/>
+      <point x="1586.4401544402" y="707" type="line"/>
+      <point x="1529.4401544402" y="385" name="inserted"/>
+      <point x="1050.4401544402" y="-32"/>
     </contour>
     <contour>
-      <point x="796" y="510" type="qcurve" smooth="yes"/>
-      <point x="882" y="510" name="inserted"/>
-      <point x="1000" y="626"/>
-      <point x="1000" y="716" type="qcurve"/>
-      <point x="1000" y="716" type="line"/>
-      <point x="1000" y="808" name="inserted"/>
-      <point x="882" y="922"/>
-      <point x="796" y="922" type="qcurve" smooth="yes"/>
-      <point x="710" y="922" name="inserted"/>
-      <point x="592" y="808"/>
-      <point x="592" y="716" type="qcurve"/>
-      <point x="592" y="716" type="line"/>
-      <point x="592" y="624" name="inserted"/>
-      <point x="710" y="510"/>
+      <point x="803.4401544402" y="510" type="qcurve" smooth="yes"/>
+      <point x="889.4401544402" y="510" name="inserted"/>
+      <point x="1019.4401544402" y="621"/>
+      <point x="1035.4401544402" y="711" type="qcurve"/>
+      <point x="1035.4401544402" y="711" type="line"/>
+      <point x="1051.4401544402" y="803" name="inserted"/>
+      <point x="946.4401544402" y="922"/>
+      <point x="860.4401544402" y="922" type="qcurve" smooth="yes"/>
+      <point x="774.4401544402" y="922" name="inserted"/>
+      <point x="645.4401544402" y="814"/>
+      <point x="629.4401544402" y="722" type="qcurve"/>
+      <point x="629.4401544402" y="722" type="line"/>
+      <point x="613.4401544402" y="630" name="inserted"/>
+      <point x="717.4401544402" y="510"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1184"/>
   <unicode hex="006F"/>
-  <anchor x="586" y="0" name="bottom"/>
-  <anchor x="592" y="510" name="center"/>
-  <anchor x="808" y="0" name="ogonek"/>
-  <anchor x="587" y="1020" name="top"/>
-  <anchor x="829" y="1020" name="topright"/>
+  <anchor x="495" y="0" name="bottom"/>
+  <anchor x="591" y="510" name="center"/>
+  <anchor x="717" y="0" name="ogonek"/>
+  <anchor x="676" y="1020" name="top"/>
+  <anchor x="918" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="588" y="-36" type="qcurve" smooth="yes"/>
-      <point x="328" y="-36" name="inserted"/>
-      <point x="20" y="292"/>
-      <point x="20" y="512" type="qcurve"/>
-      <point x="20" y="512" type="line"/>
-      <point x="20" y="738" name="inserted"/>
-      <point x="338" y="1068"/>
-      <point x="588" y="1068" type="qcurve" smooth="yes"/>
-      <point x="842" y="1068" name="inserted"/>
-      <point x="1164" y="732"/>
-      <point x="1164" y="512" type="qcurve"/>
-      <point x="1164" y="512" type="line"/>
-      <point x="1164" y="300" name="inserted"/>
-      <point x="850" y="-36"/>
+      <point x="520" y="-36" type="qcurve"/>
+      <point x="263" y="-36" name="inserted"/>
+      <point x="-19" y="307"/>
+      <point x="20" y="527" type="qcurve"/>
+      <point x="20" y="527" type="line"/>
+      <point x="64" y="762" name="inserted"/>
+      <point x="394" y="1068"/>
+      <point x="689" y="1068" type="qcurve" smooth="yes"/>
+      <point x="921" y="1068" name="inserted"/>
+      <point x="1200" y="736"/>
+      <point x="1159" y="487" type="qcurve"/>
+      <point x="1159" y="487" type="line"/>
+      <point x="1133" y="302" name="inserted"/>
+      <point x="798" y="-36"/>
     </contour>
     <contour>
-      <point x="592" y="382" type="qcurve" smooth="yes"/>
-      <point x="658" y="382" name="inserted"/>
-      <point x="722" y="456"/>
-      <point x="722" y="510" type="qcurve"/>
-      <point x="722" y="510" type="line"/>
-      <point x="722" y="564" name="inserted"/>
-      <point x="656" y="638"/>
-      <point x="592" y="638" type="qcurve" smooth="yes"/>
-      <point x="528" y="638" name="inserted"/>
-      <point x="460" y="566"/>
-      <point x="460" y="510" type="qcurve"/>
-      <point x="460" y="510" type="line"/>
-      <point x="460" y="454" name="inserted"/>
-      <point x="526" y="382"/>
+      <point x="572" y="382" type="qcurve" smooth="yes"/>
+      <point x="638" y="382" name="inserted"/>
+      <point x="715" y="456"/>
+      <point x="725" y="510" type="qcurve"/>
+      <point x="725" y="510" type="line"/>
+      <point x="734" y="564" name="inserted"/>
+      <point x="681" y="638"/>
+      <point x="617" y="638" type="qcurve" smooth="yes"/>
+      <point x="553" y="638" name="inserted"/>
+      <point x="473" y="566"/>
+      <point x="463" y="510" type="qcurve"/>
+      <point x="463" y="510" type="line"/>
+      <point x="453" y="454" name="inserted"/>
+      <point x="506" y="382"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND100.ufo/fontinfo.plist
@@ -112,7 +112,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -120,7 +120,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1778"/>
   <unicode hex="004F"/>
-  <anchor x="889" y="0" name="bottom"/>
-  <anchor x="889" y="715" name="center"/>
-  <anchor x="1124" y="0" name="ogonek"/>
-  <anchor x="889" y="1432" name="top"/>
-  <anchor x="1139" y="1432" name="topright"/>
+  <anchor x="799" y="0" name="bottom"/>
+  <anchor x="925.0737912065524" y="715" name="center"/>
+  <anchor x="1034" y="0" name="ogonek"/>
+  <anchor x="1051.5002363745218" y="1432" name="top"/>
+  <anchor x="1301.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="888" y="-32" type="qcurve"/>
-      <point x="557" y="-33"/>
-      <point x="119" y="393"/>
-      <point x="119" y="715" type="qcurve"/>
-      <point x="119" y="715" type="line"/>
-      <point x="119" y="1036"/>
-      <point x="556" y="1465"/>
-      <point x="888" y="1465" type="qcurve"/>
-      <point x="1217" y="1465"/>
-      <point x="1658" y="1034"/>
-      <point x="1658" y="715" type="qcurve"/>
-      <point x="1658" y="715" type="line"/>
-      <point x="1658" y="399"/>
-      <point x="1215" y="-32"/>
+      <point x="793" y="-32" type="qcurve"/>
+      <point x="466" y="-33"/>
+      <point x="105" y="393"/>
+      <point x="156" y="715" type="qcurve"/>
+      <point x="156" y="715" type="line"/>
+      <point x="213" y="1036"/>
+      <point x="725" y="1465"/>
+      <point x="1057" y="1465" type="qcurve"/>
+      <point x="1386" y="1465"/>
+      <point x="1751" y="1034"/>
+      <point x="1694" y="715" type="qcurve"/>
+      <point x="1694" y="715" type="line"/>
+      <point x="1639" y="399"/>
+      <point x="1120" y="-32"/>
     </contour>
     <contour>
-      <point x="888" y="108" type="qcurve"/>
-      <point x="1156" y="108"/>
-      <point x="1510" y="455"/>
-      <point x="1510" y="715" type="qcurve"/>
-      <point x="1510" y="715" type="line"/>
-      <point x="1510" y="976"/>
-      <point x="1156" y="1324"/>
-      <point x="888" y="1324" type="qcurve"/>
-      <point x="619" y="1324"/>
-      <point x="267" y="976"/>
-      <point x="267" y="715" type="qcurve"/>
-      <point x="267" y="715" type="line"/>
-      <point x="267" y="453"/>
-      <point x="619" y="108"/>
+      <point x="818" y="102" type="qcurve"/>
+      <point x="1086" y="102"/>
+      <point x="1498" y="455"/>
+      <point x="1544" y="715" type="qcurve"/>
+      <point x="1544" y="715" type="line"/>
+      <point x="1590" y="976"/>
+      <point x="1300" y="1330"/>
+      <point x="1032" y="1330" type="qcurve"/>
+      <point x="763" y="1330"/>
+      <point x="354" y="976"/>
+      <point x="308" y="715" type="qcurve"/>
+      <point x="308" y="715" type="line"/>
+      <point x="262" y="453"/>
+      <point x="549" y="102"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1221"/>
   <unicode hex="006F"/>
-  <anchor x="611" y="0" name="bottom"/>
-  <anchor x="611" y="510" name="center"/>
-  <anchor x="809" y="0" name="ogonek"/>
-  <anchor x="611" y="1020" name="top"/>
-  <anchor x="782" y="1020" name="topright"/>
+  <anchor x="521" y="0" name="bottom"/>
+  <anchor x="610.9267601613171" y="510" name="center"/>
+  <anchor x="719" y="0" name="ogonek"/>
+  <anchor x="700.8535203226343" y="1020" name="top"/>
+  <anchor x="871.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="609" y="-32" type="qcurve"/>
-      <point x="368" y="-32"/>
-      <point x="66" y="271"/>
-      <point x="66" y="504" type="qcurve"/>
-      <point x="66" y="504" type="line"/>
-      <point x="66" y="737"/>
-      <point x="373" y="1045"/>
-      <point x="609" y="1045" type="qcurve"/>
-      <point x="844" y="1045"/>
-      <point x="1155" y="733"/>
-      <point x="1155" y="505" type="qcurve"/>
-      <point x="1155" y="505" type="line"/>
-      <point x="1155" y="274"/>
-      <point x="847" y="-32"/>
+      <point x="514" y="-32" type="qcurve"/>
+      <point x="279" y="-32"/>
+      <point x="27" y="271"/>
+      <point x="65" y="504" type="qcurve"/>
+      <point x="65" y="504" type="line"/>
+      <point x="106" y="737"/>
+      <point x="468" y="1045"/>
+      <point x="704" y="1045" type="qcurve"/>
+      <point x="939" y="1045"/>
+      <point x="1195" y="733"/>
+      <point x="1154" y="505" type="qcurve"/>
+      <point x="1154" y="505" type="line"/>
+      <point x="1114" y="274"/>
+      <point x="752" y="-32"/>
     </contour>
     <contour>
-      <point x="611" y="102" type="qcurve"/>
-      <point x="792" y="102"/>
-      <point x="1011" y="325"/>
-      <point x="1011" y="504" type="qcurve"/>
-      <point x="1011" y="504" type="line"/>
-      <point x="1011" y="680"/>
-      <point x="788" y="909"/>
-      <point x="611" y="909" type="qcurve"/>
-      <point x="431" y="909"/>
-      <point x="210" y="684"/>
-      <point x="210" y="504" type="qcurve"/>
-      <point x="210" y="504" type="line"/>
-      <point x="210" y="323"/>
-      <point x="426" y="102"/>
+      <point x="539" y="100" type="qcurve"/>
+      <point x="720" y="100"/>
+      <point x="979" y="325"/>
+      <point x="1010" y="504" type="qcurve"/>
+      <point x="1010" y="504" type="line"/>
+      <point x="1041" y="680"/>
+      <point x="859" y="911"/>
+      <point x="682" y="911" type="qcurve"/>
+      <point x="502" y="911"/>
+      <point x="241" y="684"/>
+      <point x="209" y="504" type="qcurve"/>
+      <point x="209" y="504" type="line"/>
+      <point x="177" y="323"/>
+      <point x="354" y="100"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND100.ufo/fontinfo.plist
@@ -47,7 +47,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -55,7 +55,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="2668"/>
   <unicode hex="004F"/>
-  <anchor x="1339" y="0" name="bottom"/>
-  <anchor x="1341" y="693" name="center"/>
-  <anchor x="1774" y="0" name="ogonek"/>
-  <anchor x="1334" y="1432" name="top"/>
-  <anchor x="1771" y="1432" name="topright"/>
+  <anchor x="1249" y="0" name="bottom"/>
+  <anchor x="1373.1945976309662" y="693" name="center"/>
+  <anchor x="1684" y="0" name="ogonek"/>
+  <anchor x="1496.5002363745218" y="1432" name="top"/>
+  <anchor x="1933.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1338" y="-41" type="qcurve" smooth="yes"/>
-      <point x="802" y="-41"/>
-      <point x="110" y="372"/>
-      <point x="110" y="691" type="qcurve"/>
-      <point x="110" y="712" type="line"/>
-      <point x="110" y="1045"/>
-      <point x="799" y="1476"/>
-      <point x="1333" y="1476" type="qcurve" smooth="yes"/>
-      <point x="1868" y="1476"/>
-      <point x="2558" y="1045"/>
-      <point x="2558" y="712" type="qcurve"/>
-      <point x="2558" y="691" type="line"/>
-      <point x="2558" y="372"/>
-      <point x="1870" y="-41"/>
+      <point x="1242" y="-41" type="qcurve" smooth="yes"/>
+      <point x="706" y="-41"/>
+      <point x="86" y="372"/>
+      <point x="143" y="691" type="qcurve"/>
+      <point x="146" y="712" type="line"/>
+      <point x="205" y="1045"/>
+      <point x="970" y="1476"/>
+      <point x="1504" y="1476" type="qcurve" smooth="yes"/>
+      <point x="2039" y="1476"/>
+      <point x="2653" y="1045"/>
+      <point x="2594" y="712" type="qcurve"/>
+      <point x="2591" y="691" type="line"/>
+      <point x="2534" y="372"/>
+      <point x="1774" y="-41"/>
     </contour>
     <contour>
-      <point x="1338" y="-30" type="qcurve" smooth="yes"/>
-      <point x="1866" y="-30"/>
-      <point x="2547" y="378"/>
-      <point x="2547" y="693" type="qcurve"/>
-      <point x="2547" y="712" type="line"/>
-      <point x="2547" y="1041"/>
-      <point x="1863" y="1465"/>
-      <point x="1334" y="1465" type="qcurve" smooth="yes"/>
-      <point x="805" y="1465"/>
-      <point x="121" y="1041"/>
-      <point x="121" y="712" type="qcurve"/>
-      <point x="121" y="693" type="line"/>
-      <point x="121" y="378"/>
-      <point x="807" y="-30"/>
+      <point x="1243" y="-30" type="qcurve" smooth="yes"/>
+      <point x="1771" y="-30"/>
+      <point x="2524" y="378"/>
+      <point x="2580" y="693" type="qcurve"/>
+      <point x="2583" y="712" type="line"/>
+      <point x="2641" y="1041"/>
+      <point x="2032" y="1465"/>
+      <point x="1503" y="1465" type="qcurve" smooth="yes"/>
+      <point x="974" y="1465"/>
+      <point x="215" y="1041"/>
+      <point x="157" y="712" type="qcurve"/>
+      <point x="154" y="693" type="line"/>
+      <point x="98" y="378"/>
+      <point x="712" y="-30"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="2036"/>
   <unicode hex="006F"/>
-  <anchor x="1019" y="0" name="bottom"/>
-  <anchor x="1020" y="518" name="center"/>
-  <anchor x="1374" y="0" name="ogonek"/>
-  <anchor x="1019" y="1020" name="top"/>
-  <anchor x="1430" y="1020" name="topright"/>
+  <anchor x="929" y="0" name="bottom"/>
+  <anchor x="1021.3373760069849" y="518" name="center"/>
+  <anchor x="1284" y="0" name="ogonek"/>
+  <anchor x="1108.8535203226343" y="1020" name="top"/>
+  <anchor x="1519.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="1019" y="-30" type="qcurve" smooth="yes"/>
-      <point x="578" y="-30"/>
-      <point x="82" y="271"/>
+      <point x="924" y="-30" type="qcurve" smooth="yes"/>
+      <point x="483" y="-30"/>
+      <point x="40" y="271"/>
       <point x="82" y="512" type="qcurve"/>
-      <point x="82" y="514" type="line"/>
-      <point x="82" y="758"/>
-      <point x="578" y="1062"/>
-      <point x="1019" y="1062" type="qcurve" smooth="yes"/>
-      <point x="1459" y="1062"/>
-      <point x="1954" y="758"/>
-      <point x="1954" y="514" type="qcurve"/>
+      <point x="83" y="514" type="line"/>
+      <point x="126" y="758"/>
+      <point x="675" y="1062"/>
+      <point x="1116" y="1062" type="qcurve" smooth="yes"/>
+      <point x="1556" y="1062"/>
+      <point x="1998" y="758"/>
+      <point x="1955" y="514" type="qcurve"/>
       <point x="1954" y="511" type="line"/>
-      <point x="1954" y="270"/>
-      <point x="1459" y="-30"/>
+      <point x="1912" y="270"/>
+      <point x="1364" y="-30"/>
     </contour>
     <contour>
-      <point x="1019" y="-20" type="qcurve" smooth="yes"/>
-      <point x="1455" y="-20"/>
-      <point x="1944" y="275"/>
+      <point x="925" y="-20" type="qcurve" smooth="yes"/>
+      <point x="1361" y="-20"/>
+      <point x="1902" y="275"/>
       <point x="1944" y="511" type="qcurve"/>
-      <point x="1944" y="514" type="line"/>
-      <point x="1944" y="753"/>
-      <point x="1455" y="1052"/>
-      <point x="1019" y="1052" type="qcurve" smooth="yes"/>
-      <point x="582" y="1052"/>
-      <point x="92" y="753"/>
-      <point x="92" y="514" type="qcurve"/>
+      <point x="1945" y="514" type="line"/>
+      <point x="1987" y="753"/>
+      <point x="1550" y="1052"/>
+      <point x="1114" y="1052" type="qcurve" smooth="yes"/>
+      <point x="677" y="1052"/>
+      <point x="135" y="753"/>
+      <point x="93" y="514" type="qcurve"/>
       <point x="92" y="512" type="line"/>
-      <point x="92" y="276"/>
-      <point x="582" y="-20"/>
+      <point x="51" y="276"/>
+      <point x="488" y="-20"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND100.ufo/fontinfo.plist
@@ -76,7 +76,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -84,7 +84,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND100.ufo/glyphs/O_.glif
@@ -2,42 +2,42 @@
 <glyph name="O" format="2">
   <advance width="2576"/>
   <unicode hex="004F"/>
-  <anchor x="1289" y="0" name="bottom"/>
-  <anchor x="1290" y="716" name="center"/>
-  <anchor x="1731" y="0" name="ogonek"/>
-  <anchor x="1294" y="1432" name="top"/>
-  <anchor x="1694" y="1432" name="topright"/>
+  <anchor x="1199" y="0" name="bottom"/>
+  <anchor x="1326.250118187261" y="716" name="center"/>
+  <anchor x="1641" y="0" name="ogonek"/>
+  <anchor x="1456.5002363745218" y="1432" name="top"/>
+  <anchor x="1856.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1292" y="-41" type="qcurve" smooth="yes"/>
-      <point x="717" y="-41"/>
-      <point x="44" y="364"/>
-      <point x="44" y="691" type="qcurve"/>
-      <point x="44" y="691" type="line"/>
-      <point x="44" y="1048"/>
-      <point x="710" y="1476"/>
-      <point x="1292" y="1476" type="qcurve" smooth="yes"/>
-      <point x="1862" y="1476"/>
-      <point x="2532" y="1035"/>
-      <point x="2532" y="691" type="qcurve"/>
-      <point x="2532" y="691" type="line"/>
-      <point x="2532" y="374"/>
-      <point x="1826" y="-41"/>
+      <point x="1216" y="-41" type="qcurve" smooth="yes"/>
+      <point x="620" y="-41"/>
+      <point x="25" y="426"/>
+      <point x="89" y="774" type="qcurve"/>
+      <point x="89" y="774" type="line"/>
+      <point x="140" y="1074"/>
+      <point x="851" y="1476"/>
+      <point x="1452" y="1476" type="qcurve" smooth="yes"/>
+      <point x="2024" y="1476"/>
+      <point x="2619" y="1009"/>
+      <point x="2559" y="665" type="qcurve"/>
+      <point x="2559" y="665" type="line"/>
+      <point x="2503" y="348"/>
+      <point x="1787" y="-41"/>
     </contour>
     <contour>
       <point x="1288" y="508" type="qcurve" smooth="yes"/>
       <point x="1473" y="508"/>
-      <point x="1657" y="621"/>
-      <point x="1657" y="717" type="qcurve"/>
-      <point x="1657" y="717" type="line"/>
-      <point x="1657" y="808"/>
-      <point x="1466" y="924"/>
-      <point x="1288" y="924" type="qcurve" smooth="yes"/>
-      <point x="1114" y="924"/>
-      <point x="919" y="812"/>
-      <point x="919" y="717" type="qcurve"/>
-      <point x="919" y="717" type="line"/>
-      <point x="918" y="617"/>
+      <point x="1676" y="621"/>
+      <point x="1693" y="717" type="qcurve"/>
+      <point x="1693" y="717" type="line"/>
+      <point x="1709" y="808"/>
+      <point x="1539" y="924"/>
+      <point x="1361" y="924" type="qcurve" smooth="yes"/>
+      <point x="1187" y="924"/>
+      <point x="972" y="812"/>
+      <point x="955" y="717" type="qcurve"/>
+      <point x="955" y="717" type="line"/>
+      <point x="937" y="617"/>
       <point x="1126" y="508"/>
     </contour>
   </outline>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="2162"/>
   <unicode hex="006F"/>
-  <anchor x="1085" y="0" name="bottom"/>
-  <anchor x="1085" y="510" name="center"/>
-  <anchor x="1497" y="0" name="ogonek"/>
-  <anchor x="1081" y="1020" name="top"/>
-  <anchor x="1545" y="1020" name="topright"/>
+  <anchor x="993.6859813084112" y="0" name="bottom"/>
+  <anchor x="1083.6127414697285" y="510" name="center"/>
+  <anchor x="1405.685981308411" y="0" name="ogonek"/>
+  <anchor x="1169.5395016310454" y="1020" name="top"/>
+  <anchor x="1633.5395016310454" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="1085" y="-34" type="qcurve" smooth="yes"/>
-      <point x="573" y="-34"/>
-      <point x="24" y="292"/>
-      <point x="24" y="521" type="qcurve"/>
-      <point x="24" y="521" type="line"/>
-      <point x="25" y="757"/>
-      <point x="581" y="1067"/>
-      <point x="1085" y="1067" type="qcurve"/>
-      <point x="1583" y="1068"/>
-      <point x="2138" y="764"/>
-      <point x="2138" y="520" type="qcurve"/>
-      <point x="2138" y="520" type="line"/>
-      <point x="2138" y="291"/>
-      <point x="1588" y="-34"/>
+      <point x="1009.6859813084112" y="-34" type="qcurve" smooth="yes"/>
+      <point x="454.6859813084112" y="-34"/>
+      <point x="-2.3140186915887853" y="306"/>
+      <point x="36.685981308411215" y="539" type="qcurve"/>
+      <point x="36.685981308411215" y="539" type="line"/>
+      <point x="79.68598130841121" y="780"/>
+      <point x="665.6859813084112" y="1067"/>
+      <point x="1181.685981308411" y="1067" type="qcurve"/>
+      <point x="1655.685981308411" y="1076"/>
+      <point x="2171.685981308411" y="744"/>
+      <point x="2126.685981308411" y="492" type="qcurve"/>
+      <point x="2126.685981308411" y="492" type="line"/>
+      <point x="2085.685981308411" y="268"/>
+      <point x="1517.685981308411" y="-34"/>
     </contour>
     <contour>
-      <point x="1080" y="392" type="qcurve" smooth="yes"/>
-      <point x="1218" y="392"/>
-      <point x="1348" y="462"/>
-      <point x="1348" y="510" type="qcurve"/>
-      <point x="1348" y="510" type="line"/>
-      <point x="1348" y="561"/>
-      <point x="1217" y="632"/>
-      <point x="1080" y="632" type="qcurve" smooth="yes"/>
-      <point x="943" y="632"/>
-      <point x="814" y="568"/>
-      <point x="814" y="511" type="qcurve"/>
-      <point x="814" y="511" type="line"/>
-      <point x="814" y="462"/>
-      <point x="942" y="392"/>
+      <point x="1057.685981308411" y="392" type="qcurve" smooth="yes"/>
+      <point x="1201.685981308411" y="392"/>
+      <point x="1332.685981308411" y="462"/>
+      <point x="1341.685981308411" y="510" type="qcurve"/>
+      <point x="1341.685981308411" y="510" type="line"/>
+      <point x="1350.685981308411" y="561"/>
+      <point x="1236.685981308411" y="632"/>
+      <point x="1099.685981308411" y="632" type="qcurve" smooth="yes"/>
+      <point x="969.6859813084112" y="632"/>
+      <point x="827.6859813084112" y="568"/>
+      <point x="817.6859813084112" y="511" type="qcurve"/>
+      <point x="817.6859813084112" y="511" type="line"/>
+      <point x="808.6859813084112" y="462"/>
+      <point x="922.6859813084112" y="392"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND100.ufo/fontinfo.plist
@@ -98,7 +98,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -106,7 +106,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="2678"/>
   <unicode hex="004F"/>
-  <anchor x="1341" y="0" name="bottom"/>
-  <anchor x="1336" y="707" name="center"/>
-  <anchor x="1791" y="0" name="ogonek"/>
-  <anchor x="1347" y="1432" name="top"/>
-  <anchor x="1797" y="1432" name="topright"/>
+  <anchor x="1251.2564102564102" y="0" name="bottom"/>
+  <anchor x="1370.919585617295" y="707" name="center"/>
+  <anchor x="1701.2564102564102" y="0" name="ogonek"/>
+  <anchor x="1509.7566466309322" y="1432" name="top"/>
+  <anchor x="1959.7566466309322" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1342" y="-40" type="qcurve" smooth="yes"/>
-      <point x="765" y="-41"/>
-      <point x="110" y="375"/>
-      <point x="110" y="700" type="qcurve"/>
-      <point x="110" y="700" type="line"/>
-      <point x="110" y="1034"/>
-      <point x="756" y="1476"/>
-      <point x="1342" y="1476" type="qcurve" smooth="yes"/>
-      <point x="1914" y="1476"/>
-      <point x="2568" y="1038"/>
-      <point x="2568" y="701" type="qcurve"/>
-      <point x="2568" y="701" type="line"/>
-      <point x="2568" y="378"/>
-      <point x="1911" y="-39"/>
+      <point x="1246" y="-40" type="qcurve" smooth="yes"/>
+      <point x="658" y="-40"/>
+      <point x="88" y="373"/>
+      <point x="145" y="698" type="qcurve"/>
+      <point x="145" y="698" type="line"/>
+      <point x="204" y="1034"/>
+      <point x="931" y="1476"/>
+      <point x="1513" y="1476" type="qcurve" smooth="yes"/>
+      <point x="2086" y="1476"/>
+      <point x="2662" y="1030"/>
+      <point x="2603" y="693" type="qcurve"/>
+      <point x="2603" y="693" type="line"/>
+      <point x="2546" y="371"/>
+      <point x="1840" y="-40"/>
     </contour>
     <contour>
-      <point x="1338" y="106" type="qcurve" smooth="yes"/>
-      <point x="1842" y="106"/>
-      <point x="2412" y="442"/>
-      <point x="2412" y="701" type="qcurve"/>
-      <point x="2412" y="701" type="line"/>
-      <point x="2412" y="971"/>
-      <point x="1835" y="1328"/>
-      <point x="1338" y="1328" type="qcurve" smooth="yes"/>
-      <point x="834" y="1328"/>
-      <point x="266" y="977"/>
-      <point x="266" y="700" type="qcurve"/>
-      <point x="266" y="700" type="line"/>
-      <point x="266" y="437"/>
-      <point x="842" y="106"/>
+      <point x="1265" y="106" type="qcurve" smooth="yes"/>
+      <point x="1786" y="106"/>
+      <point x="2399" y="440"/>
+      <point x="2447" y="701" type="qcurve"/>
+      <point x="2447" y="701" type="line"/>
+      <point x="2494" y="969"/>
+      <point x="2006" y="1330"/>
+      <point x="1485" y="1330" type="qcurve" smooth="yes"/>
+      <point x="978" y="1330"/>
+      <point x="348" y="953"/>
+      <point x="300" y="684" type="qcurve"/>
+      <point x="300" y="684" type="line"/>
+      <point x="254" y="421"/>
+      <point x="773" y="106"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="2042"/>
   <unicode hex="006F"/>
-  <anchor x="1015" y="0" name="bottom"/>
-  <anchor x="1015" y="510" name="center"/>
-  <anchor x="1405" y="0" name="ogonek"/>
-  <anchor x="1015" y="1020" name="top"/>
-  <anchor x="1398" y="1020" name="topright"/>
+  <anchor x="925" y="0" name="bottom"/>
+  <anchor x="1014.9267601613171" y="510" name="center"/>
+  <anchor x="1315" y="0" name="ogonek"/>
+  <anchor x="1104.8535203226343" y="1020" name="top"/>
+  <anchor x="1487.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="1021" y="-40" type="qcurve" smooth="yes"/>
-      <point x="590" y="-40"/>
-      <point x="70" y="280"/>
-      <point x="70" y="512" type="qcurve"/>
-      <point x="70" y="512" type="line"/>
-      <point x="70" y="746"/>
-      <point x="590" y="1060"/>
-      <point x="1021" y="1060" type="qcurve" smooth="yes"/>
-      <point x="1463" y="1060"/>
-      <point x="1972" y="751"/>
-      <point x="1972" y="513" type="qcurve"/>
-      <point x="1972" y="513" type="line"/>
-      <point x="1972" y="276"/>
-      <point x="1442" y="-40"/>
+      <point x="918" y="-40" type="qcurve" smooth="yes"/>
+      <point x="477" y="-40"/>
+      <point x="26" y="266"/>
+      <point x="70" y="505" type="qcurve"/>
+      <point x="70" y="505" type="line"/>
+      <point x="113" y="747"/>
+      <point x="658" y="1060"/>
+      <point x="1120" y="1060" type="qcurve" smooth="yes"/>
+      <point x="1546" y="1060"/>
+      <point x="2014" y="750"/>
+      <point x="1972" y="512" type="qcurve"/>
+      <point x="1972" y="512" type="line"/>
+      <point x="1927" y="272"/>
+      <point x="1376" y="-40"/>
     </contour>
     <contour>
-      <point x="1023" y="102" type="qcurve" smooth="yes"/>
-      <point x="1406" y="102"/>
-      <point x="1824" y="338"/>
-      <point x="1824" y="512" type="qcurve"/>
-      <point x="1824" y="512" type="line"/>
-      <point x="1824" y="688"/>
-      <point x="1402" y="918"/>
-      <point x="1023" y="918" type="qcurve" smooth="yes"/>
-      <point x="639" y="918"/>
-      <point x="218" y="687"/>
-      <point x="218" y="511" type="qcurve"/>
-      <point x="218" y="511" type="line"/>
-      <point x="218" y="341"/>
-      <point x="622" y="102"/>
+      <point x="950" y="99" type="qcurve" smooth="yes"/>
+      <point x="1338" y="99"/>
+      <point x="1793" y="335"/>
+      <point x="1824" y="511" type="qcurve"/>
+      <point x="1824" y="511" type="line"/>
+      <point x="1855" y="687"/>
+      <point x="1473" y="921"/>
+      <point x="1093" y="921" type="qcurve" smooth="yes"/>
+      <point x="712" y="921"/>
+      <point x="249" y="686"/>
+      <point x="219" y="505" type="qcurve"/>
+      <point x="219" y="505" type="line"/>
+      <point x="188" y="333"/>
+      <point x="564" y="99"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND100.ufo/fontinfo.plist
@@ -51,7 +51,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -59,7 +59,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="436"/>
   <unicode hex="004F"/>
-  <guideline x="218" y="1306" angle="90" identifier="hEvpvYajYE"/>
-  <anchor x="217" y="0" name="bottom"/>
-  <anchor x="218" y="716" name="center"/>
-  <anchor x="259" y="0" name="ogonek"/>
-  <anchor x="218" y="1432" name="top"/>
-  <anchor x="258" y="1432" name="topright"/>
+  <guideline x="358.2830368052553" y="1306" angle="100" identifier="hEvpvYajYE"/>
+  <anchor x="127" y="0" name="bottom"/>
+  <anchor x="254.2501181872609" y="716" name="center"/>
+  <anchor x="169" y="0" name="ogonek"/>
+  <anchor x="380.5002363745218" y="1432" name="top"/>
+  <anchor x="420.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="217" y="-4" type="qcurve" smooth="yes"/>
-      <point x="139" y="-4"/>
-      <point x="70" y="91"/>
-      <point x="70" y="197" type="qcurve"/>
-      <point x="70" y="1233" type="line"/>
-      <point x="70" y="1340"/>
-      <point x="140" y="1436"/>
-      <point x="218" y="1436" type="qcurve" smooth="yes"/>
-      <point x="296" y="1436"/>
-      <point x="366" y="1340"/>
-      <point x="366" y="1233" type="qcurve"/>
-      <point x="366" y="197" type="line"/>
-      <point x="366" y="91"/>
-      <point x="296" y="-4"/>
+      <point x="126" y="-4" type="qcurve" smooth="yes"/>
+      <point x="50" y="-4"/>
+      <point x="-4" y="91"/>
+      <point x="15" y="197" type="qcurve"/>
+      <point x="197" y="1233" type="line"/>
+      <point x="216" y="1340"/>
+      <point x="304" y="1436"/>
+      <point x="381" y="1436" type="qcurve" smooth="yes"/>
+      <point x="459" y="1436"/>
+      <point x="512" y="1340"/>
+      <point x="493" y="1233" type="qcurve"/>
+      <point x="311" y="197" type="line"/>
+      <point x="292" y="91"/>
+      <point x="203" y="-4"/>
     </contour>
     <contour>
-      <point x="217" y="0" type="qcurve" smooth="yes"/>
-      <point x="293" y="0"/>
-      <point x="362" y="93"/>
-      <point x="362" y="197" type="qcurve"/>
-      <point x="362" y="1233" type="line"/>
-      <point x="362" y="1338"/>
-      <point x="294" y="1432"/>
-      <point x="218" y="1432" type="qcurve" smooth="yes"/>
-      <point x="142" y="1432"/>
-      <point x="74" y="1338"/>
-      <point x="74" y="1233" type="qcurve"/>
-      <point x="74" y="197" type="line"/>
-      <point x="74" y="93"/>
-      <point x="142" y="0"/>
+      <point x="127" y="0" type="qcurve" smooth="yes"/>
+      <point x="203" y="0"/>
+      <point x="288" y="93"/>
+      <point x="307" y="197" type="qcurve"/>
+      <point x="489" y="1233" type="line"/>
+      <point x="508" y="1338"/>
+      <point x="457" y="1432"/>
+      <point x="381" y="1432" type="qcurve" smooth="yes"/>
+      <point x="305" y="1432"/>
+      <point x="220" y="1338"/>
+      <point x="201" y="1233" type="qcurve"/>
+      <point x="19" y="197" type="line"/>
+      <point x="0" y="93"/>
+      <point x="52" y="0"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND100.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="426"/>
   <unicode hex="006F"/>
-  <guideline x="213" y="619" angle="90" identifier="WQeFHH5tKG"/>
-  <anchor x="221" y="0" name="bottom"/>
-  <anchor x="213" y="510" name="center"/>
-  <anchor x="252" y="0" name="ogonek"/>
-  <anchor x="223" y="1020" name="top"/>
-  <anchor x="285" y="1020" name="topright"/>
+  <guideline x="232.14640105853982" y="619" angle="100" identifier="WQeFHH5tKG"/>
+  <anchor x="131" y="0" name="bottom"/>
+  <anchor x="212.92676016131713" y="510" name="center"/>
+  <anchor x="162" y="0" name="ogonek"/>
+  <anchor x="312.85352032263427" y="1020" name="top"/>
+  <anchor x="374.85352032263427" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="211" y="-4" type="qcurve" smooth="yes"/>
-      <point x="134" y="-4"/>
-      <point x="65" y="95"/>
-      <point x="65" y="205" type="qcurve"/>
-      <point x="65" y="823" type="line"/>
-      <point x="65" y="934"/>
-      <point x="136" y="1032"/>
-      <point x="213" y="1032" type="qcurve" smooth="yes"/>
-      <point x="292" y="1032"/>
-      <point x="361" y="934"/>
-      <point x="361" y="823" type="qcurve"/>
-      <point x="361" y="205" type="line"/>
-      <point x="361" y="95"/>
-      <point x="290" y="-4"/>
+      <point x="120" y="-4" type="qcurve" smooth="yes"/>
+      <point x="43" y="-4"/>
+      <point x="-9" y="95"/>
+      <point x="11" y="205" type="qcurve"/>
+      <point x="120" y="823" type="line"/>
+      <point x="139" y="934"/>
+      <point x="227" y="1032"/>
+      <point x="304" y="1032" type="qcurve" smooth="yes"/>
+      <point x="383" y="1032"/>
+      <point x="435" y="934"/>
+      <point x="416" y="823" type="qcurve"/>
+      <point x="307" y="205" type="line"/>
+      <point x="287" y="95"/>
+      <point x="199" y="-4"/>
     </contour>
     <contour>
-      <point x="211" y="0" type="qcurve" smooth="yes"/>
-      <point x="288" y="0"/>
-      <point x="357" y="97"/>
-      <point x="357" y="206" type="qcurve"/>
-      <point x="357" y="823" type="line"/>
-      <point x="357" y="932"/>
-      <point x="290" y="1028"/>
-      <point x="213" y="1028" type="qcurve"/>
-      <point x="138" y="1028"/>
-      <point x="69" y="932"/>
-      <point x="69" y="823" type="qcurve"/>
-      <point x="69" y="206" type="line"/>
-      <point x="69" y="97"/>
-      <point x="136" y="0"/>
+      <point x="120" y="0" type="qcurve" smooth="yes"/>
+      <point x="197" y="0"/>
+      <point x="284" y="97"/>
+      <point x="303" y="206" type="qcurve"/>
+      <point x="412" y="823" type="line"/>
+      <point x="431" y="932"/>
+      <point x="381" y="1028"/>
+      <point x="304" y="1028" type="qcurve"/>
+      <point x="229" y="1028"/>
+      <point x="143" y="932"/>
+      <point x="124" y="823" type="qcurve"/>
+      <point x="15" y="206" type="line"/>
+      <point x="-4" y="97"/>
+      <point x="45" y="0"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND100.ufo/fontinfo.plist
@@ -88,7 +88,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -96,7 +96,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1332"/>
   <unicode hex="004F"/>
-  <guideline x="666" y="0" angle="90" identifier="0M3O9gaZ6r"/>
-  <anchor x="666" y="0" name="bottom"/>
-  <anchor x="664" y="716" name="center"/>
-  <anchor x="876" y="0" name="ogonek"/>
-  <anchor x="666" y="1433" name="top"/>
-  <anchor x="831" y="1432" name="topright"/>
+  <guideline x="576" y="0" angle="100" identifier="0M3O9gaZ6r"/>
+  <anchor x="576" y="0" name="bottom"/>
+  <anchor x="700.2501181872609" y="716" name="center"/>
+  <anchor x="786" y="0" name="ogonek"/>
+  <anchor x="828.6765633552303" y="1433" name="top"/>
+  <anchor x="993.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="666" y="-32" type="qcurve" smooth="yes"/>
-      <point x="374" y="-32"/>
-      <point x="24" y="373"/>
-      <point x="24" y="720" type="qcurve"/>
-      <point x="24" y="729" type="line"/>
-      <point x="24" y="1071"/>
-      <point x="376" y="1460"/>
-      <point x="666" y="1460" type="qcurve" smooth="yes"/>
-      <point x="956" y="1460"/>
-      <point x="1308" y="1059"/>
-      <point x="1308" y="729" type="qcurve"/>
-      <point x="1308" y="720" type="line"/>
-      <point x="1308" y="383"/>
-      <point x="956" y="-32"/>
+      <point x="580" y="-32" type="qcurve" smooth="yes"/>
+      <point x="308" y="-32"/>
+      <point x="0" y="373"/>
+      <point x="61" y="720" type="qcurve"/>
+      <point x="63" y="729" type="line"/>
+      <point x="123" y="1071"/>
+      <point x="514" y="1460"/>
+      <point x="827" y="1460" type="qcurve" smooth="yes"/>
+      <point x="1104" y="1460"/>
+      <point x="1406" y="1069"/>
+      <point x="1347" y="729" type="qcurve"/>
+      <point x="1345" y="720" type="line"/>
+      <point x="1284" y="357"/>
+      <point x="896" y="-32"/>
     </contour>
     <contour>
-      <point x="666" y="525" type="qcurve" smooth="yes"/>
-      <point x="705" y="525"/>
-      <point x="739" y="574"/>
-      <point x="739" y="633" type="qcurve"/>
-      <point x="739" y="801" type="line"/>
-      <point x="739" y="862"/>
-      <point x="705" y="913"/>
-      <point x="666" y="913" type="qcurve" smooth="yes"/>
-      <point x="627" y="913"/>
-      <point x="593" y="862"/>
-      <point x="593" y="801" type="qcurve"/>
-      <point x="593" y="633" type="line"/>
-      <point x="593" y="574"/>
-      <point x="627" y="525"/>
+      <point x="669" y="525" type="qcurve" smooth="yes"/>
+      <point x="708" y="525"/>
+      <point x="751" y="574"/>
+      <point x="761" y="633" type="qcurve" smooth="yes"/>
+      <point x="790" y="801" type="line" smooth="yes"/>
+      <point x="801" y="862"/>
+      <point x="776" y="913"/>
+      <point x="737" y="913" type="qcurve" smooth="yes"/>
+      <point x="698" y="913"/>
+      <point x="655" y="862"/>
+      <point x="644" y="801" type="qcurve" smooth="yes"/>
+      <point x="615" y="633" type="line" smooth="yes"/>
+      <point x="605" y="574"/>
+      <point x="630" y="525"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1150"/>
   <unicode hex="006F"/>
-  <anchor x="575" y="0" name="bottom"/>
-  <anchor x="578" y="510" name="center"/>
-  <anchor x="776" y="0" name="ogonek"/>
-  <anchor x="575" y="1020" name="top"/>
-  <anchor x="752" y="1020" name="topright"/>
+  <anchor x="485" y="0" name="bottom"/>
+  <anchor x="577.9267601613171" y="510" name="center"/>
+  <anchor x="686" y="0" name="ogonek"/>
+  <anchor x="664.8535203226343" y="1020" name="top"/>
+  <anchor x="841.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="570" y="-32" type="qcurve"/>
-      <point x="328" y="-32"/>
-      <point x="16" y="276"/>
-      <point x="16" y="514" type="qcurve"/>
-      <point x="16" y="514" type="line"/>
-      <point x="16" y="751"/>
-      <point x="328" y="1058"/>
-      <point x="570" y="1058" type="qcurve" smooth="yes"/>
-      <point x="816" y="1058"/>
-      <point x="1134" y="751"/>
-      <point x="1134" y="514" type="qcurve"/>
-      <point x="1134" y="514" type="line"/>
-      <point x="1134" y="276"/>
-      <point x="816" y="-32"/>
+      <point x="493" y="-32" type="qcurve"/>
+      <point x="265" y="-32"/>
+      <point x="-25" y="276"/>
+      <point x="17" y="514" type="qcurve"/>
+      <point x="17" y="514" type="line"/>
+      <point x="58" y="755"/>
+      <point x="386" y="1058"/>
+      <point x="630" y="1058" type="qcurve" smooth="yes"/>
+      <point x="894" y="1058"/>
+      <point x="1176" y="751"/>
+      <point x="1135" y="514" type="qcurve"/>
+      <point x="1135" y="514" type="line"/>
+      <point x="1093" y="270"/>
+      <point x="760" y="-32"/>
     </contour>
     <contour>
-      <point x="576" y="420" type="qcurve" smooth="yes"/>
-      <point x="608" y="420"/>
-      <point x="630" y="452"/>
-      <point x="630" y="482" type="qcurve"/>
-      <point x="630" y="542" type="line"/>
-      <point x="630" y="582"/>
-      <point x="606" y="614"/>
-      <point x="576" y="614" type="qcurve" smooth="yes"/>
-      <point x="544" y="614"/>
-      <point x="520" y="580"/>
-      <point x="520" y="542" type="qcurve"/>
-      <point x="520" y="482" type="line"/>
-      <point x="520" y="453"/>
-      <point x="544" y="420"/>
+      <point x="560" y="420" type="qcurve" smooth="yes"/>
+      <point x="590" y="420"/>
+      <point x="619" y="452"/>
+      <point x="625" y="482" type="qcurve" smooth="yes"/>
+      <point x="636" y="542" type="line" smooth="yes"/>
+      <point x="643" y="582"/>
+      <point x="621" y="614"/>
+      <point x="594" y="614" type="qcurve" smooth="yes"/>
+      <point x="562" y="614"/>
+      <point x="532" y="580"/>
+      <point x="526" y="542" type="qcurve" smooth="yes"/>
+      <point x="515" y="482" type="line" smooth="yes"/>
+      <point x="510" y="453"/>
+      <point x="531" y="420"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND100.ufo/fontinfo.plist
@@ -101,7 +101,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -109,7 +109,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="496"/>
   <unicode hex="004F"/>
-  <guideline x="248" y="1079" angle="90" identifier="HniCRbuluR"/>
-  <anchor x="248" y="0" name="bottom"/>
-  <anchor x="248" y="716" name="center"/>
-  <anchor x="319" y="0" name="ogonek"/>
-  <anchor x="247" y="1432" name="top"/>
-  <anchor x="333" y="1432" name="topright"/>
+  <guideline x="348.25681218443367" y="1079" angle="100" identifier="HniCRbuluR"/>
+  <anchor x="158" y="0" name="bottom"/>
+  <anchor x="284.2501181872609" y="716" name="center"/>
+  <anchor x="229" y="0" name="ogonek"/>
+  <anchor x="409.5002363745218" y="1432" name="top"/>
+  <anchor x="495.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="248" y="-10" type="qcurve" smooth="yes"/>
-      <point x="150" y="-10"/>
-      <point x="44" y="114"/>
-      <point x="44" y="224" type="qcurve"/>
-      <point x="44" y="1216" type="line" smooth="yes"/>
-      <point x="44" y="1328"/>
-      <point x="148" y="1446"/>
-      <point x="248" y="1446" type="qcurve" smooth="yes"/>
-      <point x="348" y="1446"/>
-      <point x="452" y="1328"/>
-      <point x="452" y="1216" type="qcurve"/>
-      <point x="452" y="224" type="line" smooth="yes"/>
-      <point x="452" y="114"/>
-      <point x="346" y="-10"/>
+      <point x="156" y="-10" type="qcurve" smooth="yes"/>
+      <point x="58" y="-10"/>
+      <point x="-26" y="114"/>
+      <point x="-7" y="224" type="qcurve"/>
+      <point x="168" y="1216" type="line" smooth="yes"/>
+      <point x="188" y="1328"/>
+      <point x="313" y="1446"/>
+      <point x="413" y="1446" type="qcurve" smooth="yes"/>
+      <point x="513" y="1446"/>
+      <point x="596" y="1328"/>
+      <point x="576" y="1216" type="qcurve"/>
+      <point x="401" y="224" type="line" smooth="yes"/>
+      <point x="382" y="114"/>
+      <point x="254" y="-10"/>
     </contour>
     <contour>
-      <point x="248" y="130" type="qcurve" smooth="yes"/>
-      <point x="284" y="130"/>
-      <point x="312" y="176"/>
-      <point x="312" y="232" type="qcurve"/>
-      <point x="312" y="1202" type="line" smooth="yes"/>
-      <point x="312" y="1256"/>
-      <point x="282" y="1304"/>
-      <point x="248" y="1304" type="qcurve" smooth="yes"/>
-      <point x="214" y="1304"/>
-      <point x="184" y="1256"/>
-      <point x="184" y="1202" type="qcurve"/>
-      <point x="184" y="232" type="line" smooth="yes"/>
-      <point x="184" y="176"/>
-      <point x="212" y="130"/>
+      <point x="181" y="130" type="qcurve" smooth="yes"/>
+      <point x="217" y="130"/>
+      <point x="253" y="176"/>
+      <point x="263" y="232" type="qcurve"/>
+      <point x="434" y="1202" type="line" smooth="yes"/>
+      <point x="444" y="1257"/>
+      <point x="420" y="1304"/>
+      <point x="387" y="1304" type="qcurve" smooth="yes"/>
+      <point x="352" y="1304"/>
+      <point x="315" y="1256"/>
+      <point x="306" y="1202" type="qcurve"/>
+      <point x="135" y="232" type="line" smooth="yes"/>
+      <point x="125" y="176"/>
+      <point x="145" y="130"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND100.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="424"/>
   <unicode hex="006F"/>
-  <guideline x="212" y="689" angle="90" identifier="uFr6e3RYj8"/>
-  <anchor x="212" y="0" name="bottom"/>
-  <anchor x="212" y="510" name="center"/>
-  <anchor x="286" y="0" name="ogonek"/>
-  <anchor x="212" y="1020" name="top"/>
-  <anchor x="281" y="1020" name="topright"/>
+  <guideline x="243.48928970813233" y="689" angle="100" identifier="uFr6e3RYj8"/>
+  <anchor x="122" y="0" name="bottom"/>
+  <anchor x="211.92676016131713" y="510" name="center"/>
+  <anchor x="196" y="0" name="ogonek"/>
+  <anchor x="301.85352032263427" y="1020" name="top"/>
+  <anchor x="370.85352032263427" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="212" y="-12" type="qcurve" smooth="yes"/>
-      <point x="124" y="-12"/>
-      <point x="36" y="92"/>
-      <point x="36" y="198" type="qcurve"/>
-      <point x="36" y="816" type="line"/>
-      <point x="36" y="924"/>
-      <point x="124" y="1032"/>
-      <point x="212" y="1032" type="qcurve" smooth="yes"/>
-      <point x="296" y="1032"/>
-      <point x="388" y="920"/>
-      <point x="388" y="816" type="qcurve"/>
-      <point x="388" y="198" type="line"/>
-      <point x="388" y="92"/>
-      <point x="300" y="-12"/>
+      <point x="120" y="-12" type="qcurve" smooth="yes"/>
+      <point x="32" y="-12"/>
+      <point x="-38" y="92"/>
+      <point x="-19" y="198" type="qcurve"/>
+      <point x="90" y="816" type="line"/>
+      <point x="109" y="924"/>
+      <point x="216" y="1032"/>
+      <point x="304" y="1032" type="qcurve" smooth="yes"/>
+      <point x="388" y="1032"/>
+      <point x="460" y="920"/>
+      <point x="442" y="816" type="qcurve"/>
+      <point x="333" y="198" type="line"/>
+      <point x="314" y="92"/>
+      <point x="208" y="-12"/>
     </contour>
     <contour>
-      <point x="212" y="122" type="qcurve" smooth="yes"/>
-      <point x="234" y="122"/>
-      <point x="254" y="160"/>
-      <point x="254" y="198" type="qcurve"/>
-      <point x="254" y="824" type="line" smooth="yes"/>
-      <point x="254" y="866"/>
-      <point x="234" y="896"/>
-      <point x="212" y="896" type="qcurve" smooth="yes"/>
-      <point x="190" y="896"/>
-      <point x="170" y="866"/>
-      <point x="170" y="824" type="qcurve"/>
-      <point x="170" y="198" type="line" smooth="yes"/>
-      <point x="170" y="160"/>
-      <point x="190" y="122"/>
+      <point x="143" y="122" type="qcurve" smooth="yes"/>
+      <point x="165" y="122"/>
+      <point x="192" y="160"/>
+      <point x="199" y="198" type="qcurve"/>
+      <point x="309" y="824" type="line" smooth="yes"/>
+      <point x="316" y="866"/>
+      <point x="302" y="896"/>
+      <point x="280" y="896" type="qcurve" smooth="yes"/>
+      <point x="258" y="896"/>
+      <point x="232" y="866"/>
+      <point x="225" y="824" type="qcurve"/>
+      <point x="115" y="198" type="line" smooth="yes"/>
+      <point x="108" y="160"/>
+      <point x="121" y="122"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND100.ufo/fontinfo.plist
@@ -43,7 +43,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -51,7 +51,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="836"/>
   <unicode hex="004F"/>
-  <guideline x="418" y="1069" angle="90" identifier="i4Hg9FmbRY"/>
-  <anchor x="430" y="0" name="bottom"/>
-  <anchor x="418" y="716" name="center"/>
-  <anchor x="518" y="0" name="ogonek"/>
-  <anchor x="431" y="1432" name="top"/>
-  <anchor x="531" y="1432" name="topright"/>
+  <guideline x="516.4935423773491" y="1069" angle="100" identifier="i4Hg9FmbRY"/>
+  <anchor x="340" y="0" name="bottom"/>
+  <anchor x="454.2501181872609" y="716" name="center"/>
+  <anchor x="428" y="0" name="ogonek"/>
+  <anchor x="593.5002363745218" y="1432" name="top"/>
+  <anchor x="693.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="417" y="-13" type="qcurve" smooth="yes"/>
-      <point x="272" y="-13" name="inserted"/>
-      <point x="115" y="169"/>
-      <point x="115" y="337" type="qcurve"/>
-      <point x="115" y="1093" type="line"/>
-      <point x="115" y="1262" name="inserted"/>
-      <point x="272" y="1445"/>
-      <point x="418" y="1445" type="qcurve" smooth="yes"/>
-      <point x="563" y="1445" name="inserted"/>
-      <point x="721" y="1262"/>
-      <point x="721" y="1093" type="qcurve"/>
-      <point x="721" y="337" type="line"/>
-      <point x="721" y="169" name="inserted"/>
-      <point x="564" y="-13"/>
+      <point x="325" y="-13" type="qcurve" smooth="yes"/>
+      <point x="180" y="-13" name="inserted"/>
+      <point x="55" y="169"/>
+      <point x="84" y="337" type="qcurve"/>
+      <point x="218" y="1093" type="line"/>
+      <point x="247" y="1262" name="inserted"/>
+      <point x="438" y="1445"/>
+      <point x="583" y="1445" type="qcurve" smooth="yes"/>
+      <point x="728" y="1445" name="inserted"/>
+      <point x="853" y="1262"/>
+      <point x="824" y="1093" type="qcurve"/>
+      <point x="690" y="337" type="line"/>
+      <point x="661" y="169" name="inserted"/>
+      <point x="471" y="-13"/>
     </contour>
     <contour>
-      <point x="417" y="-9" type="qcurve" smooth="yes"/>
-      <point x="560" y="-9" name="inserted"/>
-      <point x="716" y="171"/>
-      <point x="716" y="337" type="qcurve"/>
-      <point x="716" y="1094" type="line"/>
-      <point x="716" y="1260" name="inserted"/>
-      <point x="561" y="1441"/>
-      <point x="417" y="1441" type="qcurve" smooth="yes"/>
-      <point x="274" y="1441" name="inserted"/>
-      <point x="119" y="1260"/>
-      <point x="119" y="1094" type="qcurve"/>
-      <point x="119" y="337" type="line"/>
-      <point x="119" y="171" name="inserted"/>
-      <point x="274" y="-9"/>
+      <point x="325" y="-9" type="qcurve" smooth="yes"/>
+      <point x="468" y="-9" name="inserted"/>
+      <point x="657" y="170"/>
+      <point x="686" y="337" type="qcurve"/>
+      <point x="820" y="1094" type="line"/>
+      <point x="849" y="1260" name="inserted"/>
+      <point x="726" y="1441"/>
+      <point x="581" y="1441" type="qcurve" smooth="yes"/>
+      <point x="439" y="1441" name="inserted"/>
+      <point x="251" y="1260"/>
+      <point x="222" y="1094" type="qcurve"/>
+      <point x="88" y="337" type="line"/>
+      <point x="59" y="171" name="inserted"/>
+      <point x="183" y="-9"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND100.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="658"/>
   <unicode hex="006F"/>
-  <guideline x="329" y="775" angle="90" identifier="b4tQfMxpGF"/>
-  <anchor x="328" y="0" name="bottom"/>
-  <anchor x="329" y="510" name="center"/>
-  <anchor x="407" y="0" name="ogonek"/>
-  <anchor x="329" y="1020" name="top"/>
-  <anchor x="426" y="1020" name="topright"/>
+  <guideline x="375.65341004906037" y="775" angle="100" identifier="b4tQfMxpGF"/>
+  <anchor x="238" y="0" name="bottom"/>
+  <anchor x="328.92676016131713" y="510" name="center"/>
+  <anchor x="317" y="0" name="ogonek"/>
+  <anchor x="418.85352032263427" y="1020" name="top"/>
+  <anchor x="515.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="328" y="-10" type="qcurve" smooth="yes"/>
-      <point x="210" y="-10" name="inserted"/>
-      <point x="77" y="141"/>
-      <point x="77" y="287" type="qcurve"/>
-      <point x="77" y="741" type="line"/>
-      <point x="77" y="886" name="inserted"/>
-      <point x="211" y="1037"/>
-      <point x="329" y="1037" type="qcurve" smooth="yes"/>
-      <point x="448" y="1037" name="inserted"/>
-      <point x="581" y="886"/>
-      <point x="581" y="741" type="qcurve"/>
-      <point x="581" y="287" type="line"/>
-      <point x="581" y="141" name="inserted"/>
-      <point x="446" y="-10"/>
+      <point x="236" y="-10" type="qcurve" smooth="yes"/>
+      <point x="119" y="-10" name="inserted"/>
+      <point x="11" y="141"/>
+      <point x="37" y="287" type="qcurve"/>
+      <point x="117" y="741" type="line"/>
+      <point x="143" y="886" name="inserted"/>
+      <point x="303" y="1037"/>
+      <point x="421" y="1037" type="qcurve" smooth="yes"/>
+      <point x="540" y="1037" name="inserted"/>
+      <point x="647" y="885"/>
+      <point x="621" y="741" type="qcurve"/>
+      <point x="541" y="287" type="line"/>
+      <point x="515" y="141" name="inserted"/>
+      <point x="354" y="-10"/>
     </contour>
     <contour>
-      <point x="328" y="-6" type="qcurve" smooth="yes"/>
-      <point x="445" y="-6" name="inserted"/>
-      <point x="578" y="143"/>
-      <point x="578" y="287" type="qcurve"/>
-      <point x="578" y="741" type="line"/>
-      <point x="578" y="884" name="inserted"/>
-      <point x="447" y="1033"/>
-      <point x="329" y="1033" type="qcurve" smooth="yes"/>
-      <point x="213" y="1033" name="inserted"/>
-      <point x="81" y="884"/>
-      <point x="81" y="741" type="qcurve"/>
-      <point x="81" y="287" type="line"/>
-      <point x="81" y="143" name="inserted"/>
-      <point x="212" y="-6"/>
+      <point x="236" y="-6" type="qcurve" smooth="yes"/>
+      <point x="353" y="-6" name="inserted"/>
+      <point x="512" y="143"/>
+      <point x="537" y="287" type="qcurve"/>
+      <point x="617" y="741" type="line"/>
+      <point x="642" y="884" name="inserted"/>
+      <point x="539" y="1033"/>
+      <point x="421" y="1033" type="qcurve" smooth="yes"/>
+      <point x="305" y="1033" name="inserted"/>
+      <point x="146" y="884"/>
+      <point x="121" y="741" type="qcurve"/>
+      <point x="41" y="287" type="line"/>
+      <point x="16" y="143" name="inserted"/>
+      <point x="120" y="-6"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND100.ufo/fontinfo.plist
@@ -43,7 +43,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -51,7 +51,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1419"/>
   <unicode hex="004F"/>
-  <anchor x="708" y="0" name="bottom"/>
-  <anchor x="706" y="716" name="center"/>
-  <anchor x="933" y="0" name="ogonek"/>
-  <anchor x="708" y="1433" name="top"/>
-  <anchor x="891" y="1432" name="topright"/>
+  <anchor x="618" y="0" name="bottom"/>
+  <anchor x="742.2501181872609" y="716" name="center"/>
+  <anchor x="843" y="0" name="ogonek"/>
+  <anchor x="870.6765633552303" y="1433" name="top"/>
+  <anchor x="1053.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="709" y="-32" type="qcurve" smooth="yes"/>
-      <point x="410" y="-32" name="inserted"/>
-      <point x="29" y="350"/>
-      <point x="29" y="678" type="qcurve"/>
-      <point x="29" y="765" type="line"/>
-      <point x="29" y="1089" name="inserted"/>
-      <point x="408" y="1461"/>
-      <point x="709" y="1461" type="qcurve" smooth="yes"/>
-      <point x="1011" y="1461" name="inserted"/>
-      <point x="1389" y="1078"/>
-      <point x="1389" y="764" type="qcurve"/>
-      <point x="1389" y="678" type="line"/>
-      <point x="1389" y="360" name="inserted"/>
-      <point x="1008" y="-32"/>
+      <point x="613.3575366173292" y="-32" type="qcurve" smooth="yes"/>
+      <point x="337" y="-32" name="inserted"/>
+      <point x="0" y="350"/>
+      <point x="59" y="678" type="qcurve" smooth="yes"/>
+      <point x="74" y="765" type="line" smooth="yes"/>
+      <point x="131" y="1089" name="inserted"/>
+      <point x="526" y="1461"/>
+      <point x="846" y="1461" type="qcurve" smooth="yes"/>
+      <point x="1164" y="1461" name="inserted"/>
+      <point x="1489.0804852037252" y="1078"/>
+      <point x="1433.7138132612672" y="764" type="qcurve"/>
+      <point x="1418.5496929203393" y="678" type="line"/>
+      <point x="1362.4777130550474" y="360" name="inserted"/>
+      <point x="945" y="-32"/>
     </contour>
     <contour>
-      <point x="709" y="518" type="qcurve" smooth="yes"/>
-      <point x="766" y="518" name="inserted"/>
-      <point x="826" y="589"/>
-      <point x="826" y="658" type="qcurve"/>
-      <point x="826" y="771" type="line"/>
-      <point x="826" y="842" name="inserted"/>
-      <point x="766" y="914"/>
-      <point x="709" y="914" type="qcurve" smooth="yes"/>
-      <point x="652" y="914" name="inserted"/>
-      <point x="593" y="842"/>
-      <point x="593" y="771" type="qcurve"/>
-      <point x="593" y="658" type="line"/>
-      <point x="593" y="589" name="inserted"/>
-      <point x="652" y="518"/>
+      <point x="710.3373760069849" y="518" type="qcurve" smooth="yes"/>
+      <point x="767.3373760069849" y="518" name="inserted"/>
+      <point x="840" y="589"/>
+      <point x="852" y="658" type="qcurve" smooth="yes"/>
+      <point x="872" y="771" type="line" smooth="yes"/>
+      <point x="884" y="842" name="inserted"/>
+      <point x="837.162860367537" y="914"/>
+      <point x="780.162860367537" y="914" type="qcurve" smooth="yes"/>
+      <point x="723.162860367537" y="914" name="inserted"/>
+      <point x="651" y="842"/>
+      <point x="639" y="771" type="qcurve" smooth="yes"/>
+      <point x="619" y="658" type="line" smooth="yes"/>
+      <point x="607" y="589" name="inserted"/>
+      <point x="653.3373760069849" y="518"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1161"/>
   <unicode hex="006F"/>
-  <anchor x="579" y="0" name="bottom"/>
-  <anchor x="583" y="510" name="center"/>
-  <anchor x="793" y="0" name="ogonek"/>
-  <anchor x="579" y="1020" name="top"/>
-  <anchor x="778" y="1020" name="topright"/>
+  <anchor x="489" y="0" name="bottom"/>
+  <anchor x="582.9267601613171" y="510" name="center"/>
+  <anchor x="703" y="0" name="ogonek"/>
+  <anchor x="668.8535203226343" y="1020" name="top"/>
+  <anchor x="867.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="576" y="-33" type="qcurve" smooth="yes"/>
-      <point x="325" y="-33" name="inserted"/>
-      <point x="17" y="262"/>
-      <point x="17" y="505" type="qcurve"/>
-      <point x="17" y="522" type="line"/>
-      <point x="17" y="766" name="inserted"/>
-      <point x="325" y="1061"/>
-      <point x="576" y="1061" type="qcurve" smooth="yes"/>
-      <point x="829" y="1061" name="inserted"/>
-      <point x="1144" y="765"/>
-      <point x="1144" y="522" type="qcurve"/>
-      <point x="1144" y="505" type="line"/>
-      <point x="1144" y="264" name="inserted"/>
-      <point x="829" y="-33"/>
+      <point x="490" y="-33" type="qcurve" smooth="yes"/>
+      <point x="255" y="-33" name="inserted"/>
+      <point x="-27" y="262"/>
+      <point x="16" y="505" type="qcurve"/>
+      <point x="19" y="522" type="line"/>
+      <point x="62" y="766" name="inserted"/>
+      <point x="388" y="1061"/>
+      <point x="658" y="1061" type="qcurve" smooth="yes"/>
+      <point x="927" y="1061" name="inserted"/>
+      <point x="1189" y="765"/>
+      <point x="1146" y="522" type="qcurve"/>
+      <point x="1143" y="505" type="line"/>
+      <point x="1101" y="264" name="inserted"/>
+      <point x="762" y="-33"/>
     </contour>
     <contour>
-      <point x="581" y="407" type="qcurve" smooth="yes"/>
-      <point x="619" y="407" name="inserted"/>
-      <point x="661" y="452"/>
-      <point x="661" y="491" type="qcurve"/>
-      <point x="661" y="537" type="line"/>
-      <point x="661" y="579" name="inserted"/>
-      <point x="617" y="622"/>
-      <point x="581" y="622" type="qcurve" smooth="yes"/>
-      <point x="545" y="622" name="inserted"/>
-      <point x="500" y="580"/>
-      <point x="500" y="537" type="qcurve"/>
-      <point x="500" y="492" type="line"/>
-      <point x="500" y="452" name="inserted"/>
-      <point x="544" y="408"/>
+      <point x="563" y="407" type="qcurve" smooth="yes"/>
+      <point x="601" y="407" name="inserted"/>
+      <point x="651" y="452"/>
+      <point x="658" y="491" type="qcurve" smooth="yes"/>
+      <point x="666" y="537" type="line" smooth="yes"/>
+      <point x="673" y="579" name="inserted"/>
+      <point x="637" y="622"/>
+      <point x="601" y="622" type="qcurve" smooth="yes"/>
+      <point x="565" y="622" name="inserted"/>
+      <point x="513" y="580"/>
+      <point x="505" y="537" type="qcurve" smooth="yes"/>
+      <point x="497" y="492" type="line" smooth="yes"/>
+      <point x="490" y="452" name="inserted"/>
+      <point x="526" y="408"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND100.ufo/fontinfo.plist
@@ -43,7 +43,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -51,7 +51,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="818"/>
   <unicode hex="004F"/>
-  <guideline x="409" y="948" angle="90" identifier="41ur2866O7"/>
-  <anchor x="462" y="0" name="bottom"/>
-  <anchor x="409" y="716" name="center"/>
-  <anchor x="572" y="0" name="ogonek"/>
-  <anchor x="461" y="1432" name="top"/>
-  <anchor x="595" y="1432" name="topright"/>
+  <guideline x="486.1579777116" y="948" angle="100" identifier="41ur2866O7"/>
+  <anchor x="372" y="0" name="bottom"/>
+  <anchor x="445.2501181873" y="716" name="center"/>
+  <anchor x="482" y="0" name="ogonek"/>
+  <anchor x="623.5002363745" y="1432" name="top"/>
+  <anchor x="757.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="409" y="-18" type="qcurve"/>
-      <point x="257" y="-18"/>
-      <point x="84" y="168"/>
-      <point x="84" y="318" type="qcurve"/>
-      <point x="84" y="1119" type="line"/>
-      <point x="84" y="1269"/>
-      <point x="255" y="1452"/>
-      <point x="409" y="1452" type="qcurve"/>
-      <point x="562" y="1452"/>
-      <point x="734" y="1268"/>
-      <point x="734" y="1119" type="qcurve"/>
-      <point x="734" y="318" type="line"/>
-      <point x="734" y="170"/>
-      <point x="560" y="-18"/>
+      <point x="316" y="-18" type="qcurve"/>
+      <point x="169" y="-18"/>
+      <point x="24" y="168"/>
+      <point x="50" y="318" type="qcurve" smooth="yes"/>
+      <point x="191" y="1119" type="line" smooth="yes"/>
+      <point x="218" y="1269"/>
+      <point x="410" y="1452"/>
+      <point x="575" y="1452" type="qcurve"/>
+      <point x="718" y="1452"/>
+      <point x="868" y="1268"/>
+      <point x="841" y="1119" type="qcurve" smooth="yes"/>
+      <point x="700" y="318" type="line" smooth="yes"/>
+      <point x="674" y="170"/>
+      <point x="479" y="-18"/>
     </contour>
     <contour>
-      <point x="409" y="123" type="qcurve"/>
-      <point x="498" y="122"/>
-      <point x="592" y="229"/>
-      <point x="592" y="320" type="qcurve"/>
-      <point x="592" y="1113" type="line"/>
-      <point x="592" y="1202"/>
-      <point x="497" y="1309"/>
-      <point x="409" y="1309" type="qcurve"/>
-      <point x="321" y="1309"/>
-      <point x="227" y="1202"/>
-      <point x="227" y="1113" type="qcurve"/>
-      <point x="227" y="320" type="line"/>
-      <point x="227" y="229"/>
-      <point x="320" y="122"/>
+      <point x="341" y="123" type="qcurve"/>
+      <point x="430" y="122"/>
+      <point x="542" y="229"/>
+      <point x="558" y="320" type="qcurve" smooth="yes"/>
+      <point x="698" y="1113" type="line" smooth="yes"/>
+      <point x="714" y="1202"/>
+      <point x="638" y="1309"/>
+      <point x="550" y="1309" type="qcurve"/>
+      <point x="462" y="1309"/>
+      <point x="349" y="1202"/>
+      <point x="333" y="1113" type="qcurve" smooth="yes"/>
+      <point x="193" y="320" type="line" smooth="yes"/>
+      <point x="177" y="229"/>
+      <point x="252" y="122"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND100.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="690"/>
   <unicode hex="006F"/>
-  <guideline x="346" y="655" angle="90" identifier="E9GpXnKKZy"/>
-  <anchor x="345" y="0" name="bottom"/>
-  <anchor x="345" y="510" name="center"/>
-  <anchor x="459" y="0" name="ogonek"/>
-  <anchor x="345" y="1020" name="top"/>
-  <anchor x="448" y="1020" name="topright"/>
+  <guideline x="371.494172364" y="655" angle="100" identifier="E9GpXnKKZy"/>
+  <anchor x="255" y="0" name="bottom"/>
+  <anchor x="344.9267601613" y="510" name="center"/>
+  <anchor x="369" y="0" name="ogonek"/>
+  <anchor x="434.8535203226" y="1020" name="top"/>
+  <anchor x="537.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="345" y="-19" type="qcurve"/>
-      <point x="214" y="-19"/>
-      <point x="63" y="138"/>
-      <point x="63" y="283" type="qcurve"/>
-      <point x="63" y="730" type="line"/>
-      <point x="63" y="875"/>
-      <point x="215" y="1036"/>
-      <point x="345" y="1036" type="qcurve"/>
-      <point x="472" y="1036"/>
-      <point x="627" y="871"/>
-      <point x="627" y="730" type="qcurve"/>
-      <point x="627" y="283" type="line"/>
-      <point x="627" y="140"/>
-      <point x="476" y="-19"/>
+      <point x="252" y="-19" type="qcurve"/>
+      <point x="126" y="-19"/>
+      <point x="-3" y="138"/>
+      <point x="23" y="283" type="qcurve" smooth="yes"/>
+      <point x="102" y="730" type="line" smooth="yes"/>
+      <point x="127" y="875"/>
+      <point x="298" y="1036"/>
+      <point x="435" y="1037" type="qcurve"/>
+      <point x="557" y="1036"/>
+      <point x="691" y="871"/>
+      <point x="666" y="730" type="qcurve" smooth="yes"/>
+      <point x="587" y="283" type="line" smooth="yes"/>
+      <point x="562" y="140"/>
+      <point x="398" y="-19"/>
     </contour>
     <contour>
-      <point x="346" y="115" type="qcurve"/>
-      <point x="413" y="115"/>
-      <point x="489" y="201"/>
-      <point x="489" y="281" type="qcurve"/>
-      <point x="489" y="736" type="line"/>
-      <point x="489" y="818"/>
-      <point x="412" y="900"/>
-      <point x="346" y="900" type="qcurve"/>
-      <point x="278" y="900"/>
-      <point x="200" y="819"/>
-      <point x="200" y="736" type="qcurve"/>
-      <point x="200" y="281" type="line"/>
-      <point x="200" y="200"/>
-      <point x="277" y="115"/>
+      <point x="276" y="115" type="qcurve"/>
+      <point x="343" y="115"/>
+      <point x="434" y="201"/>
+      <point x="449" y="281" type="qcurve" smooth="yes"/>
+      <point x="529" y="736" type="line" smooth="yes"/>
+      <point x="543" y="818"/>
+      <point x="481" y="900"/>
+      <point x="415" y="900" type="qcurve"/>
+      <point x="347" y="900"/>
+      <point x="254" y="819"/>
+      <point x="240" y="736" type="qcurve" smooth="yes"/>
+      <point x="160" y="281" type="line" smooth="yes"/>
+      <point x="145" y="200"/>
+      <point x="207" y="115"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND100.ufo/fontinfo.plist
@@ -43,7 +43,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -51,7 +51,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1397"/>
   <unicode hex="004F"/>
-  <guideline x="698" y="1019" angle="90" identifier="mstlIjMGNd"/>
-  <anchor x="728" y="0" name="bottom"/>
-  <anchor x="698" y="716" name="center"/>
-  <anchor x="892" y="0" name="ogonek"/>
-  <anchor x="728" y="1432" name="top"/>
-  <anchor x="912" y="1432" name="topright"/>
+  <guideline x="787.6771933419" y="1019" angle="100" identifier="mstlIjMGNd"/>
+  <anchor x="638" y="0" name="bottom"/>
+  <anchor x="734.2501181873" y="716" name="center"/>
+  <anchor x="802" y="0" name="ogonek"/>
+  <anchor x="890.5002363745" y="1432" name="top"/>
+  <anchor x="1074.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="698" y="-26" type="qcurve" smooth="yes"/>
-      <point x="426" y="-26" name="inserted"/>
-      <point x="110" y="320"/>
-      <point x="110" y="612" type="qcurve"/>
-      <point x="110" y="819" type="line"/>
-      <point x="110" y="1112" name="inserted"/>
-      <point x="426" y="1458"/>
-      <point x="698" y="1458" type="qcurve" smooth="yes"/>
-      <point x="971" y="1458" name="inserted"/>
-      <point x="1287" y="1112"/>
-      <point x="1287" y="819" type="qcurve"/>
-      <point x="1287" y="612" type="line"/>
-      <point x="1287" y="320" name="inserted"/>
-      <point x="971" y="-26"/>
+      <point x="603.4154985016" y="-26" type="qcurve" smooth="yes"/>
+      <point x="331.4154985016" y="-26" name="inserted"/>
+      <point x="76.4246338267" y="320"/>
+      <point x="127.9121121936" y="612" type="qcurve"/>
+      <point x="164.4117972002" y="819" type="line"/>
+      <point x="216.0756025478" y="1112" name="inserted"/>
+      <point x="593.0847378729" y="1458"/>
+      <point x="865.0847378729" y="1458" type="qcurve" smooth="yes"/>
+      <point x="1138.0847378729" y="1458" name="inserted"/>
+      <point x="1393.0756025478" y="1112"/>
+      <point x="1341.4117972002" y="819" type="qcurve"/>
+      <point x="1304.9121121936" y="612" type="line"/>
+      <point x="1253.4246338267" y="320" name="inserted"/>
+      <point x="876.4154985016" y="-26"/>
     </contour>
     <contour>
-      <point x="698" y="-22" type="qcurve" smooth="yes"/>
-      <point x="969" y="-22" name="inserted"/>
-      <point x="1283" y="321"/>
-      <point x="1283" y="612" type="qcurve"/>
-      <point x="1283" y="819" type="line"/>
-      <point x="1283" y="1110" name="inserted"/>
-      <point x="969" y="1454"/>
-      <point x="698" y="1454" type="qcurve" smooth="yes"/>
-      <point x="428" y="1454" name="inserted"/>
-      <point x="114" y="1110"/>
-      <point x="114" y="819" type="qcurve"/>
-      <point x="114" y="612" type="line"/>
-      <point x="114" y="321" name="inserted"/>
-      <point x="428" y="-22"/>
+      <point x="604.1208064244" y="-22" type="qcurve" smooth="yes"/>
+      <point x="875.1208064244" y="-22" name="inserted"/>
+      <point x="1249.6009608074" y="321"/>
+      <point x="1300.9121121936" y="612" type="qcurve"/>
+      <point x="1337.4117972002" y="819" type="line"/>
+      <point x="1388.7229485864" y="1110" name="inserted"/>
+      <point x="1135.3794299501" y="1454"/>
+      <point x="864.3794299501" y="1454" type="qcurve" smooth="yes"/>
+      <point x="594.3794299501" y="1454" name="inserted"/>
+      <point x="219.7229485864" y="1110"/>
+      <point x="168.4117972002" y="819" type="qcurve"/>
+      <point x="131.9121121936" y="612" type="line"/>
+      <point x="80.6009608074" y="321" name="inserted"/>
+      <point x="334.1208064244" y="-22"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND100.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1056"/>
   <unicode hex="006F"/>
-  <guideline x="528" y="694" angle="90" identifier="ia0rMPxuSn"/>
-  <anchor x="529" y="0" name="bottom"/>
-  <anchor x="527" y="510" name="center"/>
-  <anchor x="665" y="0" name="ogonek"/>
-  <anchor x="528" y="1020" name="top"/>
-  <anchor x="673" y="1020" name="topright"/>
+  <guideline x="560.3709246117" y="694" angle="100" identifier="ia0rMPxuSn"/>
+  <anchor x="439" y="0" name="bottom"/>
+  <anchor x="526.9267601613" y="510" name="center"/>
+  <anchor x="575" y="0" name="ogonek"/>
+  <anchor x="617.8535203226" y="1020" name="top"/>
+  <anchor x="762.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="527" y="-18" type="qcurve" smooth="yes"/>
-      <point x="335" y="-18" name="inserted"/>
-      <point x="93" y="224"/>
-      <point x="93" y="434" type="qcurve"/>
-      <point x="93" y="591" type="line"/>
-      <point x="93" y="801" name="inserted"/>
-      <point x="335" y="1043"/>
-      <point x="528" y="1043" type="qcurve" smooth="yes"/>
-      <point x="721" y="1043" name="inserted"/>
-      <point x="963" y="801"/>
-      <point x="963" y="591" type="qcurve"/>
-      <point x="963" y="434" type="line"/>
-      <point x="963" y="224" name="inserted"/>
-      <point x="720" y="-18"/>
+      <point x="433.8261143472" y="-18" type="qcurve" smooth="yes"/>
+      <point x="243" y="-18" name="inserted"/>
+      <point x="42.4972436787" y="224"/>
+      <point x="79.5259096275" y="434" type="qcurve"/>
+      <point x="107.2092455987" y="591" type="line"/>
+      <point x="144.2379115475" y="801" name="inserted"/>
+      <point x="428" y="1043"/>
+      <point x="621.9090408789" y="1043" type="qcurve" smooth="yes"/>
+      <point x="815" y="1043" name="inserted"/>
+      <point x="1014.2379115475" y="801"/>
+      <point x="977.2092455987" y="591" type="qcurve"/>
+      <point x="949.5259096275" y="434" type="line"/>
+      <point x="912.4972436787" y="224" name="inserted"/>
+      <point x="628" y="-18"/>
     </contour>
     <contour>
-      <point x="527" y="-14" type="qcurve" smooth="yes"/>
-      <point x="718" y="-14" name="inserted"/>
-      <point x="959" y="226"/>
-      <point x="959" y="434" type="qcurve"/>
-      <point x="959" y="591" type="line"/>
-      <point x="959" y="799" name="inserted"/>
-      <point x="719" y="1039"/>
-      <point x="528" y="1039" type="qcurve" smooth="yes"/>
-      <point x="337" y="1039" name="inserted"/>
-      <point x="97" y="799"/>
-      <point x="97" y="591" type="qcurve"/>
-      <point x="97" y="434" type="line"/>
-      <point x="97" y="226" name="inserted"/>
-      <point x="337" y="-14"/>
+      <point x="434.5314222701" y="-14" type="qcurve" smooth="yes"/>
+      <point x="625.5314222701" y="-14" name="inserted"/>
+      <point x="908.8498976401" y="226"/>
+      <point x="945.5259096275" y="434" type="qcurve"/>
+      <point x="973.2092455987" y="591" type="line"/>
+      <point x="1009.8852575861" y="799" name="inserted"/>
+      <point x="813" y="1039"/>
+      <point x="621.2037329561" y="1039" type="qcurve" smooth="yes"/>
+      <point x="430" y="1039" name="inserted"/>
+      <point x="147.8852575861" y="799"/>
+      <point x="111.2092455987" y="591" type="qcurve"/>
+      <point x="83.5259096275" y="434" type="line"/>
+      <point x="46.8498976401" y="226" name="inserted"/>
+      <point x="244.5314222701" y="-14"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND100.ufo/fontinfo.plist
@@ -43,7 +43,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -51,7 +51,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1540"/>
   <unicode hex="004F"/>
-  <guideline x="770" y="803" angle="90" identifier="k9gxyg9MgX"/>
-  <anchor x="766" y="0" name="bottom"/>
-  <anchor x="770" y="716" name="center"/>
-  <anchor x="1000" y="0" name="ogonek"/>
-  <anchor x="766" y="1432" name="top"/>
-  <anchor x="975" y="1432" name="topright"/>
+  <guideline x="821.5905655089" y="803" angle="100" identifier="k9gxyg9MgX"/>
+  <anchor x="676" y="0" name="bottom"/>
+  <anchor x="806.2501181873" y="716" name="center"/>
+  <anchor x="910" y="0" name="ogonek"/>
+  <anchor x="928.5002363745" y="1432" name="top"/>
+  <anchor x="1137.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="770" y="-32" type="qcurve" smooth="yes"/>
-      <point x="460" y="-32" name="inserted"/>
-      <point x="37" y="363"/>
-      <point x="37" y="705" type="qcurve"/>
-      <point x="37" y="731" type="line"/>
-      <point x="37" y="1071" name="inserted"/>
-      <point x="452" y="1463"/>
-      <point x="770" y="1463" type="qcurve" smooth="yes"/>
-      <point x="1088" y="1463" name="inserted"/>
-      <point x="1503" y="1059"/>
-      <point x="1503" y="731" type="qcurve"/>
-      <point x="1503" y="705" type="line"/>
-      <point x="1503" y="375" name="inserted"/>
-      <point x="1080" y="-32"/>
+      <point x="723" y="-32" type="qcurve" smooth="yes"/>
+      <point x="381" y="-32" name="inserted"/>
+      <point x="20" y="396"/>
+      <point x="70" y="694" type="qcurve" smooth="yes"/>
+      <point x="83" y="772" type="line" smooth="yes"/>
+      <point x="137" y="1097" name="inserted"/>
+      <point x="561" y="1463"/>
+      <point x="897" y="1463" type="qcurve" smooth="yes"/>
+      <point x="1239" y="1463" name="inserted"/>
+      <point x="1595" y="1023"/>
+      <point x="1537" y="711" type="qcurve" smooth="yes"/>
+      <point x="1523" y="635" type="line" smooth="yes"/>
+      <point x="1466" y="327" name="inserted"/>
+      <point x="1033" y="-32"/>
     </contour>
     <contour>
-      <point x="770" y="508" type="qcurve" smooth="yes"/>
-      <point x="852" y="508" name="inserted"/>
-      <point x="948" y="611"/>
-      <point x="948" y="694" type="qcurve"/>
-      <point x="948" y="728" type="line"/>
-      <point x="948" y="814" name="inserted"/>
-      <point x="852" y="915"/>
-      <point x="770" y="915" type="qcurve" smooth="yes"/>
-      <point x="688" y="915" name="inserted"/>
-      <point x="592" y="814"/>
-      <point x="592" y="728" type="qcurve"/>
-      <point x="592" y="694" type="line"/>
-      <point x="592" y="609" name="inserted"/>
-      <point x="688" y="508"/>
+      <point x="774" y="508" type="qcurve" smooth="yes"/>
+      <point x="867" y="508" name="inserted"/>
+      <point x="964" y="609"/>
+      <point x="979" y="687" type="qcurve" smooth="yes"/>
+      <point x="986" y="723" type="line" smooth="yes"/>
+      <point x="1003" y="809" name="inserted"/>
+      <point x="916" y="915"/>
+      <point x="835" y="915" type="qcurve" smooth="yes"/>
+      <point x="738" y="915" name="inserted"/>
+      <point x="644" y="817"/>
+      <point x="630" y="731" type="qcurve" smooth="yes"/>
+      <point x="624" y="697" type="line" smooth="yes"/>
+      <point x="610" y="615" name="inserted"/>
+      <point x="695" y="508"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND100.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1177"/>
   <unicode hex="006F"/>
-  <guideline x="589" y="571" angle="90" identifier="6ptYoWzioQ"/>
-  <anchor x="584" y="0" name="bottom"/>
-  <anchor x="589" y="510" name="center"/>
-  <anchor x="811" y="0" name="ogonek"/>
-  <anchor x="584" y="1020" name="top"/>
-  <anchor x="813" y="1020" name="topright"/>
+  <guideline x="599.6827059845" y="571" angle="100" identifier="6ptYoWzioQ"/>
+  <anchor x="494" y="0" name="bottom"/>
+  <anchor x="588.9267601613" y="510" name="center"/>
+  <anchor x="721" y="0" name="ogonek"/>
+  <anchor x="673.8535203226" y="1020" name="top"/>
+  <anchor x="902.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="584" y="-35" type="qcurve" smooth="yes"/>
-      <point x="321" y="-35" name="inserted"/>
-      <point x="19" y="267"/>
-      <point x="19" y="492" type="qcurve"/>
-      <point x="19" y="533" type="line"/>
-      <point x="19" y="763" name="inserted"/>
-      <point x="321" y="1066"/>
-      <point x="584" y="1066" type="qcurve" smooth="yes"/>
-      <point x="847" y="1066" name="inserted"/>
-      <point x="1158" y="761"/>
-      <point x="1158" y="533" type="qcurve"/>
-      <point x="1158" y="492" type="line"/>
-      <point x="1158" y="270" name="inserted"/>
-      <point x="847" y="-35"/>
+      <point x="487.8285556752" y="-35" type="qcurve" smooth="yes"/>
+      <point x="224.8285556752" y="-35" name="inserted"/>
+      <point x="-23.9206961508" y="267"/>
+      <point x="15.7528745086" y="492" type="qcurve"/>
+      <point x="22.9822807176" y="533" type="line"/>
+      <point x="63.5374862806" y="763" name="inserted"/>
+      <point x="418.9645614352" y="1066"/>
+      <point x="681.9645614352" y="1066" type="qcurve" smooth="yes"/>
+      <point x="944.9645614352" y="1066" name="inserted"/>
+      <point x="1202.1848323191" y="761"/>
+      <point x="1161.9822807176" y="533" type="qcurve"/>
+      <point x="1154.7528745086" y="492" type="line"/>
+      <point x="1115.6082847913" y="270" name="inserted"/>
+      <point x="750.8285556752" y="-35"/>
     </contour>
     <contour>
-      <point x="589" y="390" type="qcurve" smooth="yes"/>
-      <point x="648" y="390" name="inserted"/>
-      <point x="704" y="454"/>
-      <point x="704" y="504" type="qcurve"/>
-      <point x="704" y="516" type="line"/>
-      <point x="704" y="567" name="inserted"/>
-      <point x="646" y="633"/>
-      <point x="589" y="633" type="qcurve" smooth="yes"/>
-      <point x="531" y="633" name="inserted"/>
-      <point x="472" y="569"/>
-      <point x="472" y="517" type="qcurve"/>
-      <point x="472" y="505" type="line"/>
-      <point x="472" y="453" name="inserted"/>
-      <point x="530" y="390"/>
+      <point x="567.7675224763" y="390" type="qcurve" smooth="yes"/>
+      <point x="626.7675224763" y="390" name="inserted"/>
+      <point x="694.0524492416" y="454"/>
+      <point x="702.8687982771" y="504" type="qcurve"/>
+      <point x="704.9847220456" y="516" type="line"/>
+      <point x="713.9773980617" y="567" name="inserted"/>
+      <point x="667.6149787885" y="633"/>
+      <point x="610.6149787885" y="633" type="qcurve" smooth="yes"/>
+      <point x="552.6149787885" y="633" name="inserted"/>
+      <point x="482.3300520231" y="569"/>
+      <point x="473.1610490263" y="517" type="qcurve"/>
+      <point x="471.0451252578" y="505" type="line"/>
+      <point x="461.8761222609" y="453" name="inserted"/>
+      <point x="508.7675224763" y="390"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND100.ufo/fontinfo.plist
@@ -43,7 +43,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -51,7 +51,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1522"/>
   <unicode hex="004F"/>
-  <anchor x="761" y="0" name="bottom"/>
-  <anchor x="761" y="716" name="center"/>
-  <anchor x="976" y="0" name="ogonek"/>
-  <anchor x="761" y="1432" name="top"/>
-  <anchor x="978" y="1432" name="topright"/>
+  <anchor x="671" y="0" name="bottom"/>
+  <anchor x="797.2501181873" y="716" name="center"/>
+  <anchor x="886" y="0" name="ogonek"/>
+  <anchor x="923.5002363745" y="1432" name="top"/>
+  <anchor x="1140.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="760" y="-28" type="qcurve"/>
-      <point x="456" y="-28"/>
-      <point x="104" y="337"/>
-      <point x="104" y="617" type="qcurve"/>
-      <point x="104" y="815" type="line"/>
-      <point x="104" y="1094"/>
-      <point x="455" y="1461"/>
-      <point x="760" y="1461" type="qcurve"/>
-      <point x="1064" y="1461"/>
-      <point x="1418" y="1093"/>
-      <point x="1418" y="815" type="qcurve"/>
-      <point x="1418" y="617" type="line"/>
-      <point x="1418" y="342"/>
-      <point x="1062" y="-28"/>
+      <point x="696" y="-28" type="qcurve"/>
+      <point x="385" y="-28"/>
+      <point x="73" y="337"/>
+      <point x="123" y="617" type="qcurve"/>
+      <point x="159" y="823" type="line" smooth="yes"/>
+      <point x="206" y="1094"/>
+      <point x="596" y="1461"/>
+      <point x="918" y="1461" type="qcurve"/>
+      <point x="1222" y="1461"/>
+      <point x="1520" y="1093"/>
+      <point x="1471" y="815" type="qcurve"/>
+      <point x="1434" y="601" type="line" smooth="yes"/>
+      <point x="1390" y="342"/>
+      <point x="998" y="-28"/>
     </contour>
     <contour>
-      <point x="760" y="112" type="qcurve"/>
-      <point x="1002" y="112"/>
-      <point x="1272" y="399"/>
-      <point x="1272" y="618" type="qcurve"/>
-      <point x="1272" y="812" type="line"/>
-      <point x="1272" y="1032"/>
-      <point x="1002" y="1316"/>
-      <point x="760" y="1316" type="qcurve"/>
-      <point x="518" y="1316"/>
-      <point x="251" y="1032"/>
-      <point x="251" y="812" type="qcurve"/>
-      <point x="251" y="618" type="line"/>
-      <point x="251" y="398"/>
-      <point x="518" y="112"/>
+      <point x="689" y="112" type="qcurve"/>
+      <point x="931" y="112"/>
+      <point x="1251" y="399"/>
+      <point x="1290" y="618" type="qcurve"/>
+      <point x="1324" y="812" type="line"/>
+      <point x="1363" y="1032"/>
+      <point x="1146" y="1316"/>
+      <point x="899" y="1316" type="qcurve"/>
+      <point x="657" y="1316"/>
+      <point x="344" y="1049"/>
+      <point x="304" y="812" type="qcurve"/>
+      <point x="266" y="598" type="line" smooth="yes"/>
+      <point x="231" y="398"/>
+      <point x="447" y="112"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1062"/>
   <unicode hex="006F"/>
-  <anchor x="531" y="0" name="bottom"/>
-  <anchor x="531" y="510" name="center"/>
-  <anchor x="708" y="0" name="ogonek"/>
-  <anchor x="531" y="1020" name="top"/>
-  <anchor x="682" y="1020" name="topright"/>
+  <anchor x="441" y="0" name="bottom"/>
+  <anchor x="530.9267601613" y="510" name="center"/>
+  <anchor x="618" y="0" name="ogonek"/>
+  <anchor x="620.8535203226" y="1020" name="top"/>
+  <anchor x="771.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="530" y="-28" type="qcurve"/>
-      <point x="319" y="-28"/>
-      <point x="60" y="225"/>
-      <point x="60" y="443" type="qcurve"/>
-      <point x="60" y="567" type="line"/>
-      <point x="60" y="784"/>
-      <point x="323" y="1042"/>
-      <point x="530" y="1042" type="qcurve"/>
-      <point x="735" y="1042"/>
-      <point x="1002" y="780"/>
-      <point x="1001" y="567" type="qcurve"/>
-      <point x="1001" y="443" type="line"/>
-      <point x="1002" y="228"/>
-      <point x="738" y="-28"/>
+      <point x="460" y="-28" type="qcurve"/>
+      <point x="236" y="-28"/>
+      <point x="8" y="217"/>
+      <point x="48" y="443" type="qcurve" smooth="yes"/>
+      <point x="74" y="592" type="line" smooth="yes"/>
+      <point x="111" y="800"/>
+      <point x="387" y="1042"/>
+      <point x="613" y="1042" type="qcurve"/>
+      <point x="818" y="1042"/>
+      <point x="1052" y="798"/>
+      <point x="1014" y="583" type="qcurve" smooth="yes"/>
+      <point x="983" y="406" type="line" smooth="yes"/>
+      <point x="950" y="221"/>
+      <point x="681" y="-28"/>
     </contour>
     <contour>
-      <point x="532" y="106" type="qcurve"/>
-      <point x="680" y="106"/>
-      <point x="859" y="282"/>
-      <point x="859" y="443" type="qcurve"/>
-      <point x="859" y="568" type="line"/>
-      <point x="859" y="728"/>
-      <point x="677" y="906"/>
-      <point x="532" y="906" type="qcurve"/>
-      <point x="383" y="906"/>
-      <point x="202" y="731"/>
-      <point x="202" y="568" type="qcurve"/>
-      <point x="202" y="443" type="line"/>
-      <point x="202" y="280"/>
-      <point x="379" y="106"/>
+      <point x="465" y="106" type="qcurve"/>
+      <point x="623" y="106"/>
+      <point x="818" y="276"/>
+      <point x="844" y="424" type="qcurve" smooth="yes"/>
+      <point x="874" y="595" type="line" smooth="yes"/>
+      <point x="899" y="736"/>
+      <point x="752" y="907"/>
+      <point x="594" y="907" type="qcurve"/>
+      <point x="434" y="907"/>
+      <point x="241" y="734"/>
+      <point x="215" y="583" type="qcurve" smooth="yes"/>
+      <point x="190" y="443" type="line" smooth="yes"/>
+      <point x="160" y="273"/>
+      <point x="310" y="106"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND100.ufo/fontinfo.plist
@@ -100,7 +100,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -108,7 +108,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND100.ufo/glyphs/O_.glif
@@ -16,30 +16,30 @@
       <point x="122" y="716" type="qcurve"/>
       <point x="122" y="716" type="line"/>
       <point x="178" y="1033"/>
-      <point x="675" y="1464"/>
+      <point x="670" y="1464"/>
       <point x="990" y="1464" type="qcurve" smooth="yes"/>
-      <point x="1302" y="1464"/>
+      <point x="1300" y="1464"/>
       <point x="1650" y="1030"/>
       <point x="1594" y="716" type="qcurve"/>
       <point x="1594" y="716" type="line"/>
       <point x="1539" y="398"/>
-      <point x="1038" y="-32"/>
+      <point x="1043" y="-32"/>
     </contour>
     <contour>
       <point x="732" y="-2" type="qcurve" smooth="yes"/>
-      <point x="1024" y="-2"/>
-      <point x="1508" y="410"/>
+      <point x="1027" y="-2"/>
+      <point x="1508" y="406"/>
       <point x="1562" y="716" type="qcurve"/>
       <point x="1562" y="716" type="line"/>
-      <point x="1616" y="1023"/>
-      <point x="1285" y="1434"/>
+      <point x="1616" y="1027"/>
+      <point x="1284" y="1434"/>
       <point x="985" y="1434" type="qcurve" smooth="yes"/>
-      <point x="689" y="1434"/>
+      <point x="685" y="1434"/>
       <point x="208" y="1022"/>
       <point x="154" y="716" type="qcurve"/>
       <point x="154" y="716" type="line"/>
       <point x="100" y="402"/>
-      <point x="437" y="-2"/>
+      <point x="434" y="-2"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND100.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="1644"/>
   <unicode hex="004F"/>
   <guideline x="822" y="987" angle="90" identifier="nW4hK5kVQ2"/>
-  <anchor x="822" y="0" name="bottom"/>
+  <anchor x="696" y="0" name="bottom"/>
   <anchor x="821" y="716" name="center"/>
-  <anchor x="1044" y="0" name="ogonek"/>
-  <anchor x="822" y="1432" name="top"/>
-  <anchor x="1046" y="1432" name="topright"/>
+  <anchor x="918" y="0" name="ogonek"/>
+  <anchor x="948" y="1432" name="top"/>
+  <anchor x="1172" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="822" y="-32" type="qcurve" smooth="yes"/>
-      <point x="512" y="-32"/>
-      <point x="86" y="396"/>
-      <point x="86" y="716" type="qcurve"/>
-      <point x="86" y="716" type="line"/>
-      <point x="86" y="1030"/>
-      <point x="510" y="1464"/>
-      <point x="822" y="1464" type="qcurve" smooth="yes"/>
-      <point x="1134" y="1464"/>
-      <point x="1558" y="1030"/>
-      <point x="1558" y="716" type="qcurve"/>
-      <point x="1558" y="716" type="line"/>
-      <point x="1558" y="402"/>
-      <point x="1130" y="-32"/>
+      <point x="726" y="-32" type="qcurve" smooth="yes"/>
+      <point x="416" y="-32"/>
+      <point x="66" y="396"/>
+      <point x="122" y="716" type="qcurve"/>
+      <point x="122" y="716" type="line"/>
+      <point x="178" y="1033"/>
+      <point x="675" y="1464"/>
+      <point x="990" y="1464" type="qcurve" smooth="yes"/>
+      <point x="1302" y="1464"/>
+      <point x="1650" y="1030"/>
+      <point x="1594" y="716" type="qcurve"/>
+      <point x="1594" y="716" type="line"/>
+      <point x="1539" y="398"/>
+      <point x="1038" y="-32"/>
     </contour>
     <contour>
-      <point x="822" y="-2" type="qcurve" smooth="yes"/>
-      <point x="1114" y="-2"/>
-      <point x="1526" y="410"/>
-      <point x="1526" y="716" type="qcurve"/>
-      <point x="1526" y="716" type="line"/>
-      <point x="1526" y="1020"/>
-      <point x="1116" y="1434"/>
-      <point x="822" y="1434" type="qcurve" smooth="yes"/>
-      <point x="526" y="1434"/>
-      <point x="118" y="1022"/>
-      <point x="118" y="716" type="qcurve"/>
-      <point x="118" y="716" type="line"/>
-      <point x="118" y="408"/>
-      <point x="528" y="-2"/>
+      <point x="732" y="-2" type="qcurve" smooth="yes"/>
+      <point x="1024" y="-2"/>
+      <point x="1508" y="410"/>
+      <point x="1562" y="716" type="qcurve"/>
+      <point x="1562" y="716" type="line"/>
+      <point x="1616" y="1023"/>
+      <point x="1285" y="1434"/>
+      <point x="985" y="1434" type="qcurve" smooth="yes"/>
+      <point x="689" y="1434"/>
+      <point x="208" y="1022"/>
+      <point x="154" y="716" type="qcurve"/>
+      <point x="154" y="716" type="line"/>
+      <point x="100" y="402"/>
+      <point x="437" y="-2"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1206"/>
   <unicode hex="006F"/>
-  <anchor x="604" y="0" name="bottom"/>
-  <anchor x="603" y="510" name="center"/>
-  <anchor x="793" y="0" name="ogonek"/>
-  <anchor x="604" y="1020" name="top"/>
-  <anchor x="746" y="1020" name="topright"/>
+  <anchor x="515" y="0" name="bottom"/>
+  <anchor x="604" y="510" name="center"/>
+  <anchor x="704" y="0" name="ogonek"/>
+  <anchor x="695" y="1020" name="top"/>
+  <anchor x="837" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="604" y="-32" type="qcurve" smooth="yes"/>
-      <point x="374" y="-32"/>
-      <point x="96" y="274"/>
-      <point x="96" y="504" type="qcurve"/>
-      <point x="96" y="504" type="line"/>
-      <point x="96" y="732"/>
-      <point x="384" y="1038"/>
-      <point x="604" y="1038" type="qcurve" smooth="yes"/>
-      <point x="824" y="1038"/>
-      <point x="1110" y="726"/>
-      <point x="1110" y="504" type="qcurve"/>
-      <point x="1110" y="504" type="line"/>
-      <point x="1110" y="280"/>
-      <point x="834" y="-32"/>
+      <point x="508" y="-32" type="qcurve" smooth="yes"/>
+      <point x="278" y="-32"/>
+      <point x="54" y="274"/>
+      <point x="95" y="504" type="qcurve"/>
+      <point x="95" y="504" type="line"/>
+      <point x="135" y="732"/>
+      <point x="477" y="1038"/>
+      <point x="697" y="1038" type="qcurve" smooth="yes"/>
+      <point x="917" y="1038"/>
+      <point x="1148" y="726"/>
+      <point x="1109" y="504" type="qcurve"/>
+      <point x="1109" y="504" type="line"/>
+      <point x="1069" y="280"/>
+      <point x="738" y="-32"/>
     </contour>
     <contour>
-      <point x="604" y="-2" type="qcurve" smooth="yes"/>
-      <point x="812" y="-2"/>
-      <point x="1078" y="286"/>
-      <point x="1078" y="504" type="qcurve"/>
-      <point x="1078" y="504" type="line"/>
-      <point x="1078" y="716"/>
-      <point x="808" y="1010"/>
-      <point x="604" y="1010" type="qcurve" smooth="yes"/>
-      <point x="400" y="1010"/>
-      <point x="128" y="724"/>
-      <point x="128" y="504" type="qcurve"/>
-      <point x="128" y="504" type="line"/>
-      <point x="128" y="282"/>
-      <point x="394" y="-2"/>
+      <point x="514" y="-2" type="qcurve" smooth="yes"/>
+      <point x="722" y="-2"/>
+      <point x="1038" y="286"/>
+      <point x="1077" y="504" type="qcurve"/>
+      <point x="1077" y="504" type="line"/>
+      <point x="1115" y="717"/>
+      <point x="905" y="1011"/>
+      <point x="692" y="1010" type="qcurve"/>
+      <point x="488" y="1010"/>
+      <point x="166" y="724"/>
+      <point x="127" y="504" type="qcurve"/>
+      <point x="127" y="504" type="line"/>
+      <point x="88" y="282"/>
+      <point x="294" y="-2"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND100.ufo/glyphs/o.glif
@@ -15,18 +15,18 @@
       <point x="95" y="504" type="qcurve"/>
       <point x="95" y="504" type="line"/>
       <point x="135" y="732"/>
-      <point x="477" y="1038"/>
+      <point x="469" y="1038"/>
       <point x="697" y="1038" type="qcurve" smooth="yes"/>
       <point x="917" y="1038"/>
       <point x="1148" y="726"/>
       <point x="1109" y="504" type="qcurve"/>
       <point x="1109" y="504" type="line"/>
       <point x="1069" y="280"/>
-      <point x="738" y="-32"/>
+      <point x="746" y="-32"/>
     </contour>
     <contour>
       <point x="514" y="-2" type="qcurve" smooth="yes"/>
-      <point x="722" y="-2"/>
+      <point x="724" y="-2"/>
       <point x="1038" y="286"/>
       <point x="1077" y="504" type="qcurve"/>
       <point x="1077" y="504" type="line"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND100.ufo/fontinfo.plist
@@ -120,7 +120,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -128,7 +128,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1640"/>
   <unicode hex="004F"/>
-  <guideline x="820" y="0" angle="90" identifier="YxXI3YIqmn"/>
-  <anchor x="820" y="0" name="bottom"/>
-  <anchor x="819" y="712" name="center"/>
-  <anchor x="1048" y="0" name="ogonek"/>
-  <anchor x="820" y="1432" name="top"/>
-  <anchor x="1042" y="1432" name="topright"/>
+  <guideline x="730" y="0" angle="100" identifier="YxXI3YIqmn"/>
+  <anchor x="730" y="0" name="bottom"/>
+  <anchor x="854.5448102644" y="712" name="center"/>
+  <anchor x="958" y="0" name="ogonek"/>
+  <anchor x="982.5002363745" y="1432" name="top"/>
+  <anchor x="1204.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="820" y="-32" type="qcurve" smooth="yes"/>
-      <point x="518" y="-32" name="inserted"/>
-      <point x="64" y="360"/>
-      <point x="64" y="716" type="qcurve"/>
-      <point x="64" y="716" type="line"/>
-      <point x="64" y="1072" name="inserted"/>
-      <point x="522" y="1464"/>
-      <point x="820" y="1464" type="qcurve" smooth="yes"/>
-      <point x="1118" y="1464" name="inserted"/>
-      <point x="1576" y="1058"/>
-      <point x="1576" y="716" type="qcurve"/>
-      <point x="1576" y="716" type="line"/>
-      <point x="1576" y="374" name="inserted"/>
-      <point x="1122" y="-32"/>
+      <point x="757" y="-32" type="qcurve" smooth="yes"/>
+      <point x="436" y="-32" name="inserted"/>
+      <point x="41" y="379"/>
+      <point x="104" y="735" type="qcurve"/>
+      <point x="104" y="735" type="line"/>
+      <point x="165" y="1069" name="inserted"/>
+      <point x="645" y="1464"/>
+      <point x="962" y="1464" type="qcurve" smooth="yes"/>
+      <point x="1281" y="1464" name="inserted"/>
+      <point x="1671" y="1046"/>
+      <point x="1610" y="704" type="qcurve"/>
+      <point x="1610" y="704" type="line"/>
+      <point x="1550" y="367" name="inserted"/>
+      <point x="1069" y="-32"/>
     </contour>
     <contour>
-      <point x="820" y="436" type="qcurve" smooth="yes"/>
-      <point x="938" y="436" name="inserted"/>
-      <point x="1096" y="594"/>
-      <point x="1096" y="716" type="qcurve"/>
-      <point x="1096" y="716" type="line"/>
-      <point x="1096" y="840" name="inserted"/>
-      <point x="938" y="996"/>
-      <point x="820" y="996" type="qcurve" smooth="yes"/>
-      <point x="704" y="996" name="inserted"/>
-      <point x="544" y="840"/>
-      <point x="544" y="716" type="qcurve"/>
-      <point x="544" y="716" type="line"/>
-      <point x="544" y="592" name="inserted"/>
-      <point x="702" y="436"/>
+      <point x="815" y="436" type="qcurve" smooth="yes"/>
+      <point x="942" y="436" name="inserted"/>
+      <point x="1110" y="586"/>
+      <point x="1131" y="708" type="qcurve"/>
+      <point x="1131" y="708" type="line"/>
+      <point x="1153" y="832" name="inserted"/>
+      <point x="1029" y="996"/>
+      <point x="898" y="996" type="qcurve" smooth="yes"/>
+      <point x="768" y="996" name="inserted"/>
+      <point x="603" y="846"/>
+      <point x="581" y="722" type="qcurve"/>
+      <point x="581" y="722" type="line"/>
+      <point x="559" y="598" name="inserted"/>
+      <point x="689" y="436"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND100.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND100.ufo/glyphs/O_slash-bar.glif
@@ -3,8 +3,8 @@
   <advance width="1352"/>
   <guideline x="1136" y="1556" angle="0" identifier="fvnbo6j53E"/>
   <guideline x="935" y="203" angle="0" identifier="d9WG2Xza9B"/>
-  <guideline x="1379" y="1430" angle="311.74588385830623" identifier="yp1HhutcJH"/>
-  <guideline x="82.25272750458731" y="264.7575895073989" angle="0" identifier="TIKSdIvz4t"/>
+  <guideline x="1379" y="1430" angle="311.7458838583" identifier="yp1HhutcJH"/>
+  <guideline x="82.2527275046" y="264.7575895074" angle="0" identifier="TIKSdIvz4t"/>
   <outline>
     <contour>
       <point x="594" y="871" type="line"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND100.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1352"/>
   <unicode hex="006F"/>
-  <guideline x="676" y="0" angle="90" identifier="oZaZpTlb3t"/>
-  <anchor x="674" y="0" name="bottom"/>
-  <anchor x="675" y="511" name="center"/>
-  <anchor x="950" y="0" name="ogonek"/>
-  <anchor x="676" y="1020" name="top"/>
-  <anchor x="964" y="1020" name="topright"/>
+  <guideline x="586" y="0" angle="100" identifier="oZaZpTlb3t"/>
+  <anchor x="584" y="0" name="bottom"/>
+  <anchor x="675.103087142" y="511" name="center"/>
+  <anchor x="860" y="0" name="ogonek"/>
+  <anchor x="765.8535203226" y="1020" name="top"/>
+  <anchor x="1053.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="676" y="-44" type="qcurve"/>
-      <point x="378" y="-44" name="inserted"/>
-      <point x="50" y="274"/>
-      <point x="50" y="516" type="qcurve"/>
-      <point x="50" y="516" type="line"/>
-      <point x="50" y="758" name="inserted"/>
-      <point x="386" y="1080"/>
-      <point x="676" y="1080" type="qcurve"/>
-      <point x="966" y="1080" name="inserted"/>
-      <point x="1302" y="750"/>
-      <point x="1302" y="516" type="qcurve"/>
-      <point x="1302" y="516" type="line"/>
-      <point x="1302" y="281" name="inserted"/>
-      <point x="975" y="-44"/>
+      <point x="621" y="-44" type="qcurve"/>
+      <point x="325" y="-44" name="inserted"/>
+      <point x="12" y="298"/>
+      <point x="55" y="540" type="qcurve"/>
+      <point x="55" y="540" type="line"/>
+      <point x="98" y="776" name="inserted"/>
+      <point x="439" y="1080"/>
+      <point x="739" y="1080" type="qcurve"/>
+      <point x="1031" y="1080" name="inserted"/>
+      <point x="1340" y="736"/>
+      <point x="1299" y="498" type="qcurve"/>
+      <point x="1299" y="498" type="line"/>
+      <point x="1258" y="263" name="inserted"/>
+      <point x="909" y="-44"/>
     </contour>
     <contour>
-      <point x="676" y="342" type="qcurve" smooth="yes"/>
-      <point x="758" y="342" name="inserted"/>
-      <point x="840" y="440"/>
-      <point x="840" y="512" type="qcurve"/>
-      <point x="840" y="512" type="line"/>
-      <point x="840" y="584" name="inserted"/>
-      <point x="756" y="682"/>
-      <point x="676" y="682" type="qcurve" smooth="yes"/>
-      <point x="596" y="682" name="inserted"/>
-      <point x="512" y="584"/>
-      <point x="512" y="512" type="qcurve"/>
-      <point x="512" y="512" type="line"/>
-      <point x="512" y="440" name="inserted"/>
-      <point x="594" y="342"/>
+      <point x="655" y="342" type="qcurve" smooth="yes"/>
+      <point x="737" y="342" name="inserted"/>
+      <point x="827" y="436"/>
+      <point x="839" y="505" type="qcurve"/>
+      <point x="839" y="505" type="line"/>
+      <point x="852" y="585" name="inserted"/>
+      <point x="782" y="682"/>
+      <point x="698" y="682" type="qcurve" smooth="yes"/>
+      <point x="618" y="682" name="inserted"/>
+      <point x="527" y="587"/>
+      <point x="513" y="520" type="qcurve"/>
+      <point x="513" y="520" type="line"/>
+      <point x="501" y="440" name="inserted"/>
+      <point x="572" y="342"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND100.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND100.ufo/glyphs/oslash-bar.glif
@@ -3,7 +3,7 @@
   <advance width="1194"/>
   <guideline x="714" y="880" angle="0" identifier="Iwq6ljlUe2"/>
   <guideline x="69" y="148" angle="0" identifier="T8IdXXEZNg"/>
-  <guideline x="1033" y="967" angle="311.6580561427389" identifier="EQHxbY05Pq"/>
+  <guideline x="1033" y="967" angle="311.6580561427" identifier="EQHxbY05Pq"/>
   <outline>
     <contour>
       <point x="536" y="589" type="line"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND100.ufo/fontinfo.plist
@@ -90,7 +90,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -98,7 +98,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1648"/>
   <unicode hex="004F"/>
-  <anchor x="824" y="2" name="bottom"/>
-  <anchor x="823" y="716" name="center"/>
-  <anchor x="1055" y="2" name="ogonek"/>
-  <anchor x="824" y="1432" name="top"/>
-  <anchor x="1078" y="1432" name="topright"/>
+  <anchor x="734.3526539614" y="2" name="bottom"/>
+  <anchor x="859.2501181873" y="716" name="center"/>
+  <anchor x="965.3526539614" y="2" name="ogonek"/>
+  <anchor x="986.5002363745" y="1432" name="top"/>
+  <anchor x="1240.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="824" y="-32" type="qcurve" smooth="yes"/>
-      <point x="512" y="-32"/>
-      <point x="90" y="402"/>
-      <point x="90" y="720" type="qcurve"/>
-      <point x="90" y="720" type="line"/>
-      <point x="90" y="1036"/>
-      <point x="514" y="1464"/>
-      <point x="824" y="1464" type="qcurve" smooth="yes"/>
-      <point x="1133" y="1464"/>
-      <point x="1558" y="1039"/>
-      <point x="1558" y="720" type="qcurve"/>
-      <point x="1558" y="720" type="line"/>
-      <point x="1558" y="402"/>
-      <point x="1136" y="-32"/>
+      <point x="728.3575366173" y="-32" type="qcurve" smooth="yes"/>
+      <point x="413" y="-32"/>
+      <point x="71" y="412"/>
+      <point x="126.9554261101" y="720" type="qcurve"/>
+      <point x="126.9554261101" y="720" type="line"/>
+      <point x="183" y="1047"/>
+      <point x="669" y="1464"/>
+      <point x="992.1426997572" y="1464" type="qcurve" smooth="yes"/>
+      <point x="1303" y="1464"/>
+      <point x="1651" y="1029"/>
+      <point x="1594.9554261101" y="720" type="qcurve"/>
+      <point x="1594.9554261101" y="720" type="line"/>
+      <point x="1539" y="391"/>
+      <point x="1054" y="-32"/>
     </contour>
     <contour>
-      <point x="824" y="130" type="qcurve" smooth="yes"/>
-      <point x="1064" y="130"/>
-      <point x="1386" y="464"/>
-      <point x="1386" y="720" type="qcurve"/>
-      <point x="1386" y="720" type="line"/>
-      <point x="1386" y="975"/>
-      <point x="1061" y="1302"/>
-      <point x="824" y="1302" type="qcurve" smooth="yes"/>
-      <point x="586" y="1302"/>
-      <point x="262" y="973"/>
-      <point x="262" y="720" type="qcurve"/>
-      <point x="262" y="720" type="line"/>
-      <point x="262" y="464"/>
-      <point x="584" y="130"/>
+      <point x="756.9225074921" y="130" type="qcurve" smooth="yes"/>
+      <point x="997" y="130"/>
+      <point x="1378" y="469"/>
+      <point x="1422.9554261101" y="720" type="qcurve"/>
+      <point x="1422.9554261101" y="720" type="line"/>
+      <point x="1468" y="981"/>
+      <point x="1212" y="1302"/>
+      <point x="963.5777288824" y="1302" type="qcurve" smooth="yes"/>
+      <point x="726" y="1302"/>
+      <point x="344" y="967"/>
+      <point x="298.9554261101" y="720" type="qcurve"/>
+      <point x="298.9554261101" y="720" type="line"/>
+      <point x="254" y="457"/>
+      <point x="506" y="130"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1192"/>
   <unicode hex="006F"/>
-  <anchor x="596" y="0" name="bottom"/>
-  <anchor x="596" y="510" name="center"/>
-  <anchor x="786" y="0" name="ogonek"/>
-  <anchor x="596" y="1020" name="top"/>
-  <anchor x="780" y="1020" name="topright"/>
+  <anchor x="506" y="0" name="bottom"/>
+  <anchor x="595.9267601613" y="510" name="center"/>
+  <anchor x="696" y="0" name="ogonek"/>
+  <anchor x="685.8535203226" y="1020" name="top"/>
+  <anchor x="869.8535203226" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="596" y="-32" type="qcurve" smooth="yes"/>
-      <point x="370" y="-32"/>
-      <point x="72" y="278"/>
-      <point x="72" y="510" type="qcurve"/>
-      <point x="72" y="510" type="line"/>
-      <point x="72" y="748"/>
-      <point x="371" y="1052"/>
-      <point x="596" y="1052" type="qcurve"/>
-      <point x="820" y="1052"/>
-      <point x="1120" y="745"/>
-      <point x="1120" y="515" type="qcurve"/>
-      <point x="1120" y="515" type="line"/>
-      <point x="1120" y="278"/>
-      <point x="823" y="-32"/>
+      <point x="500.3575366173" y="-32" type="qcurve" smooth="yes"/>
+      <point x="279" y="-32"/>
+      <point x="31.018900637" y="278"/>
+      <point x="71.9267601613" y="510" type="qcurve"/>
+      <point x="71.9267601613" y="510" type="line"/>
+      <point x="114" y="752"/>
+      <point x="456" y="1052"/>
+      <point x="691.4959837053" y="1052" type="qcurve"/>
+      <point x="910" y="1052"/>
+      <point x="1161.3636006278" y="745"/>
+      <point x="1120.8083950649" y="515" type="qcurve"/>
+      <point x="1120.8083950649" y="515" type="line"/>
+      <point x="1079" y="274"/>
+      <point x="737" y="-32"/>
     </contour>
     <contour>
-      <point x="596" y="122" type="qcurve" smooth="yes"/>
-      <point x="746" y="122"/>
-      <point x="950" y="340"/>
-      <point x="950" y="513" type="qcurve"/>
-      <point x="950" y="513" type="line"/>
-      <point x="950" y="685"/>
-      <point x="744" y="898"/>
-      <point x="596" y="898" type="qcurve" smooth="yes"/>
-      <point x="446" y="898"/>
-      <point x="240" y="684"/>
-      <point x="240" y="512" type="qcurve"/>
-      <point x="240" y="512" type="line"/>
-      <point x="240" y="342"/>
-      <point x="444" y="122"/>
+      <point x="527.5118916464" y="122" type="qcurve" smooth="yes"/>
+      <point x="678" y="122"/>
+      <point x="919.9511734409" y="340"/>
+      <point x="950.4557411034" y="513" type="qcurve"/>
+      <point x="950.4557411034" y="513" type="line"/>
+      <point x="980.7839817853" y="685"/>
+      <point x="815" y="897"/>
+      <point x="664.3416286762" y="898" type="qcurve" smooth="yes"/>
+      <point x="514" y="899"/>
+      <point x="270.6076548046" y="684"/>
+      <point x="240.2794141227" y="512" type="qcurve"/>
+      <point x="240.2794141227" y="512" type="line"/>
+      <point x="210.3038274023" y="342"/>
+      <point x="373" y="122"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND100.ufo/fontinfo.plist
@@ -102,7 +102,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -110,7 +110,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="2453"/>
   <unicode hex="004F"/>
-  <guideline x="1227" y="1333" angle="90" identifier="NdNAS6hVej"/>
-  <anchor x="1226" y="1" name="bottom"/>
-  <anchor x="1227" y="722" name="center"/>
-  <anchor x="1591" y="0" name="ogonek"/>
-  <anchor x="1227" y="1438" name="top"/>
-  <anchor x="1417" y="1438" name="topright"/>
+  <guideline x="1372.0438652843839" y="1333" angle="100" identifier="NdNAS6hVej"/>
+  <anchor x="1136.1763269807084" y="1" name="bottom"/>
+  <anchor x="1264.3080800715118" y="722" name="center"/>
+  <anchor x="1501" y="0" name="ogonek"/>
+  <anchor x="1390.5581982587726" y="1438" name="top"/>
+  <anchor x="1580.5581982587726" y="1438" name="topright"/>
   <outline>
     <contour>
-      <point x="1226" y="-37" type="qcurve" smooth="yes"/>
-      <point x="757" y="-37"/>
-      <point x="116" y="382"/>
-      <point x="116" y="716" type="qcurve"/>
-      <point x="116" y="716" type="line"/>
-      <point x="116" y="1039"/>
-      <point x="756" y="1469"/>
-      <point x="1226" y="1469" type="qcurve" smooth="yes"/>
-      <point x="1696" y="1469"/>
-      <point x="2337" y="1039"/>
-      <point x="2337" y="715" type="qcurve"/>
-      <point x="2337" y="715" type="line"/>
-      <point x="2337" y="388"/>
-      <point x="1693" y="-37"/>
+      <point x="1129.4759017137867" y="-37" type="qcurve" smooth="yes"/>
+      <point x="670" y="-37"/>
+      <point x="93" y="385"/>
+      <point x="152.2501181872609" y="716" type="qcurve"/>
+      <point x="152.2501181872609" y="716" type="line"/>
+      <point x="209.2037329560951" y="1039"/>
+      <point x="915" y="1469"/>
+      <point x="1395.0243346607351" y="1469" type="qcurve" smooth="yes"/>
+      <point x="1855" y="1469"/>
+      <point x="2430.2037329560953" y="1039"/>
+      <point x="2373.0737912065524" y="715" type="qcurve"/>
+      <point x="2373.0737912065524" y="715" type="line"/>
+      <point x="2315.4148685148843" y="388"/>
+      <point x="1606" y="-37"/>
     </contour>
     <contour>
-      <point x="1227" y="-6" type="qcurve" smooth="yes"/>
-      <point x="1679" y="-6"/>
-      <point x="2302" y="404"/>
-      <point x="2302" y="715" type="qcurve"/>
-      <point x="2302" y="715" type="line"/>
-      <point x="2302" y="1025"/>
-      <point x="1679" y="1438"/>
-      <point x="1227" y="1438" type="qcurve" smooth="yes"/>
-      <point x="772" y="1438"/>
-      <point x="151" y="1027"/>
-      <point x="151" y="716" type="qcurve"/>
-      <point x="151" y="716" type="line"/>
-      <point x="151" y="402"/>
-      <point x="773" y="-6"/>
+      <point x="1135.9420381157493" y="-6" type="qcurve" smooth="yes"/>
+      <point x="1588" y="-6"/>
+      <point x="2283.23610020622" y="404"/>
+      <point x="2338.0737912065524" y="715" type="qcurve"/>
+      <point x="2338.0737912065524" y="715" type="line"/>
+      <point x="2392.7351552261766" y="1025"/>
+      <point x="1846" y="1438"/>
+      <point x="1390.5581982587726" y="1438" type="qcurve" smooth="yes"/>
+      <point x="936" y="1438"/>
+      <point x="242.0878091875935" y="1027"/>
+      <point x="187.2501181872609" y="716" type="qcurve"/>
+      <point x="187.2501181872609" y="716" type="line"/>
+      <point x="131.88344624480294" y="402"/>
+      <point x="679" y="-6"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND100.ufo/glyphs/o.glif
@@ -2,44 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1768"/>
   <unicode hex="006F"/>
-  <guideline x="887" y="682" angle="90" identifier="CcsyYkeFFF"/>
-  <anchor x="888" y="0" name="bottom"/>
-  <anchor x="884" y="505" name="center"/>
-  <anchor x="1196" y="0" name="ogonek"/>
-  <anchor x="889" y="1020" name="top"/>
-  <anchor x="1006" y="1020" name="topright"/>
+  <guideline x="917.2550008431731" y="682" angle="100" identifier="CcsyYkeFFF"/>
+  <anchor x="798" y="0" name="bottom"/>
+  <anchor x="883.0451252577748" y="505" name="center"/>
+  <anchor x="1106" y="0" name="ogonek"/>
+  <anchor x="978.8535203226343" y="1020" name="top"/>
+  <anchor x="1095.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="885" y="-39" type="qcurve" smooth="yes"/>
-      <point x="540" y="-39"/>
-      <point x="110" y="274"/>
-      <point x="110" y="515" type="qcurve"/>
-      <point x="110" y="515" type="line"/>
-      <point x="110" y="742"/>
-      <point x="553" y="1049"/>
-      <point x="888" y="1049" type="qcurve" smooth="yes"/>
-      <point x="1222" y="1049"/>
-      <point x="1658" y="737"/>
-      <point x="1658" y="509" type="qcurve"/>
-      <point x="1658" y="509" type="line"/>
-      <point x="1658" y="276"/>
-      <point x="1231" y="-39"/>
+      <point x="788.1232477523698" y="-39" type="qcurve"/>
+      <point x="451" y="-39"/>
+      <point x="68" y="270"/>
+      <point x="110.80839506485947" y="515" type="qcurve"/>
+      <point x="110.80839506485947" y="515" type="line"/>
+      <point x="151" y="747"/>
+      <point x="637" y="1049"/>
+      <point x="982.9670027631798" y="1049" type="qcurve"/>
+      <point x="1306" y="1049"/>
+      <point x="1697.9529847821386" y="737"/>
+      <point x="1657.7504331806088" y="509" type="qcurve"/>
+      <point x="1657.7504331806088" y="509" type="line"/>
+      <point x="1617" y="268"/>
+      <point x="1143" y="-39"/>
     </contour>
     <contour>
-      <point x="887" y="-9" type="qcurve" smooth="yes"/>
-      <point x="1208" y="-9"/>
-      <point x="1628" y="282"/>
-      <point x="1628" y="511" type="qcurve"/>
-      <point x="1628" y="511" type="line"/>
-      <point x="1628" y="728"/>
-      <point x="1202" y="1019"/>
-      <point x="887" y="1019" type="qcurve" smooth="yes"/>
-      <point x="569" y="1019"/>
-      <point x="142" y="736"/>
+      <point x="795.4130571736238" y="-9" type="qcurve" smooth="yes"/>
+      <point x="1120" y="-9"/>
+      <point x="1587.724208559787" y="282"/>
+      <point x="1628.1030871420255" y="511" type="qcurve"/>
+      <point x="1628.1030871420255" y="511" type="line"/>
+      <point x="1666.3660419557625" y="728"/>
+      <point x="1292" y="1019"/>
+      <point x="976.6771933419259" y="1019" type="qcurve" smooth="yes"/>
+      <point x="655" y="1019"/>
+      <point x="181" y="734"/>
       <point x="142" y="515" type="qcurve"/>
       <point x="142" y="515" type="line"/>
-      <point x="142" y="282"/>
-      <point x="562" y="-9"/>
+      <point x="101" y="284"/>
+      <point x="470" y="-9"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND100.ufo/fontinfo.plist
@@ -94,7 +94,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -102,7 +102,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="2449"/>
   <unicode hex="004F"/>
-  <guideline x="1224.5" y="0" angle="90" identifier="gl5Dx0G3oJ"/>
-  <anchor x="1225" y="0" name="bottom"/>
-  <anchor x="1224" y="706" name="center"/>
-  <anchor x="1597" y="0" name="ogonek"/>
-  <anchor x="1225" y="1432" name="top"/>
-  <anchor x="1380" y="1432" name="topright"/>
+  <guideline x="1134.5" y="0" angle="100" identifier="gl5Dx0G3oJ"/>
+  <anchor x="1135" y="0" name="bottom"/>
+  <anchor x="1258.4868483801763" y="706" name="center"/>
+  <anchor x="1507" y="0" name="ogonek"/>
+  <anchor x="1387.5002363745218" y="1432" name="top"/>
+  <anchor x="1542.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1224" y="-37" type="qcurve" smooth="yes"/>
-      <point x="763" y="-37"/>
-      <point x="94" y="349"/>
-      <point x="94" y="716" type="qcurve"/>
-      <point x="94" y="716" type="line"/>
-      <point x="94" y="1083"/>
-      <point x="768" y="1469"/>
-      <point x="1224" y="1469" type="qcurve" smooth="yes"/>
-      <point x="1680" y="1469"/>
-      <point x="2355" y="1069"/>
-      <point x="2355" y="714" type="qcurve"/>
-      <point x="2355" y="714" type="line"/>
-      <point x="2355" y="363"/>
-      <point x="1685" y="-37"/>
+      <point x="1128" y="-37" type="qcurve" smooth="yes"/>
+      <point x="637" y="-37"/>
+      <point x="68" y="359"/>
+      <point x="130" y="716" type="qcurve"/>
+      <point x="130" y="716" type="line"/>
+      <point x="198" y="1102"/>
+      <point x="897" y="1469"/>
+      <point x="1393" y="1469" type="qcurve" smooth="yes"/>
+      <point x="1879" y="1469"/>
+      <point x="2452" y="1059"/>
+      <point x="2391" y="714" type="qcurve"/>
+      <point x="2391" y="714" type="line"/>
+      <point x="2326" y="344"/>
+      <point x="1629" y="-37"/>
     </contour>
     <contour>
-      <point x="1225" y="411" type="qcurve" smooth="yes"/>
-      <point x="1503" y="411"/>
-      <point x="1872" y="572"/>
-      <point x="1872" y="717" type="qcurve"/>
-      <point x="1872" y="717" type="line"/>
-      <point x="1872" y="864"/>
-      <point x="1501" y="1018"/>
-      <point x="1225" y="1018" type="qcurve" smooth="yes"/>
-      <point x="950" y="1018"/>
-      <point x="577" y="864"/>
-      <point x="577" y="719" type="qcurve"/>
-      <point x="577" y="719" type="line"/>
-      <point x="577" y="570"/>
-      <point x="947" y="411"/>
+      <point x="1208" y="411" type="qcurve" smooth="yes"/>
+      <point x="1486" y="411"/>
+      <point x="1883" y="572"/>
+      <point x="1909" y="717" type="qcurve"/>
+      <point x="1909" y="717" type="line"/>
+      <point x="1934" y="864"/>
+      <point x="1601" y="1018"/>
+      <point x="1315" y="1018" type="qcurve" smooth="yes"/>
+      <point x="1040" y="1018"/>
+      <point x="639" y="864"/>
+      <point x="614" y="719" type="qcurve"/>
+      <point x="614" y="719" type="line"/>
+      <point x="588" y="570"/>
+      <point x="910" y="411"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1962"/>
   <unicode hex="006F"/>
-  <anchor x="979" y="0" name="bottom"/>
-  <anchor x="980" y="516" name="center"/>
-  <anchor x="1393" y="0" name="ogonek"/>
-  <anchor x="981" y="1020" name="top"/>
-  <anchor x="1402" y="1020" name="topright"/>
+  <anchor x="889" y="0" name="bottom"/>
+  <anchor x="980.9847220455679" y="516" name="center"/>
+  <anchor x="1303" y="0" name="ogonek"/>
+  <anchor x="1070.8535203226343" y="1020" name="top"/>
+  <anchor x="1491.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="981" y="-52" type="qcurve" smooth="yes"/>
-      <point x="568" y="-52"/>
-      <point x="88" y="270"/>
-      <point x="88" y="514" type="qcurve"/>
-      <point x="88" y="514" type="line"/>
-      <point x="88" y="765"/>
-      <point x="576" y="1088"/>
-      <point x="981" y="1088" type="qcurve"/>
-      <point x="1385" y="1088"/>
-      <point x="1874" y="757"/>
-      <point x="1874" y="515" type="qcurve"/>
-      <point x="1874" y="515" type="line"/>
-      <point x="1874" y="273"/>
-      <point x="1395" y="-52"/>
+      <point x="882" y="-52" type="qcurve" smooth="yes"/>
+      <point x="459" y="-52"/>
+      <point x="46" y="270"/>
+      <point x="89" y="514" type="qcurve"/>
+      <point x="89" y="514" type="line"/>
+      <point x="135" y="775"/>
+      <point x="658" y="1088"/>
+      <point x="1083" y="1088" type="qcurve" smooth="yes"/>
+      <point x="1497" y="1088"/>
+      <point x="1918" y="757"/>
+      <point x="1875" y="515" type="qcurve"/>
+      <point x="1875" y="515" type="line"/>
+      <point x="1830" y="263"/>
+      <point x="1316" y="-52"/>
     </contour>
     <contour>
-      <point x="983" y="334" type="qcurve" smooth="yes"/>
-      <point x="1178" y="334"/>
-      <point x="1414" y="434"/>
-      <point x="1414" y="516" type="qcurve"/>
-      <point x="1414" y="516" type="line"/>
-      <point x="1414" y="593"/>
-      <point x="1174" y="690"/>
-      <point x="983" y="690" type="qcurve" smooth="yes"/>
-      <point x="789" y="690"/>
-      <point x="550" y="593"/>
-      <point x="550" y="515" type="qcurve"/>
-      <point x="550" y="515" type="line"/>
-      <point x="550" y="438"/>
-      <point x="786" y="334"/>
+      <point x="952" y="334" type="qcurve" smooth="yes"/>
+      <point x="1147" y="334"/>
+      <point x="1401" y="434"/>
+      <point x="1415" y="516" type="qcurve"/>
+      <point x="1415" y="516" type="line"/>
+      <point x="1429" y="593"/>
+      <point x="1226" y="690"/>
+      <point x="1015" y="690" type="qcurve" smooth="yes"/>
+      <point x="821" y="690"/>
+      <point x="565" y="593"/>
+      <point x="551" y="515" type="qcurve"/>
+      <point x="551" y="515" type="line"/>
+      <point x="537" y="438"/>
+      <point x="735" y="334"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND100.ufo/fontinfo.plist
@@ -80,7 +80,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -88,7 +88,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="2457"/>
   <unicode hex="004F"/>
-  <anchor x="1228" y="0" name="bottom"/>
-  <anchor x="1229" y="716" name="center"/>
-  <anchor x="1591" y="0" name="ogonek"/>
-  <anchor x="1233" y="1432" name="top"/>
-  <anchor x="1453" y="1432" name="topright"/>
+  <anchor x="1138" y="0" name="bottom"/>
+  <anchor x="1265.250118187261" y="716" name="center"/>
+  <anchor x="1501" y="0" name="ogonek"/>
+  <anchor x="1395.5002363745218" y="1432" name="top"/>
+  <anchor x="1615.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1228" y="-37" type="qcurve" smooth="yes"/>
-      <point x="757" y="-37"/>
-      <point x="120" y="396"/>
-      <point x="120" y="716" type="qcurve"/>
-      <point x="120" y="716" type="line"/>
-      <point x="120" y="1044"/>
-      <point x="760" y="1469"/>
-      <point x="1228" y="1469" type="qcurve" smooth="yes"/>
-      <point x="1695" y="1469"/>
-      <point x="2337" y="1046"/>
-      <point x="2337" y="716" type="qcurve"/>
-      <point x="2337" y="716" type="line"/>
-      <point x="2337" y="396"/>
-      <point x="1699" y="-37"/>
+      <point x="1131.4759017137867" y="-37" type="qcurve" smooth="yes"/>
+      <point x="659" y="-38"/>
+      <point x="100" y="391"/>
+      <point x="156.2501181872609" y="716" type="qcurve"/>
+      <point x="156.2501181872609" y="716" type="line"/>
+      <point x="214" y="1053"/>
+      <point x="884" y="1468"/>
+      <point x="1397.0243346607351" y="1469" type="qcurve" smooth="yes"/>
+      <point x="1855" y="1470"/>
+      <point x="2431" y="1051"/>
+      <point x="2373.250118187261" y="716" type="qcurve"/>
+      <point x="2373.250118187261" y="716" type="line"/>
+      <point x="2317" y="390"/>
+      <point x="1632" y="-36"/>
     </contour>
     <contour>
-      <point x="1229" y="135" type="qcurve" smooth="yes"/>
-      <point x="1629" y="135"/>
-      <point x="2162" y="464"/>
-      <point x="2162" y="716" type="qcurve"/>
-      <point x="2162" y="716" type="line"/>
-      <point x="2162" y="976"/>
-      <point x="1624" y="1294"/>
-      <point x="1229" y="1294" type="qcurve" smooth="yes"/>
-      <point x="832" y="1294"/>
-      <point x="295" y="975"/>
-      <point x="295" y="716" type="qcurve"/>
-      <point x="295" y="716" type="line"/>
-      <point x="295" y="464"/>
-      <point x="829" y="135"/>
+      <point x="1162.8041423956429" y="135" type="qcurve" smooth="yes"/>
+      <point x="1563" y="136"/>
+      <point x="2153.8157190487277" y="464"/>
+      <point x="2198.250118187261" y="716" type="qcurve"/>
+      <point x="2198.250118187261" y="716" type="line"/>
+      <point x="2244.095133171462" y="976"/>
+      <point x="1766" y="1298"/>
+      <point x="1367" y="1297" type="qcurve" smooth="yes"/>
+      <point x="970" y="1296"/>
+      <point x="376.91880619075334" y="975"/>
+      <point x="331.2501181872609" y="716" type="qcurve"/>
+      <point x="331.2501181872609" y="716" type="line"/>
+      <point x="286.8157190487277" y="464"/>
+      <point x="753" y="134"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1802"/>
   <unicode hex="006F"/>
-  <anchor x="900" y="0" name="bottom"/>
-  <anchor x="900" y="510" name="center"/>
-  <anchor x="1216" y="0" name="ogonek"/>
-  <anchor x="900" y="1020" name="top"/>
-  <anchor x="1087" y="1020" name="topright"/>
+  <anchor x="810" y="0" name="bottom"/>
+  <anchor x="899.9267601613171" y="510" name="center"/>
+  <anchor x="1126" y="0" name="ogonek"/>
+  <anchor x="989.8535203226343" y="1020" name="top"/>
+  <anchor x="1176.8535203226343" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="901" y="-40" type="qcurve" smooth="yes"/>
-      <point x="560" y="-40"/>
-      <point x="110" y="278"/>
+      <point x="804" y="-40" type="qcurve" smooth="yes"/>
+      <point x="458" y="-40"/>
+      <point x="68" y="273"/>
       <point x="110" y="512" type="qcurve"/>
       <point x="110" y="512" type="line"/>
-      <point x="110" y="752"/>
-      <point x="561" y="1060"/>
-      <point x="901" y="1060" type="qcurve" smooth="yes"/>
-      <point x="1239" y="1060"/>
-      <point x="1692" y="749"/>
+      <point x="153" y="755"/>
+      <point x="646" y="1060"/>
+      <point x="998" y="1060" type="qcurve" smooth="yes"/>
+      <point x="1341" y="1060"/>
+      <point x="1734" y="754"/>
       <point x="1692" y="513" type="qcurve"/>
       <point x="1692" y="513" type="line"/>
-      <point x="1692" y="274"/>
-      <point x="1243" y="-40"/>
+      <point x="1649" y="271"/>
+      <point x="1158" y="-40"/>
     </contour>
     <contour>
-      <point x="903" y="111" type="qcurve" smooth="yes"/>
-      <point x="1166" y="111"/>
-      <point x="1524" y="336"/>
+      <point x="833" y="111" type="qcurve" smooth="yes"/>
+      <point x="1096" y="111"/>
+      <point x="1492" y="336"/>
       <point x="1524" y="513" type="qcurve"/>
       <point x="1524" y="513" type="line"/>
-      <point x="1524" y="689"/>
-      <point x="1162" y="908"/>
-      <point x="903" y="908" type="qcurve" smooth="yes"/>
-      <point x="639" y="908"/>
-      <point x="278" y="688"/>
+      <point x="1556" y="694"/>
+      <point x="1247" y="908"/>
+      <point x="973" y="908" type="qcurve" smooth="yes"/>
+      <point x="709" y="908"/>
+      <point x="309" y="688"/>
       <point x="278" y="512" type="qcurve"/>
       <point x="278" y="512" type="line"/>
-      <point x="278" y="340"/>
-      <point x="636" y="111"/>
+      <point x="247" y="335"/>
+      <point x="551" y="111"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND100.ufo/fontinfo.plist
@@ -98,7 +98,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -106,7 +106,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="750"/>
   <unicode hex="004F"/>
-  <anchor x="376" y="0" name="bottom"/>
-  <anchor x="375" y="716" name="center"/>
-  <anchor x="479" y="0" name="ogonek"/>
-  <anchor x="376" y="1432" name="top"/>
-  <anchor x="596" y="1432" name="topright"/>
+  <anchor x="286" y="0" name="bottom"/>
+  <anchor x="411.2501181872609" y="716" name="center"/>
+  <anchor x="389" y="0" name="ogonek"/>
+  <anchor x="538.5002363745218" y="1432" name="top"/>
+  <anchor x="758.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="375" y="-18" type="qcurve" smooth="yes"/>
-      <point x="249" y="-18"/>
-      <point x="110" y="163"/>
-      <point x="110" y="416" type="qcurve"/>
-      <point x="110" y="1015" type="line"/>
-      <point x="110" y="1257"/>
-      <point x="247" y="1440"/>
-      <point x="373" y="1440" type="qcurve" smooth="yes"/>
-      <point x="503" y="1440"/>
-      <point x="640" y="1256"/>
-      <point x="640" y="1015" type="qcurve"/>
-      <point x="640" y="416" type="line"/>
-      <point x="640" y="166"/>
-      <point x="507" y="-18"/>
+      <point x="282" y="-18" type="qcurve" smooth="yes"/>
+      <point x="156" y="-18"/>
+      <point x="48" y="163"/>
+      <point x="93" y="416" type="qcurve" smooth="yes"/>
+      <point x="199" y="1015" type="line" smooth="yes"/>
+      <point x="242" y="1257"/>
+      <point x="411" y="1440"/>
+      <point x="537" y="1440" type="qcurve" smooth="yes"/>
+      <point x="667" y="1440"/>
+      <point x="772" y="1256"/>
+      <point x="729" y="1015" type="qcurve" smooth="yes"/>
+      <point x="623" y="416" type="line" smooth="yes"/>
+      <point x="579" y="166"/>
+      <point x="414" y="-18"/>
     </contour>
     <contour>
-      <point x="375" y="10" type="qcurve" smooth="yes"/>
-      <point x="483" y="10"/>
-      <point x="608" y="168"/>
-      <point x="608" y="439" type="qcurve"/>
-      <point x="608" y="992" type="line"/>
-      <point x="608" y="1244"/>
-      <point x="483" y="1410"/>
-      <point x="373" y="1410" type="qcurve" smooth="yes"/>
-      <point x="267" y="1410"/>
-      <point x="142" y="1245"/>
-      <point x="142" y="992" type="qcurve"/>
-      <point x="142" y="439" type="line"/>
-      <point x="142" y="173"/>
-      <point x="267" y="10"/>
+      <point x="287" y="10" type="qcurve" smooth="yes"/>
+      <point x="400" y="10"/>
+      <point x="548" y="173"/>
+      <point x="595" y="439" type="qcurve" smooth="yes"/>
+      <point x="693" y="992" type="line" smooth="yes"/>
+      <point x="739" y="1249"/>
+      <point x="645" y="1410"/>
+      <point x="531" y="1410" type="qcurve" smooth="yes"/>
+      <point x="425" y="1410"/>
+      <point x="272" y="1245"/>
+      <point x="227" y="992" type="qcurve" smooth="yes"/>
+      <point x="129" y="439" type="line" smooth="yes"/>
+      <point x="81" y="169"/>
+      <point x="176" y="10"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="606"/>
   <unicode hex="006F"/>
-  <anchor x="308" y="0" name="bottom"/>
-  <anchor x="303" y="507" name="center"/>
-  <anchor x="392" y="0" name="ogonek"/>
-  <anchor x="308" y="1020" name="top"/>
-  <anchor x="372" y="1020" name="topright"/>
+  <anchor x="218" y="0" name="bottom"/>
+  <anchor x="302.39777921919176" y="507" name="center"/>
+  <anchor x="302" y="0" name="ogonek"/>
+  <anchor x="397.85352032263427" y="1020" name="top"/>
+  <anchor x="461.85352032263427" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="304" y="-16" type="qcurve" smooth="yes"/>
-      <point x="198" y="-16"/>
-      <point x="90" y="133"/>
-      <point x="90" y="304" type="qcurve"/>
-      <point x="90" y="712" type="line"/>
-      <point x="90" y="890"/>
-      <point x="196" y="1030"/>
-      <point x="306" y="1030" type="qcurve" smooth="yes"/>
-      <point x="412" y="1030"/>
-      <point x="516" y="882"/>
-      <point x="516" y="712" type="qcurve"/>
-      <point x="516" y="304" type="line"/>
-      <point x="516" y="135"/>
-      <point x="414" y="-16"/>
+      <point x="211.1787683086646" y="-16" type="qcurve" smooth="yes"/>
+      <point x="109" y="-16"/>
+      <point x="23.451488434225837" y="133"/>
+      <point x="53.60340213537336" y="304" type="qcurve"/>
+      <point x="125.54481026442704" y="712" type="line"/>
+      <point x="156.93101283053383" y="890"/>
+      <point x="289" y="1030"/>
+      <point x="397.61679012971894" y="1030" type="qcurve" smooth="yes"/>
+      <point x="500" y="1030"/>
+      <point x="581.5203969848661" y="882"/>
+      <point x="551.544810264427" y="712" type="qcurve"/>
+      <point x="479.60340213537336" y="304" type="line"/>
+      <point x="449.80414239564277" y="135"/>
+      <point x="320" y="-16"/>
     </contour>
     <contour>
-      <point x="304" y="12" type="qcurve" smooth="yes"/>
-      <point x="396" y="12"/>
-      <point x="488" y="151"/>
-      <point x="488" y="319" type="qcurve"/>
-      <point x="488" y="694" type="line"/>
-      <point x="488" y="863"/>
-      <point x="400" y="1002"/>
-      <point x="306" y="1002" type="qcurve" smooth="yes"/>
-      <point x="210" y="1002"/>
-      <point x="118" y="869"/>
-      <point x="118" y="694" type="qcurve"/>
-      <point x="118" y="319" type="line"/>
-      <point x="118" y="153"/>
-      <point x="208" y="12"/>
+      <point x="216.1159237685016" y="12" type="qcurve" smooth="yes"/>
+      <point x="308" y="12"/>
+      <point x="424.62537408697824" y="151"/>
+      <point x="454.24830684600033" y="319" type="qcurve"/>
+      <point x="520.3709246116747" y="694" type="line"/>
+      <point x="550.1701843514053" y="863"/>
+      <point x="489" y="1002"/>
+      <point x="392.6796346698819" y="1002" type="qcurve" smooth="yes"/>
+      <point x="297" y="1002"/>
+      <point x="181.22814623565603" y="869"/>
+      <point x="150.3709246116747" y="694" type="qcurve"/>
+      <point x="84.24830684600033" y="319" type="line"/>
+      <point x="54.978028048395146" y="153"/>
+      <point x="120" y="12"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND100.ufo/fontinfo.plist
@@ -104,7 +104,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -112,7 +112,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1360"/>
   <unicode hex="004F"/>
-  <anchor x="692" y="0" name="bottom"/>
-  <anchor x="688" y="706" name="center"/>
-  <anchor x="873" y="0" name="ogonek"/>
-  <anchor x="692" y="1432" name="top"/>
-  <anchor x="932" y="1432" name="topright"/>
+  <anchor x="602" y="0" name="bottom"/>
+  <anchor x="722" y="706" name="center"/>
+  <anchor x="783" y="0" name="ogonek"/>
+  <anchor x="855" y="1432" name="top"/>
+  <anchor x="1095" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="680" y="-28" type="qcurve" smooth="yes"/>
-      <point x="416" y="-28"/>
-      <point x="60" y="324"/>
-      <point x="60" y="716" type="qcurve"/>
-      <point x="60" y="716" type="line"/>
-      <point x="60" y="1108"/>
-      <point x="420" y="1458"/>
-      <point x="680" y="1458" type="qcurve" smooth="yes"/>
-      <point x="940" y="1458"/>
-      <point x="1300" y="1094"/>
-      <point x="1300" y="716" type="qcurve"/>
-      <point x="1300" y="716" type="line"/>
-      <point x="1300" y="340"/>
-      <point x="944" y="-28"/>
+      <point x="621" y="-28" type="qcurve"/>
+      <point x="340" y="-26"/>
+      <point x="36" y="326"/>
+      <point x="96" y="716" type="qcurve"/>
+      <point x="96" y="716" type="line"/>
+      <point x="165" y="1108"/>
+      <point x="521" y="1458"/>
+      <point x="807" y="1458" type="qcurve" smooth="yes"/>
+      <point x="1093" y="1458"/>
+      <point x="1403" y="1094"/>
+      <point x="1336" y="716" type="qcurve"/>
+      <point x="1336" y="716" type="line"/>
+      <point x="1270" y="340"/>
+      <point x="911" y="-28"/>
     </contour>
     <contour>
-      <point x="678" y="420" type="qcurve" smooth="yes"/>
-      <point x="748" y="420"/>
+      <point x="668" y="420" type="qcurve"/>
+      <point x="738" y="420"/>
       <point x="804" y="509"/>
-      <point x="804" y="578" type="qcurve"/>
-      <point x="804" y="852" type="line"/>
-      <point x="804" y="923"/>
-      <point x="748" y="1010"/>
-      <point x="678" y="1010" type="qcurve" smooth="yes"/>
-      <point x="608" y="1010"/>
-      <point x="556" y="923"/>
-      <point x="556" y="852" type="qcurve"/>
-      <point x="556" y="578" type="line"/>
+      <point x="816" y="578" type="qcurve"/>
+      <point x="864" y="853" type="line"/>
+      <point x="877" y="923"/>
+      <point x="830" y="1010"/>
+      <point x="763" y="1010" type="qcurve" smooth="yes"/>
+      <point x="693" y="1010"/>
+      <point x="629" y="923"/>
+      <point x="616" y="852" type="qcurve"/>
+      <point x="568" y="578" type="line"/>
       <point x="556" y="509"/>
-      <point x="608" y="420"/>
+      <point x="600" y="420"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1180"/>
   <unicode hex="006F"/>
-  <anchor x="604" y="0" name="bottom"/>
+  <anchor x="514" y="0" name="bottom"/>
   <anchor x="604" y="510" name="center"/>
-  <anchor x="824" y="0" name="ogonek"/>
-  <anchor x="604" y="1020" name="top"/>
-  <anchor x="788" y="1020" name="topright"/>
+  <anchor x="734" y="0" name="ogonek"/>
+  <anchor x="694" y="1020" name="top"/>
+  <anchor x="878" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="590" y="-38" type="qcurve" smooth="yes"/>
-      <point x="338" y="-38"/>
-      <point x="36" y="235"/>
-      <point x="36" y="464" type="qcurve"/>
-      <point x="36" y="573" type="line"/>
-      <point x="36" y="797"/>
-      <point x="348" y="1066"/>
-      <point x="590" y="1066" type="qcurve" smooth="yes"/>
-      <point x="832" y="1066"/>
-      <point x="1144" y="789"/>
-      <point x="1144" y="573" type="qcurve"/>
-      <point x="1144" y="464" type="line"/>
-      <point x="1144" y="244"/>
-      <point x="842" y="-38"/>
+      <point x="525" y="-38" type="qcurve" smooth="yes"/>
+      <point x="273" y="-38"/>
+      <point x="-7" y="256"/>
+      <point x="32" y="483" type="qcurve"/>
+      <point x="47" y="573" type="line"/>
+      <point x="87" y="797"/>
+      <point x="395" y="1066"/>
+      <point x="647" y="1066" type="qcurve" smooth="yes"/>
+      <point x="889" y="1066"/>
+      <point x="1189" y="760"/>
+      <point x="1149" y="539" type="qcurve"/>
+      <point x="1134" y="451" type="line"/>
+      <point x="1097" y="245"/>
+      <point x="787" y="-38"/>
     </contour>
     <contour>
-      <point x="590" y="342" type="qcurve" smooth="yes"/>
-      <point x="645" y="342"/>
-      <point x="684" y="401"/>
-      <point x="684" y="455" type="qcurve"/>
-      <point x="684" y="564" type="line"/>
-      <point x="684" y="615"/>
-      <point x="643" y="674"/>
-      <point x="590" y="674" type="qcurve" smooth="yes"/>
-      <point x="537" y="674"/>
-      <point x="496" y="615"/>
-      <point x="496" y="564" type="qcurve"/>
-      <point x="496" y="455" type="line"/>
-      <point x="496" y="403"/>
-      <point x="537" y="342"/>
+      <point x="564" y="342" type="qcurve" smooth="yes"/>
+      <point x="619" y="342"/>
+      <point x="665" y="401"/>
+      <point x="674" y="455" type="qcurve"/>
+      <point x="693" y="564" type="line"/>
+      <point x="702" y="615"/>
+      <point x="668" y="674"/>
+      <point x="615" y="674" type="qcurve" smooth="yes"/>
+      <point x="562" y="674"/>
+      <point x="514" y="615"/>
+      <point x="505" y="564" type="qcurve"/>
+      <point x="486" y="455" type="line"/>
+      <point x="477" y="403"/>
+      <point x="511" y="342"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND100.ufo/fontinfo.plist
@@ -105,7 +105,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -113,7 +113,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="692"/>
   <unicode hex="004F"/>
-  <anchor x="347" y="0" name="bottom"/>
-  <anchor x="346" y="711" name="center"/>
-  <anchor x="467" y="0" name="ogonek"/>
-  <anchor x="347" y="1432" name="top"/>
-  <anchor x="567" y="1432" name="topright"/>
+  <anchor x="257" y="0" name="bottom"/>
+  <anchor x="381" y="711" name="center"/>
+  <anchor x="377" y="0" name="ogonek"/>
+  <anchor x="509" y="1432" name="top"/>
+  <anchor x="729" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="346" y="-22" type="qcurve" smooth="yes"/>
-      <point x="212" y="-22"/>
-      <point x="70" y="144"/>
-      <point x="70" y="316" type="qcurve" smooth="yes"/>
-      <point x="70" y="1112" type="line" smooth="yes"/>
-      <point x="70" y="1276"/>
-      <point x="216" y="1444"/>
-      <point x="346" y="1444" type="qcurve" smooth="yes"/>
-      <point x="476" y="1444"/>
-      <point x="622" y="1276"/>
-      <point x="622" y="1112" type="qcurve" smooth="yes"/>
-      <point x="622" y="316" type="line" smooth="yes"/>
-      <point x="622" y="144"/>
-      <point x="480" y="-22"/>
+      <point x="280" y="-22" type="qcurve" smooth="yes"/>
+      <point x="146" y="-22"/>
+      <point x="6" y="144"/>
+      <point x="36" y="316" type="qcurve" smooth="yes"/>
+      <point x="176" y="1112" type="line" smooth="yes"/>
+      <point x="205" y="1276"/>
+      <point x="352" y="1444"/>
+      <point x="482" y="1444" type="qcurve" smooth="yes"/>
+      <point x="612" y="1444"/>
+      <point x="757" y="1276"/>
+      <point x="728" y="1112" type="qcurve" smooth="yes"/>
+      <point x="588" y="316" type="line" smooth="yes"/>
+      <point x="558" y="144"/>
+      <point x="414" y="-22"/>
     </contour>
     <contour>
-      <point x="346" y="120" type="qcurve" smooth="yes"/>
-      <point x="402" y="120"/>
-      <point x="462" y="194"/>
-      <point x="462" y="262" type="qcurve" smooth="yes"/>
-      <point x="462" y="1158" type="line" smooth="yes"/>
-      <point x="462" y="1222"/>
-      <point x="400" y="1296"/>
-      <point x="346" y="1296" type="qcurve" smooth="yes"/>
-      <point x="290" y="1296"/>
-      <point x="230" y="1222"/>
-      <point x="230" y="1158" type="qcurve" smooth="yes"/>
-      <point x="230" y="262" type="line" smooth="yes"/>
-      <point x="230" y="194"/>
-      <point x="290" y="120"/>
+      <point x="292" y="120" type="qcurve" smooth="yes"/>
+      <point x="348" y="120"/>
+      <point x="408" y="194"/>
+      <point x="420" y="262" type="qcurve" smooth="yes"/>
+      <point x="576" y="1158" type="line" smooth="yes"/>
+      <point x="587" y="1222"/>
+      <point x="524" y="1296"/>
+      <point x="470" y="1296" type="qcurve" smooth="yes"/>
+      <point x="414" y="1296"/>
+      <point x="355" y="1222"/>
+      <point x="344" y="1158" type="qcurve" smooth="yes"/>
+      <point x="188" y="262" type="line" smooth="yes"/>
+      <point x="176" y="194"/>
+      <point x="236" y="120"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="598"/>
   <unicode hex="006F"/>
-  <anchor x="301" y="0" name="bottom"/>
+  <anchor x="211" y="0" name="bottom"/>
+  <anchor x="287" y="0" name="ogonek"/>
+  <anchor x="391" y="1020" name="top"/>
+  <anchor x="471" y="1020" name="topright"/>
   <anchor x="299" y="510" name="center"/>
-  <anchor x="377" y="0" name="ogonek"/>
-  <anchor x="301" y="1020" name="top"/>
-  <anchor x="381" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="300" y="-12" type="qcurve" smooth="yes"/>
-      <point x="186" y="-12"/>
-      <point x="56" y="144"/>
-      <point x="56" y="284" type="qcurve" smooth="yes"/>
-      <point x="56" y="756" type="line" smooth="yes"/>
-      <point x="56" y="890"/>
-      <point x="182" y="1032"/>
-      <point x="300" y="1032" type="qcurve" smooth="yes"/>
-      <point x="418" y="1032"/>
-      <point x="542" y="890"/>
-      <point x="542" y="756" type="qcurve" smooth="yes"/>
-      <point x="542" y="284" type="line" smooth="yes"/>
-      <point x="542" y="144"/>
-      <point x="414" y="-12"/>
+      <point x="223" y="-12" type="qcurve" smooth="yes"/>
+      <point x="106" y="-12"/>
+      <point x="-8" y="145"/>
+      <point x="16" y="284" type="qcurve" smooth="yes"/>
+      <point x="99" y="756" type="line" smooth="yes"/>
+      <point x="122" y="889"/>
+      <point x="252" y="1032"/>
+      <point x="370" y="1032" type="qcurve" smooth="yes"/>
+      <point x="488" y="1032"/>
+      <point x="608" y="889"/>
+      <point x="585" y="756" type="qcurve" smooth="yes"/>
+      <point x="501" y="276" type="line" smooth="yes"/>
+      <point x="477" y="140"/>
+      <point x="346" y="-12"/>
     </contour>
     <contour>
-      <point x="300" y="116" type="qcurve" smooth="yes"/>
-      <point x="348" y="116"/>
-      <point x="392" y="172"/>
-      <point x="392" y="216" type="qcurve" smooth="yes"/>
-      <point x="392" y="792" type="line" smooth="yes"/>
-      <point x="392" y="836"/>
-      <point x="350" y="892"/>
-      <point x="300" y="892" type="qcurve" smooth="yes"/>
-      <point x="248" y="892"/>
-      <point x="206" y="836"/>
-      <point x="206" y="792" type="qcurve" smooth="yes"/>
-      <point x="206" y="216" type="line" smooth="yes"/>
-      <point x="206" y="172"/>
-      <point x="250" y="116"/>
+      <point x="238" y="116" type="qcurve" smooth="yes"/>
+      <point x="283" y="116"/>
+      <point x="333" y="172"/>
+      <point x="341" y="216" type="qcurve" smooth="yes"/>
+      <point x="443" y="792" type="line" smooth="yes"/>
+      <point x="451" y="836"/>
+      <point x="412" y="892"/>
+      <point x="362" y="892" type="qcurve" smooth="yes"/>
+      <point x="312" y="892"/>
+      <point x="265" y="836"/>
+      <point x="257" y="792" type="qcurve" smooth="yes"/>
+      <point x="155" y="216" type="line" smooth="yes"/>
+      <point x="147" y="172"/>
+      <point x="188" y="116"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND100.ufo/fontinfo.plist
@@ -39,7 +39,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -47,7 +47,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1048"/>
   <unicode hex="004F"/>
-  <guideline x="524" y="963" angle="90" identifier="IPbNeuDFzw"/>
-  <anchor x="525" y="0" name="bottom"/>
-  <anchor x="524" y="716" name="center"/>
-  <anchor x="679" y="0" name="ogonek"/>
-  <anchor x="525" y="1432" name="top"/>
-  <anchor x="746" y="1432" name="topright"/>
+  <anchor x="434" y="0" name="bottom"/>
+  <anchor x="559" y="716" name="center"/>
+  <anchor x="588" y="0" name="ogonek"/>
+  <anchor x="687" y="1432" name="top"/>
+  <anchor x="908" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="524" y="-23" type="qcurve" smooth="yes"/>
-      <point x="337" y="-23"/>
-      <point x="116" y="201"/>
-      <point x="116" y="476" type="qcurve"/>
-      <point x="116" y="955" type="line"/>
-      <point x="116" y="1221"/>
-      <point x="335" y="1448"/>
-      <point x="523" y="1448" type="qcurve" smooth="yes"/>
-      <point x="713" y="1448"/>
-      <point x="932" y="1221"/>
-      <point x="932" y="955" type="qcurve"/>
-      <point x="932" y="476" type="line"/>
-      <point x="932" y="205"/>
-      <point x="715" y="-23"/>
+      <point x="444" y="-23" type="qcurve" smooth="yes"/>
+      <point x="257" y="-23"/>
+      <point x="60" y="201"/>
+      <point x="109" y="476" type="qcurve"/>
+      <point x="193" y="955" type="line"/>
+      <point x="240" y="1221"/>
+      <point x="485" y="1448"/>
+      <point x="673" y="1448" type="qcurve" smooth="yes"/>
+      <point x="863" y="1448"/>
+      <point x="1056" y="1221"/>
+      <point x="1009" y="955" type="qcurve"/>
+      <point x="925" y="476" type="line"/>
+      <point x="877" y="205"/>
+      <point x="635" y="-23"/>
     </contour>
     <contour>
-      <point x="524" y="8" type="qcurve" smooth="yes"/>
-      <point x="697" y="8"/>
-      <point x="900" y="217"/>
-      <point x="900" y="492" type="qcurve"/>
-      <point x="900" y="940" type="line"/>
-      <point x="900" y="1209"/>
-      <point x="694" y="1418"/>
-      <point x="523" y="1418" type="qcurve" smooth="yes"/>
-      <point x="353" y="1418"/>
-      <point x="148" y="1205"/>
-      <point x="148" y="940" type="qcurve"/>
-      <point x="148" y="492" type="line"/>
-      <point x="148" y="214"/>
-      <point x="354" y="8"/>
+      <point x="444" y="8" type="qcurve" smooth="yes"/>
+      <point x="617" y="8"/>
+      <point x="847" y="217"/>
+      <point x="896" y="492" type="qcurve"/>
+      <point x="975" y="940" type="line"/>
+      <point x="1022" y="1209"/>
+      <point x="843" y="1418"/>
+      <point x="672" y="1418" type="qcurve" smooth="yes"/>
+      <point x="502" y="1418"/>
+      <point x="269" y="1205"/>
+      <point x="223" y="940" type="qcurve"/>
+      <point x="144" y="492" type="line"/>
+      <point x="95" y="214"/>
+      <point x="274" y="8"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND100.ufo/glyphs/o.glif
@@ -2,44 +2,43 @@
 <glyph name="o" format="2">
   <advance width="806"/>
   <unicode hex="006F"/>
-  <guideline x="407" y="735" angle="90" identifier="nZLjWlMwGh"/>
-  <anchor x="407" y="0" name="bottom"/>
+  <anchor x="314" y="0" name="bottom"/>
   <anchor x="403" y="508" name="center"/>
-  <anchor x="529" y="0" name="ogonek"/>
-  <anchor x="407" y="1020" name="top"/>
-  <anchor x="497" y="1020" name="topright"/>
+  <anchor x="439" y="0" name="ogonek"/>
+  <anchor x="495" y="1020" name="top"/>
+  <anchor x="587" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="404" y="-21" type="qcurve" smooth="yes"/>
-      <point x="258" y="-21"/>
-      <point x="92" y="166"/>
-      <point x="92" y="361" type="qcurve"/>
-      <point x="92" y="653" type="line"/>
-      <point x="92" y="852"/>
-      <point x="256" y="1033"/>
-      <point x="406" y="1033" type="qcurve" smooth="yes"/>
-      <point x="553" y="1033"/>
-      <point x="714" y="844"/>
-      <point x="714" y="653" type="qcurve"/>
-      <point x="714" y="361" type="line"/>
-      <point x="714" y="169"/>
-      <point x="554" y="-21"/>
+      <point x="323" y="-21" type="qcurve" smooth="yes"/>
+      <point x="177" y="-21"/>
+      <point x="31" y="166"/>
+      <point x="66" y="361" type="qcurve"/>
+      <point x="117" y="653" type="line"/>
+      <point x="152" y="852"/>
+      <point x="336" y="1033"/>
+      <point x="486" y="1033" type="qcurve" smooth="yes"/>
+      <point x="633" y="1033"/>
+      <point x="773" y="844"/>
+      <point x="739" y="653" type="qcurve"/>
+      <point x="688" y="361" type="line"/>
+      <point x="654" y="169"/>
+      <point x="473" y="-21"/>
     </contour>
     <contour>
-      <point x="404" y="7" type="qcurve" smooth="yes"/>
-      <point x="535" y="7"/>
-      <point x="685" y="182"/>
-      <point x="685" y="371" type="qcurve"/>
-      <point x="685" y="641" type="line"/>
-      <point x="685" y="828"/>
-      <point x="540" y="1005"/>
-      <point x="406" y="1005" type="qcurve" smooth="yes"/>
-      <point x="271" y="1005"/>
-      <point x="121" y="835"/>
-      <point x="121" y="641" type="qcurve"/>
-      <point x="121" y="371" type="line"/>
-      <point x="121" y="182"/>
-      <point x="271" y="7"/>
+      <point x="325" y="7" type="qcurve" smooth="yes"/>
+      <point x="456" y="7"/>
+      <point x="627" y="182"/>
+      <point x="660" y="371" type="qcurve"/>
+      <point x="708" y="641" type="line"/>
+      <point x="741" y="828"/>
+      <point x="617" y="1005"/>
+      <point x="483" y="1005" type="qcurve" smooth="yes"/>
+      <point x="348" y="1005"/>
+      <point x="178" y="835"/>
+      <point x="144" y="641" type="qcurve"/>
+      <point x="96" y="371" type="line"/>
+      <point x="63" y="182"/>
+      <point x="192" y="7"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND100.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND100.ufo/glyphs/oslash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="834"/>
-  <guideline x="673" y="1045" angle="334.4400348281762" identifier="HpORYVLdin"/>
+  <guideline x="673" y="1045" angle="334.4400348282" identifier="HpORYVLdin"/>
   <outline>
     <contour>
       <point x="408" y="510" type="line"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND100.ufo/fontinfo.plist
@@ -43,7 +43,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -51,7 +51,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND100.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="1422"/>
   <unicode hex="004F"/>
   <guideline x="710" y="829" angle="90" identifier="IJF0rXCKU0"/>
-  <anchor x="734" y="0" name="bottom"/>
-  <anchor x="710" y="708" name="center"/>
-  <anchor x="921" y="0" name="ogonek"/>
-  <anchor x="734" y="1432" name="top"/>
-  <anchor x="968" y="1432" name="topright"/>
+  <anchor x="643.2827004219" y="0" name="bottom"/>
+  <anchor x="744.2827004219" y="708" name="center"/>
+  <anchor x="830.2827004219" y="0" name="ogonek"/>
+  <anchor x="895.2827004219" y="1432" name="top"/>
+  <anchor x="1129.2827004219" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="712" y="-29" type="qcurve" smooth="yes"/>
-      <point x="429" y="-29" name="inserted"/>
-      <point x="61" y="321"/>
-      <point x="61" y="686" type="qcurve"/>
-      <point x="61" y="746" type="line"/>
-      <point x="61" y="1111" name="inserted"/>
-      <point x="433" y="1460"/>
-      <point x="712" y="1460" type="qcurve" smooth="yes"/>
-      <point x="990" y="1460" name="inserted"/>
-      <point x="1361" y="1097"/>
-      <point x="1361" y="746" type="qcurve"/>
-      <point x="1361" y="686" type="line"/>
-      <point x="1361" y="336" name="inserted"/>
-      <point x="994" y="-29"/>
+      <point x="667" y="-29" type="qcurve" smooth="yes"/>
+      <point x="355" y="-29" name="inserted"/>
+      <point x="19" y="323"/>
+      <point x="92" y="686" type="qcurve"/>
+      <point x="116" y="805" type="line"/>
+      <point x="183" y="1135" name="inserted"/>
+      <point x="515" y="1460"/>
+      <point x="827" y="1460" type="qcurve" smooth="yes"/>
+      <point x="1138" y="1460" name="inserted"/>
+      <point x="1473" y="1095"/>
+      <point x="1402" y="746" type="qcurve"/>
+      <point x="1373" y="604" type="line"/>
+      <point x="1310" y="296" name="inserted"/>
+      <point x="964" y="-29"/>
     </contour>
     <contour>
-      <point x="710" y="425" type="qcurve" smooth="yes"/>
-      <point x="788" y="425" name="inserted"/>
-      <point x="870" y="527"/>
-      <point x="870" y="614" type="qcurve"/>
-      <point x="870" y="817" type="line"/>
-      <point x="870" y="905" name="inserted"/>
-      <point x="788" y="1005"/>
-      <point x="710" y="1005" type="qcurve" smooth="yes"/>
-      <point x="632" y="1005" name="inserted"/>
-      <point x="552" y="905"/>
-      <point x="552" y="817" type="qcurve"/>
-      <point x="552" y="614" type="line"/>
-      <point x="552" y="527" name="inserted"/>
-      <point x="631" y="425"/>
+      <point x="700" y="425" type="qcurve" smooth="yes"/>
+      <point x="778" y="425" name="inserted"/>
+      <point x="873" y="527"/>
+      <point x="888" y="614" type="qcurve"/>
+      <point x="924" y="817" type="line"/>
+      <point x="940" y="905" name="inserted"/>
+      <point x="870" y="1005"/>
+      <point x="792" y="1005" type="qcurve" smooth="yes"/>
+      <point x="714" y="1005" name="inserted"/>
+      <point x="622" y="905"/>
+      <point x="606" y="817" type="qcurve"/>
+      <point x="570" y="614" type="line"/>
+      <point x="555" y="527" name="inserted"/>
+      <point x="621" y="425"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND100.ufo/glyphs/o.glif
@@ -3,43 +3,43 @@
   <advance width="1238"/>
   <unicode hex="006F"/>
   <guideline x="619" y="587" angle="90" identifier="Lh5pZwwh1D"/>
-  <anchor x="627" y="0" name="bottom"/>
-  <anchor x="619" y="510" name="center"/>
-  <anchor x="868" y="0" name="ogonek"/>
-  <anchor x="628" y="1020" name="top"/>
-  <anchor x="847" y="1020" name="topright"/>
+  <anchor x="536" y="0" name="bottom"/>
+  <anchor x="618" y="510" name="center"/>
+  <anchor x="777" y="0" name="ogonek"/>
+  <anchor x="717" y="1020" name="top"/>
+  <anchor x="936" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="619" y="-40" type="qcurve"/>
-      <point x="352" y="-40" name="inserted"/>
-      <point x="41" y="244"/>
-      <point x="41" y="482" type="qcurve"/>
-      <point x="41" y="559" type="line"/>
-      <point x="41" y="793" name="inserted"/>
-      <point x="361" y="1076"/>
-      <point x="619" y="1076" type="qcurve"/>
-      <point x="877" y="1076" name="inserted"/>
-      <point x="1197" y="785"/>
-      <point x="1197" y="559" type="qcurve"/>
-      <point x="1197" y="482" type="line"/>
-      <point x="1197" y="252" name="inserted"/>
-      <point x="887" y="-40"/>
+      <point x="551" y="-40" type="qcurve"/>
+      <point x="295" y="-40" name="inserted"/>
+      <point x="-5" y="250"/>
+      <point x="40" y="504" type="qcurve"/>
+      <point x="56" y="594" type="line"/>
+      <point x="92" y="795" name="inserted"/>
+      <point x="422" y="1076"/>
+      <point x="680" y="1076" type="qcurve"/>
+      <point x="938" y="1076" name="inserted"/>
+      <point x="1245" y="785"/>
+      <point x="1206" y="559" type="qcurve"/>
+      <point x="1192" y="482" type="line"/>
+      <point x="1150" y="239" name="inserted"/>
+      <point x="819" y="-40"/>
     </contour>
     <contour>
-      <point x="619" y="342" type="qcurve" smooth="yes"/>
-      <point x="683" y="342" name="inserted"/>
-      <point x="737" y="408"/>
-      <point x="737" y="468" type="qcurve"/>
-      <point x="737" y="559" type="line"/>
-      <point x="737" y="615" name="inserted"/>
-      <point x="681" y="682"/>
-      <point x="619" y="682" type="qcurve" smooth="yes"/>
-      <point x="557" y="682" name="inserted"/>
-      <point x="502" y="616"/>
-      <point x="502" y="559" type="qcurve"/>
-      <point x="502" y="468" type="line"/>
-      <point x="502" y="409" name="inserted"/>
-      <point x="557" y="342"/>
+      <point x="588" y="349" type="qcurve" smooth="yes"/>
+      <point x="652" y="349" name="inserted"/>
+      <point x="718" y="415"/>
+      <point x="729" y="475" type="qcurve"/>
+      <point x="745" y="566" type="line"/>
+      <point x="754" y="622" name="inserted"/>
+      <point x="710" y="689"/>
+      <point x="648" y="689" type="qcurve" smooth="yes"/>
+      <point x="586" y="689" name="inserted"/>
+      <point x="520" y="623"/>
+      <point x="510" y="566" type="qcurve"/>
+      <point x="494" y="475" type="line"/>
+      <point x="483" y="416" name="inserted"/>
+      <point x="526" y="349"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND100.ufo/fontinfo.plist
@@ -39,7 +39,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -47,7 +47,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1011"/>
   <unicode hex="004F"/>
-  <anchor x="506" y="0" name="bottom"/>
-  <anchor x="505" y="713" name="center"/>
-  <anchor x="659" y="0" name="ogonek"/>
-  <anchor x="517" y="1432" name="top"/>
-  <anchor x="737" y="1432" name="topright"/>
+  <anchor x="416" y="1" name="bottom"/>
+  <anchor x="541" y="713" name="center"/>
+  <anchor x="565" y="1" name="ogonek"/>
+  <anchor x="680" y="1432" name="top"/>
+  <anchor x="900" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="506" y="-25" type="qcurve"/>
-      <point x="304" y="-25"/>
-      <point x="87" y="211"/>
-      <point x="87" y="431" type="qcurve"/>
-      <point x="87" y="1002" type="line"/>
-      <point x="87" y="1217"/>
-      <point x="307" y="1451"/>
-      <point x="506" y="1451" type="qcurve" smooth="yes"/>
-      <point x="704" y="1451"/>
-      <point x="924" y="1218"/>
-      <point x="924" y="1002" type="qcurve"/>
-      <point x="924" y="431" type="line"/>
-      <point x="924" y="211"/>
-      <point x="707" y="-25"/>
+      <point x="421" y="-25" type="qcurve"/>
+      <point x="219" y="-25"/>
+      <point x="34" y="211"/>
+      <point x="73" y="431" type="qcurve"/>
+      <point x="174" y="1002" type="line"/>
+      <point x="212" y="1217"/>
+      <point x="459" y="1451"/>
+      <point x="658" y="1451" type="qcurve" smooth="yes"/>
+      <point x="856" y="1451"/>
+      <point x="1049" y="1218"/>
+      <point x="1011" y="1002" type="qcurve"/>
+      <point x="910" y="431" type="line"/>
+      <point x="871" y="211"/>
+      <point x="622" y="-25"/>
     </contour>
     <contour>
-      <point x="506" y="124" type="qcurve"/>
-      <point x="631" y="124"/>
-      <point x="761" y="265"/>
-      <point x="761" y="396" type="qcurve"/>
-      <point x="761" y="1033" type="line"/>
-      <point x="761" y="1161"/>
-      <point x="629" y="1299"/>
-      <point x="506" y="1299" type="qcurve" smooth="yes"/>
-      <point x="380" y="1299"/>
-      <point x="250" y="1160"/>
-      <point x="250" y="1033" type="qcurve"/>
-      <point x="250" y="396" type="line"/>
-      <point x="250" y="265"/>
-      <point x="380" y="124"/>
+      <point x="442" y="124" type="qcurve"/>
+      <point x="567" y="124"/>
+      <point x="718" y="265"/>
+      <point x="741" y="396" type="qcurve"/>
+      <point x="853" y="1033" type="line"/>
+      <point x="876" y="1161"/>
+      <point x="764" y="1299"/>
+      <point x="641" y="1299" type="qcurve" smooth="yes"/>
+      <point x="515" y="1299"/>
+      <point x="365" y="1160"/>
+      <point x="342" y="1033" type="qcurve"/>
+      <point x="230" y="396" type="line"/>
+      <point x="207" y="265"/>
+      <point x="316" y="124"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="796"/>
   <unicode hex="006F"/>
-  <anchor x="399" y="0" name="bottom"/>
+  <anchor x="309" y="0" name="bottom"/>
   <anchor x="398" y="510" name="center"/>
-  <anchor x="514" y="0" name="ogonek"/>
-  <anchor x="399" y="1020" name="top"/>
-  <anchor x="514" y="1020" name="topright"/>
+  <anchor x="425" y="0" name="ogonek"/>
+  <anchor x="489" y="1020" name="top"/>
+  <anchor x="604" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="399" y="-19" type="qcurve"/>
-      <point x="247" y="-19"/>
-      <point x="61" y="160"/>
-      <point x="61" y="340" type="qcurve"/>
-      <point x="61" y="684" type="line"/>
-      <point x="61" y="861"/>
-      <point x="245" y="1039"/>
-      <point x="399" y="1039" type="qcurve"/>
-      <point x="552" y="1039"/>
-      <point x="735" y="860"/>
-      <point x="735" y="684" type="qcurve"/>
-      <point x="735" y="340" type="line"/>
-      <point x="735" y="160"/>
-      <point x="550" y="-19"/>
+      <point x="321" y="-19" type="qcurve"/>
+      <point x="169" y="-19"/>
+      <point x="-1" y="160"/>
+      <point x="31" y="340" type="qcurve"/>
+      <point x="92" y="684" type="line"/>
+      <point x="123" y="861"/>
+      <point x="322" y="1039"/>
+      <point x="476" y="1039" type="qcurve"/>
+      <point x="629" y="1039"/>
+      <point x="797" y="860"/>
+      <point x="766" y="684" type="qcurve"/>
+      <point x="705" y="340" type="line"/>
+      <point x="673" y="160"/>
+      <point x="472" y="-19"/>
     </contour>
     <contour>
-      <point x="399" y="124" type="qcurve"/>
-      <point x="481" y="124"/>
-      <point x="578" y="220"/>
-      <point x="578" y="310" type="qcurve"/>
-      <point x="578" y="709" type="line"/>
-      <point x="578" y="793"/>
-      <point x="481" y="896"/>
-      <point x="399" y="896" type="qcurve"/>
-      <point x="314" y="896"/>
-      <point x="217" y="796"/>
-      <point x="217" y="709" type="qcurve"/>
-      <point x="217" y="310" type="line"/>
-      <point x="217" y="220"/>
-      <point x="315" y="124"/>
+      <point x="335" y="124" type="qcurve"/>
+      <point x="417" y="124"/>
+      <point x="527" y="220"/>
+      <point x="543" y="310" type="qcurve"/>
+      <point x="613" y="709" type="line"/>
+      <point x="628" y="793"/>
+      <point x="545" y="896"/>
+      <point x="463" y="896" type="qcurve"/>
+      <point x="378" y="896"/>
+      <point x="267" y="796"/>
+      <point x="252" y="709" type="qcurve"/>
+      <point x="182" y="310" type="line"/>
+      <point x="166" y="220"/>
+      <point x="251" y="124"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND100.ufo/fontinfo.plist
@@ -39,7 +39,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -47,7 +47,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1465"/>
   <unicode hex="004F"/>
-  <guideline x="732" y="1055" angle="90" identifier="ZtaruHhA8f"/>
-  <anchor x="733" y="0" name="bottom"/>
-  <anchor x="732" y="716" name="center"/>
-  <anchor x="930" y="0" name="ogonek"/>
-  <anchor x="733" y="1432" name="top"/>
-  <anchor x="956" y="1432" name="topright"/>
+  <guideline x="828.0249646474306" y="1055" angle="100" identifier="ZtaruHhA8f"/>
+  <anchor x="643" y="0" name="bottom"/>
+  <anchor x="768.2501181872609" y="716" name="center"/>
+  <anchor x="840" y="0" name="ogonek"/>
+  <anchor x="895.5002363745218" y="1432" name="top"/>
+  <anchor x="1118.5002363745218" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="733" y="-29" type="qcurve" smooth="yes"/>
-      <point x="459" y="-29"/>
-      <point x="101" y="349"/>
-      <point x="101" y="656" type="qcurve"/>
-      <point x="101" y="776" type="line"/>
-      <point x="101" y="1075"/>
-      <point x="457" y="1459"/>
-      <point x="732" y="1459" type="qcurve" smooth="yes"/>
-      <point x="1008" y="1459"/>
-      <point x="1364" y="1075"/>
-      <point x="1364" y="776" type="qcurve"/>
-      <point x="1364" y="656" type="line"/>
-      <point x="1364" y="355"/>
-      <point x="1005" y="-29"/>
+      <point x="642" y="-29" type="qcurve" smooth="yes"/>
+      <point x="368" y="-29"/>
+      <point x="72.53811626725428" y="349"/>
+      <point x="126.67049934475301" y="656" type="qcurve"/>
+      <point x="147.8297370297688" y="776" type="line"/>
+      <point x="200.55150426159986" y="1075"/>
+      <point x="620" y="1459"/>
+      <point x="895" y="1459" type="qcurve" smooth="yes"/>
+      <point x="1171" y="1459"/>
+      <point x="1463.5515042615998" y="1075"/>
+      <point x="1410.8297370297687" y="776" type="qcurve"/>
+      <point x="1389.6704993447531" y="656" type="line"/>
+      <point x="1336.596078151505" y="355"/>
+      <point x="914" y="-29"/>
     </contour>
     <contour>
-      <point x="733" y="0" type="qcurve" smooth="yes"/>
-      <point x="988" y="0"/>
-      <point x="1332" y="362"/>
-      <point x="1332" y="661" type="qcurve"/>
-      <point x="1332" y="771" type="line"/>
-      <point x="1332" y="1065"/>
-      <point x="989" y="1429"/>
-      <point x="732" y="1429" type="qcurve" smooth="yes"/>
-      <point x="474" y="1429"/>
-      <point x="133" y="1067"/>
-      <point x="133" y="771" type="qcurve"/>
-      <point x="133" y="661" type="line"/>
-      <point x="133" y="361"/>
-      <point x="476" y="0"/>
+      <point x="643" y="0" type="qcurve" smooth="yes"/>
+      <point x="898" y="0"/>
+      <point x="1305.8303670164644" y="362"/>
+      <point x="1358.5521342482953" y="661" type="qcurve"/>
+      <point x="1377.9481021262266" y="771" type="line"/>
+      <point x="1429.788234454515" y="1065"/>
+      <point x="1150.9712554323964" y="1429"/>
+      <point x="893.9712554323964" y="1429" type="qcurve" smooth="yes"/>
+      <point x="635.9712554323964" y="1429"/>
+      <point x="231.14088841593212" y="1067"/>
+      <point x="178.9481021262265" y="771" type="qcurve"/>
+      <point x="159.55213424829535" y="661" type="line"/>
+      <point x="106.65404003575586" y="361"/>
+      <point x="386" y="0"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1465"/>
   <unicode hex="004F"/>
-  <guideline x="828.0249646474306" y="1055" angle="100" identifier="ZtaruHhA8f"/>
+  <guideline x="828.0249646474" y="1055" angle="100" identifier="ZtaruHhA8f"/>
   <anchor x="643" y="0" name="bottom"/>
-  <anchor x="768.2501181872609" y="716" name="center"/>
+  <anchor x="768.2501181873" y="716" name="center"/>
   <anchor x="840" y="0" name="ogonek"/>
-  <anchor x="895.5002363745218" y="1432" name="top"/>
-  <anchor x="1118.5002363745218" y="1432" name="topright"/>
+  <anchor x="895.5002363745" y="1432" name="top"/>
+  <anchor x="1118.5002363745" y="1432" name="topright"/>
   <outline>
     <contour>
       <point x="642" y="-29" type="qcurve" smooth="yes"/>
       <point x="368" y="-29"/>
-      <point x="72.53811626725428" y="349"/>
-      <point x="126.67049934475301" y="656" type="qcurve"/>
-      <point x="147.8297370297688" y="776" type="line"/>
-      <point x="200.55150426159986" y="1075"/>
+      <point x="72.5381162673" y="349"/>
+      <point x="126.6704993448" y="656" type="qcurve"/>
+      <point x="147.8297370298" y="776" type="line"/>
+      <point x="200.5515042616" y="1075"/>
       <point x="620" y="1459"/>
       <point x="895" y="1459" type="qcurve" smooth="yes"/>
       <point x="1171" y="1459"/>
-      <point x="1463.5515042615998" y="1075"/>
-      <point x="1410.8297370297687" y="776" type="qcurve"/>
-      <point x="1389.6704993447531" y="656" type="line"/>
-      <point x="1336.596078151505" y="355"/>
+      <point x="1463.5515042616" y="1075"/>
+      <point x="1410.8297370298" y="776" type="qcurve"/>
+      <point x="1389.6704993448" y="656" type="line"/>
+      <point x="1336.5960781515" y="355"/>
       <point x="914" y="-29"/>
     </contour>
     <contour>
       <point x="643" y="0" type="qcurve" smooth="yes"/>
       <point x="898" y="0"/>
-      <point x="1305.8303670164644" y="362"/>
-      <point x="1358.5521342482953" y="661" type="qcurve"/>
-      <point x="1377.9481021262266" y="771" type="line"/>
-      <point x="1429.788234454515" y="1065"/>
-      <point x="1150.9712554323964" y="1429"/>
-      <point x="893.9712554323964" y="1429" type="qcurve" smooth="yes"/>
-      <point x="635.9712554323964" y="1429"/>
-      <point x="231.14088841593212" y="1067"/>
-      <point x="178.9481021262265" y="771" type="qcurve"/>
-      <point x="159.55213424829535" y="661" type="line"/>
-      <point x="106.65404003575586" y="361"/>
+      <point x="1305.8303670165" y="362"/>
+      <point x="1358.5521342483" y="661" type="qcurve"/>
+      <point x="1377.9481021262" y="771" type="line"/>
+      <point x="1429.7882344545" y="1065"/>
+      <point x="1150.9712554324" y="1429"/>
+      <point x="893.9712554324" y="1429" type="qcurve" smooth="yes"/>
+      <point x="635.9712554324" y="1429"/>
+      <point x="231.1408884159" y="1067"/>
+      <point x="178.9481021262" y="771" type="qcurve"/>
+      <point x="159.5521342483" y="661" type="line"/>
+      <point x="106.6540400358" y="361"/>
       <point x="386" y="0"/>
     </contour>
   </outline>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND100.ufo/glyphs/o.glif
@@ -2,44 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1086"/>
   <unicode hex="006F"/>
-  <guideline x="545" y="628" angle="90" identifier="SgpTUwKMeN"/>
-  <anchor x="545" y="0" name="bottom"/>
-  <anchor x="545" y="509" name="center"/>
-  <anchor x="716" y="0" name="ogonek"/>
-  <anchor x="545" y="1020" name="top"/>
-  <anchor x="671" y="1020" name="topright"/>
+  <anchor x="454" y="0" name="bottom"/>
+  <anchor x="543" y="509" name="center"/>
+  <anchor x="626" y="0" name="ogonek"/>
+  <anchor x="635" y="1020" name="top"/>
+  <anchor x="761" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="544" y="-29" type="qcurve"/>
-      <point x="341" y="-29"/>
-      <point x="95" y="236"/>
-      <point x="95" y="464" type="qcurve"/>
-      <point x="95" y="546" type="line"/>
-      <point x="95" y="774"/>
-      <point x="341" y="1036"/>
-      <point x="545" y="1036" type="qcurve"/>
-      <point x="751" y="1036"/>
-      <point x="991" y="767"/>
-      <point x="991" y="546" type="qcurve"/>
-      <point x="991" y="464" type="line"/>
-      <point x="991" y="241"/>
-      <point x="750" y="-29"/>
+      <point x="451" y="-29" type="qcurve"/>
+      <point x="252" y="-29"/>
+      <point x="47" y="236"/>
+      <point x="87" y="464" type="qcurve"/>
+      <point x="101" y="546" type="line"/>
+      <point x="141" y="774"/>
+      <point x="432" y="1036"/>
+      <point x="636" y="1036" type="qcurve"/>
+      <point x="838" y="1036"/>
+      <point x="1036" y="767"/>
+      <point x="997" y="546" type="qcurve"/>
+      <point x="983" y="464" type="line"/>
+      <point x="943" y="241"/>
+      <point x="657" y="-29"/>
     </contour>
     <contour>
-      <point x="544" y="1" type="qcurve"/>
-      <point x="729" y="1"/>
-      <point x="960" y="249"/>
-      <point x="960" y="467" type="qcurve"/>
-      <point x="960" y="542" type="line"/>
-      <point x="960" y="755"/>
-      <point x="736" y="1008"/>
-      <point x="545" y="1008" type="qcurve"/>
-      <point x="357" y="1008"/>
-      <point x="126" y="763"/>
-      <point x="126" y="542" type="qcurve"/>
-      <point x="126" y="467" type="line"/>
-      <point x="126" y="246"/>
-      <point x="359" y="1"/>
+      <point x="454" y="1" type="qcurve"/>
+      <point x="639" y="1"/>
+      <point x="914" y="249"/>
+      <point x="952" y="467" type="qcurve"/>
+      <point x="966" y="542" type="line"/>
+      <point x="1003" y="755"/>
+      <point x="824" y="1008"/>
+      <point x="633" y="1008" type="qcurve"/>
+      <point x="445" y="1008"/>
+      <point x="171" y="763"/>
+      <point x="132" y="542" type="qcurve"/>
+      <point x="118" y="467" type="line"/>
+      <point x="79" y="246"/>
+      <point x="269" y="1"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND100.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND100.ufo/glyphs/oslash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="996"/>
-  <guideline x="534" y="462" angle="331.3895403340348" identifier="HpTBW3Ocar"/>
+  <guideline x="534" y="462" angle="331.389540334" identifier="HpTBW3Ocar"/>
   <outline>
     <contour>
       <point x="520" y="499" type="line"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND100.ufo/fontinfo.plist
@@ -43,7 +43,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -51,7 +51,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND100.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="1584"/>
   <unicode hex="004F"/>
   <guideline x="791" y="863" angle="90" identifier="A0u2HKJ6OY"/>
-  <anchor x="794" y="0" name="bottom"/>
-  <anchor x="791" y="711" name="center"/>
-  <anchor x="1028" y="0" name="ogonek"/>
-  <anchor x="794" y="1432" name="top"/>
-  <anchor x="1020" y="1432" name="topright"/>
+  <anchor x="668" y="0" name="bottom"/>
+  <anchor x="790" y="711" name="center"/>
+  <anchor x="902" y="0" name="ogonek"/>
+  <anchor x="920" y="1432" name="top"/>
+  <anchor x="1146" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="792" y="-31" type="qcurve" smooth="yes"/>
-      <point x="468" y="-31" name="inserted"/>
-      <point x="63" y="353"/>
-      <point x="63" y="716" type="qcurve"/>
-      <point x="63" y="716" type="line"/>
-      <point x="63" y="1079" name="inserted"/>
-      <point x="472" y="1463"/>
-      <point x="792" y="1463" type="qcurve" smooth="yes"/>
-      <point x="1112" y="1463" name="inserted"/>
-      <point x="1521" y="1065"/>
-      <point x="1521" y="716" type="qcurve"/>
-      <point x="1521" y="716" type="line"/>
-      <point x="1521" y="367" name="inserted"/>
-      <point x="1116" y="-31"/>
+      <point x="743" y="-31" type="qcurve"/>
+      <point x="419" y="-31" name="inserted"/>
+      <point x="36" y="353"/>
+      <point x="100" y="722" type="qcurve"/>
+      <point x="100" y="722" type="line"/>
+      <point x="164" y="1079" name="inserted"/>
+      <point x="589" y="1463"/>
+      <point x="909" y="1463" type="qcurve" smooth="yes"/>
+      <point x="1229" y="1463" name="inserted"/>
+      <point x="1618" y="1065"/>
+      <point x="1556" y="709" type="qcurve"/>
+      <point x="1556" y="709" type="line"/>
+      <point x="1495" y="367" name="inserted"/>
+      <point x="1067" y="-31"/>
     </contour>
     <contour>
-      <point x="791" y="433" type="qcurve" smooth="yes"/>
-      <point x="900" y="433" name="inserted"/>
-      <point x="1037" y="577"/>
-      <point x="1037" y="688" type="qcurve"/>
-      <point x="1037" y="743" type="line"/>
-      <point x="1037" y="857" name="inserted"/>
-      <point x="900" y="999"/>
-      <point x="791" y="999" type="qcurve" smooth="yes"/>
-      <point x="685" y="999" name="inserted"/>
-      <point x="546" y="857"/>
-      <point x="546" y="743" type="qcurve"/>
-      <point x="546" y="688" type="line"/>
-      <point x="546" y="575" name="inserted"/>
-      <point x="683" y="433"/>
+      <point x="777" y="433" type="qcurve" smooth="yes"/>
+      <point x="886" y="433" name="inserted"/>
+      <point x="1049" y="577"/>
+      <point x="1068" y="688" type="qcurve"/>
+      <point x="1078" y="743" type="line"/>
+      <point x="1098" y="857" name="inserted"/>
+      <point x="986" y="999"/>
+      <point x="877" y="999" type="qcurve" smooth="yes"/>
+      <point x="771" y="999" name="inserted"/>
+      <point x="607" y="857"/>
+      <point x="587" y="743" type="qcurve"/>
+      <point x="577" y="688" type="line"/>
+      <point x="557" y="575" name="inserted"/>
+      <point x="669" y="433"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND100.ufo/glyphs/o.glif
@@ -3,43 +3,43 @@
   <advance width="1318"/>
   <unicode hex="006F"/>
   <guideline x="659" y="583" angle="90" identifier="x79Oz6HDRB"/>
-  <anchor x="660" y="0" name="bottom"/>
-  <anchor x="659" y="511" name="center"/>
-  <anchor x="929" y="0" name="ogonek"/>
-  <anchor x="662" y="1020" name="top"/>
-  <anchor x="929" y="1020" name="topright"/>
+  <anchor x="569" y="0" name="bottom"/>
+  <anchor x="658" y="511" name="center"/>
+  <anchor x="838" y="0" name="ogonek"/>
+  <anchor x="751" y="1020" name="top"/>
+  <anchor x="1018" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="659" y="-43" type="qcurve" smooth="yes"/>
-      <point x="370" y="-43" name="inserted"/>
-      <point x="47" y="256"/>
-      <point x="47" y="506" type="qcurve"/>
-      <point x="47" y="529" type="line"/>
-      <point x="47" y="777" name="inserted"/>
-      <point x="378" y="1079"/>
-      <point x="659" y="1079" type="qcurve" smooth="yes"/>
-      <point x="939" y="1079" name="inserted"/>
-      <point x="1270" y="769"/>
-      <point x="1270" y="529" type="qcurve"/>
-      <point x="1270" y="506" type="line"/>
-      <point x="1270" y="264" name="inserted"/>
-      <point x="948" y="-43"/>
+      <point x="601" y="-43" type="qcurve" smooth="yes"/>
+      <point x="312" y="-43" name="inserted"/>
+      <point x="2" y="256"/>
+      <point x="46" y="506" type="qcurve"/>
+      <point x="50" y="529" type="line"/>
+      <point x="94" y="782" name="inserted"/>
+      <point x="438" y="1079"/>
+      <point x="719" y="1079" type="qcurve" smooth="yes"/>
+      <point x="999" y="1079" name="inserted"/>
+      <point x="1316" y="769"/>
+      <point x="1273" y="529" type="qcurve"/>
+      <point x="1269" y="506" type="line"/>
+      <point x="1227" y="257" name="inserted"/>
+      <point x="890" y="-43"/>
     </contour>
     <contour>
-      <point x="659" y="342" type="qcurve" smooth="yes"/>
-      <point x="735" y="342" name="inserted"/>
-      <point x="809" y="417"/>
-      <point x="809" y="485" type="qcurve"/>
-      <point x="809" y="540" type="line"/>
-      <point x="809" y="604" name="inserted"/>
-      <point x="733" y="682"/>
-      <point x="659" y="682" type="qcurve" smooth="yes"/>
-      <point x="584" y="682" name="inserted"/>
-      <point x="509" y="605"/>
-      <point x="509" y="540" type="qcurve"/>
-      <point x="509" y="485" type="line"/>
-      <point x="509" y="418" name="inserted"/>
-      <point x="583" y="342"/>
+      <point x="632" y="342" type="qcurve" smooth="yes"/>
+      <point x="708" y="342" name="inserted"/>
+      <point x="793" y="417"/>
+      <point x="805" y="485" type="qcurve"/>
+      <point x="814" y="540" type="line"/>
+      <point x="823" y="603" name="inserted"/>
+      <point x="760" y="682"/>
+      <point x="686" y="682" type="qcurve" smooth="yes"/>
+      <point x="611" y="682" name="inserted"/>
+      <point x="526" y="603"/>
+      <point x="514" y="540" type="qcurve"/>
+      <point x="505" y="485" type="line"/>
+      <point x="495" y="418" name="inserted"/>
+      <point x="558" y="342"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND100.ufo/fontinfo.plist
@@ -39,7 +39,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -47,7 +47,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,44 @@
 <glyph name="O" format="2">
   <advance width="1457"/>
   <unicode hex="004F"/>
-  <guideline x="729" y="1003" angle="90" identifier="p4pQtOkLme"/>
-  <anchor x="729" y="0" name="bottom"/>
-  <anchor x="728" y="715" name="center"/>
-  <anchor x="944" y="0" name="ogonek"/>
-  <anchor x="756" y="1432" name="top"/>
-  <anchor x="976" y="1432" name="topright"/>
+  <guideline x="815.8559616506" y="1003" angle="100" identifier="p4pQtOkLme"/>
+  <anchor x="639" y="2" name="bottom"/>
+  <anchor x="764" y="715" name="center"/>
+  <anchor x="854" y="0" name="ogonek"/>
+  <anchor x="919" y="1432" name="top"/>
+  <anchor x="1139" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="729" y="-30" type="qcurve"/>
-      <point x="432" y="-30"/>
-      <point x="86" y="350"/>
-      <point x="86" y="638" type="qcurve"/>
-      <point x="86" y="798" type="line"/>
-      <point x="86" y="1084"/>
-      <point x="435" y="1460"/>
-      <point x="729" y="1460" type="qcurve"/>
-      <point x="1022" y="1460"/>
-      <point x="1371" y="1086"/>
-      <point x="1371" y="798" type="qcurve"/>
-      <point x="1371" y="638" type="line"/>
-      <point x="1371" y="350"/>
-      <point x="1025" y="-30"/>
+      <point x="657" y="-30" type="qcurve"/>
+      <point x="360" y="-30"/>
+      <point x="58" y="350"/>
+      <point x="108" y="638" type="qcurve"/>
+      <point x="137" y="798" type="line"/>
+      <point x="187" y="1084"/>
+      <point x="579" y="1460"/>
+      <point x="873" y="1460" type="qcurve"/>
+      <point x="1166" y="1460"/>
+      <point x="1472" y="1086"/>
+      <point x="1422" y="798" type="qcurve"/>
+      <point x="1393" y="638" type="line"/>
+      <point x="1343" y="350"/>
+      <point x="953" y="-30"/>
     </contour>
     <contour>
-      <point x="729" y="128" type="qcurve"/>
-      <point x="952" y="128"/>
-      <point x="1201" y="410"/>
-      <point x="1201" y="628" type="qcurve"/>
-      <point x="1201" y="807" type="line"/>
-      <point x="1201" y="1024"/>
-      <point x="949" y="1301"/>
-      <point x="729" y="1301" type="qcurve"/>
-      <point x="507" y="1301"/>
-      <point x="256" y="1023"/>
-      <point x="256" y="807" type="qcurve"/>
-      <point x="256" y="628" type="line"/>
-      <point x="256" y="410"/>
-      <point x="505" y="128"/>
+      <point x="666" y="128" type="qcurve"/>
+      <point x="889" y="128"/>
+      <point x="1183" y="410"/>
+      <point x="1222" y="628" type="qcurve"/>
+      <point x="1253" y="807" type="line"/>
+      <point x="1292" y="1024"/>
+      <point x="1085" y="1301"/>
+      <point x="865" y="1301" type="qcurve"/>
+      <point x="643" y="1301"/>
+      <point x="346" y="1023"/>
+      <point x="308" y="807" type="qcurve"/>
+      <point x="277" y="628" type="line"/>
+      <point x="238" y="410"/>
+      <point x="442" y="128"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND100.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND100.ufo/glyphs/O_slash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Oslash-bar" format="2">
   <advance width="1271"/>
-  <guideline x="1121" y="1397" angle="330.751173663453" identifier="4Md523Ddk8"/>
+  <guideline x="1121" y="1397" angle="330.7511736635" identifier="4Md523Ddk8"/>
   <outline>
     <contour>
       <point x="585" y="785" type="line"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1073"/>
   <unicode hex="006F"/>
-  <anchor x="537" y="0" name="bottom"/>
+  <anchor x="447" y="0" name="bottom"/>
   <anchor x="537" y="510" name="center"/>
-  <anchor x="705" y="0" name="ogonek"/>
-  <anchor x="537" y="1020" name="top"/>
-  <anchor x="700" y="1020" name="topright"/>
+  <anchor x="615" y="0" name="ogonek"/>
+  <anchor x="627" y="1020" name="top"/>
+  <anchor x="790" y="1020" name="topright"/>
   <outline>
     <contour>
-      <point x="537" y="-28" type="qcurve"/>
-      <point x="333" y="-28"/>
-      <point x="69" y="251"/>
-      <point x="69" y="466" type="qcurve"/>
-      <point x="69" y="560" type="line"/>
-      <point x="69" y="776"/>
-      <point x="333" y="1048"/>
-      <point x="537" y="1048" type="qcurve"/>
-      <point x="740" y="1048"/>
-      <point x="1005" y="774"/>
-      <point x="1005" y="560" type="qcurve"/>
-      <point x="1005" y="466" type="line"/>
-      <point x="1005" y="251"/>
-      <point x="741" y="-28"/>
+      <point x="457" y="-28" type="qcurve"/>
+      <point x="253" y="-28"/>
+      <point x="23" y="251"/>
+      <point x="61" y="466" type="qcurve"/>
+      <point x="78" y="560" type="line"/>
+      <point x="116" y="776"/>
+      <point x="410" y="1048"/>
+      <point x="614" y="1048" type="qcurve"/>
+      <point x="817" y="1048"/>
+      <point x="1051" y="774"/>
+      <point x="1014" y="560" type="qcurve"/>
+      <point x="997" y="466" type="line"/>
+      <point x="959" y="251"/>
+      <point x="661" y="-28"/>
     </contour>
     <contour>
-      <point x="537" y="121" type="qcurve"/>
-      <point x="667" y="121"/>
-      <point x="839" y="306"/>
-      <point x="839" y="452" type="qcurve"/>
-      <point x="839" y="567" type="line"/>
-      <point x="839" y="715"/>
-      <point x="665" y="897"/>
-      <point x="537" y="897" type="qcurve"/>
-      <point x="407" y="897"/>
-      <point x="233" y="714"/>
-      <point x="233" y="567" type="qcurve"/>
-      <point x="233" y="452" type="line"/>
-      <point x="233" y="306"/>
-      <point x="405" y="121"/>
+      <point x="468" y="121" type="qcurve"/>
+      <point x="598" y="121"/>
+      <point x="803" y="306"/>
+      <point x="829" y="452" type="qcurve"/>
+      <point x="849" y="567" type="line"/>
+      <point x="875" y="715"/>
+      <point x="733" y="897"/>
+      <point x="605" y="897" type="qcurve"/>
+      <point x="475" y="897"/>
+      <point x="269" y="714"/>
+      <point x="243" y="567" type="qcurve"/>
+      <point x="223" y="452" type="line"/>
+      <point x="197" y="306"/>
+      <point x="336" y="121"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND100.ufo/fontinfo.plist
@@ -144,7 +144,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -152,7 +152,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,43 @@
 <glyph name="O" format="2">
   <advance width="1722"/>
   <unicode hex="004F"/>
-  <anchor x="861" y="0" name="bottom"/>
-  <anchor x="861" y="716" name="center"/>
-  <anchor x="1108" y="0" name="ogonek"/>
-  <anchor x="861" y="1432" name="top"/>
-  <anchor x="1060" y="1432" name="topright"/>
+  <anchor x="764.7952286282" y="0" name="bottom"/>
+  <anchor x="890.7952286282" y="716" name="center"/>
+  <anchor x="1011.7952286282" y="0" name="ogonek"/>
+  <anchor x="1017.7952286282" y="1432" name="top"/>
+  <anchor x="1216.7952286282" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="862" y="-38" type="qcurve" smooth="yes"/>
-      <point x="544" y="-38"/>
-      <point x="112" y="374"/>
-      <point x="112" y="718" type="qcurve"/>
-      <point x="112" y="718" type="line"/>
-      <point x="112" y="1038"/>
-      <point x="542" y="1474"/>
-      <point x="862" y="1474" type="qcurve" smooth="yes"/>
-      <point x="1180" y="1474"/>
-      <point x="1610" y="1044"/>
-      <point x="1610" y="718" type="qcurve"/>
-      <point x="1610" y="718" type="line"/>
-      <point x="1610" y="396"/>
-      <point x="1178" y="-38"/>
+      <point x="782.7952286282" y="-38" type="qcurve" smooth="yes"/>
+      <point x="462.7952286282" y="-39"/>
+      <point x="81.7952286282" y="374"/>
+      <point x="142.7952286282" y="718" type="qcurve"/>
+      <point x="142.7952286282" y="718" type="line"/>
+      <point x="198.7952286282" y="1044"/>
+      <point x="685.7952286282" y="1474"/>
+      <point x="1005.7952286282" y="1474" type="qcurve" smooth="yes"/>
+      <point x="1323.7952286282" y="1474"/>
+      <point x="1697.7952286282" y="1044"/>
+      <point x="1640.7952286282" y="718" type="qcurve"/>
+      <point x="1640.7952286282" y="718" type="line"/>
+      <point x="1576.7952286282" y="373"/>
+      <point x="1098.7952286282" y="-37"/>
     </contour>
     <contour>
-      <point x="862" y="32" type="qcurve" smooth="yes"/>
-      <point x="1142" y="32"/>
-      <point x="1522" y="406"/>
-      <point x="1522" y="716" type="qcurve"/>
-      <point x="1522" y="716" type="line"/>
-      <point x="1522" y="1016"/>
-      <point x="1136" y="1398"/>
-      <point x="862" y="1398" type="qcurve" smooth="yes"/>
-      <point x="582" y="1398"/>
-      <point x="200" y="1030"/>
-      <point x="200" y="716" type="qcurve"/>
-      <point x="200" y="716" type="line"/>
-      <point x="200" y="402"/>
-      <point x="588" y="32"/>
+      <point x="781.7952286282" y="32" type="qcurve" smooth="yes"/>
+      <point x="1061.7952286282" y="32"/>
+      <point x="1497.7952286282" y="406"/>
+      <point x="1551.7952286282" y="716" type="qcurve"/>
+      <point x="1551.7952286282" y="716" type="line"/>
+      <point x="1604.7952286282" y="1016"/>
+      <point x="1280.7952286282" y="1398"/>
+      <point x="1006.7952286282" y="1398" type="qcurve" smooth="yes"/>
+      <point x="726.7952286282" y="1398"/>
+      <point x="285.7952286282" y="1030"/>
+      <point x="229.7952286282" y="716" type="qcurve"/>
+      <point x="229.7952286282" y="716" type="line"/>
+      <point x="174.7952286282" y="402"/>
+      <point x="507.7952286282" y="32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="1364"/>
   <unicode hex="006F"/>
-  <anchor x="681" y="0" name="bottom"/>
-  <anchor x="682" y="542" name="center"/>
-  <anchor x="899" y="0" name="ogonek"/>
-  <anchor x="681" y="1086" name="top"/>
-  <anchor x="1061" y="1086" name="topright"/>
+  <anchor x="585.6264367816" y="0" name="bottom"/>
+  <anchor x="682.6264367816" y="542" name="center"/>
+  <anchor x="803.6264367816" y="0" name="ogonek"/>
+  <anchor x="776.6264367816" y="1086" name="top"/>
+  <anchor x="1156.6264367816" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="681" y="-36" type="qcurve" smooth="yes"/>
-      <point x="422" y="-36"/>
-      <point x="106" y="296"/>
-      <point x="106" y="541" type="qcurve"/>
-      <point x="106" y="541" type="line"/>
-      <point x="106" y="786"/>
-      <point x="430" y="1116"/>
-      <point x="681" y="1116" type="qcurve" smooth="yes"/>
-      <point x="934" y="1116"/>
-      <point x="1258" y="780"/>
-      <point x="1258" y="541" type="qcurve"/>
-      <point x="1258" y="541" type="line"/>
-      <point x="1258" y="300"/>
-      <point x="940" y="-36"/>
+      <point x="583.6264367816" y="-36" type="qcurve" smooth="yes"/>
+      <point x="324.6264367816" y="-36"/>
+      <point x="62.6264367816" y="296"/>
+      <point x="105.6264367816" y="541" type="qcurve"/>
+      <point x="105.6264367816" y="541" type="line"/>
+      <point x="149.6264367816" y="786"/>
+      <point x="525.6264367816" y="1116"/>
+      <point x="776.6264367816" y="1116" type="qcurve" smooth="yes"/>
+      <point x="1029.6264367816" y="1116"/>
+      <point x="1300.6264367816" y="780"/>
+      <point x="1257.6264367816" y="541" type="qcurve"/>
+      <point x="1257.6264367816" y="541" type="line"/>
+      <point x="1215.6264367816" y="300"/>
+      <point x="842.6264367816" y="-36"/>
     </contour>
     <contour>
-      <point x="681" y="36" type="qcurve" smooth="yes"/>
-      <point x="890" y="36"/>
-      <point x="1170" y="318"/>
-      <point x="1170" y="541" type="qcurve"/>
-      <point x="1170" y="541" type="line"/>
-      <point x="1170" y="758"/>
-      <point x="886" y="1046"/>
-      <point x="681" y="1046" type="qcurve" smooth="yes"/>
-      <point x="476" y="1046"/>
-      <point x="190" y="766"/>
-      <point x="191" y="541" type="qcurve"/>
-      <point x="191" y="541" type="line"/>
-      <point x="190" y="316"/>
-      <point x="472" y="36"/>
+      <point x="591.6264367816" y="36" type="qcurve" smooth="yes"/>
+      <point x="800.6264367816" y="36"/>
+      <point x="1130.6264367816" y="318"/>
+      <point x="1169.6264367816" y="541" type="qcurve"/>
+      <point x="1169.6264367816" y="541" type="line"/>
+      <point x="1208.6264367816" y="758"/>
+      <point x="974.6264367816" y="1046"/>
+      <point x="769.6264367816" y="1046" type="qcurve" smooth="yes"/>
+      <point x="564.6264367816" y="1046"/>
+      <point x="229.6264367816" y="766"/>
+      <point x="190.6264367816" y="541" type="qcurve"/>
+      <point x="190.6264367816" y="541" type="line"/>
+      <point x="150.6264367816" y="316"/>
+      <point x="382.6264367816" y="36"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND100.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND100.ufo/glyphs/oslash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="1180"/>
-  <guideline x="719" y="487" angle="327.90740867126584" identifier="HUt16g0QPR"/>
+  <guideline x="719" y="487" angle="327.9074086713" identifier="HUt16g0QPR"/>
   <outline>
     <contour>
       <point x="586" y="584" type="line"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND100.ufo/fontinfo.plist
@@ -126,7 +126,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -134,7 +134,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND100.ufo/fontinfo.plist
@@ -164,7 +164,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -172,7 +172,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND100.ufo/glyphs/O_.glif
@@ -1,44 +1,48 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="O" format="2">
-  <advance width="1672"/>
+  <advance width="1673"/>
   <unicode hex="004F"/>
-  <anchor x="838" y="0" name="bottom"/>
-  <anchor x="836" y="720" name="center"/>
-  <anchor x="1087" y="0" name="ogonek"/>
-  <anchor x="836" y="1432" name="top"/>
-  <anchor x="1058" y="1432" name="topright"/>
+  <guideline x="1653" y="1109" angle="80" identifier="yRrmG6phu3"/>
+  <guideline x="1446" y="1036" angle="80" identifier="GvEgeRoy6z"/>
+  <guideline x="178" y="1229" angle="80" identifier="qGa5ONEdWt"/>
+  <guideline x="368" y="1207" angle="80" identifier="Enj6pzyxsA"/>
+  <anchor x="742.6260504202" y="0" name="bottom"/>
+  <anchor x="867.6260504202" y="720" name="center"/>
+  <anchor x="991.6260504202" y="0" name="ogonek"/>
+  <anchor x="993.6260504202" y="1432" name="top"/>
+  <anchor x="1215.6260504202" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="836" y="-38" type="qcurve" smooth="yes"/>
-      <point x="510" y="-38"/>
-      <point x="88" y="386"/>
-      <point x="88" y="718" type="qcurve"/>
-      <point x="88" y="718" type="line"/>
-      <point x="88" y="1038"/>
-      <point x="518" y="1474"/>
-      <point x="836" y="1474" type="qcurve" smooth="yes"/>
-      <point x="1156" y="1474"/>
-      <point x="1584" y="1042"/>
-      <point x="1584" y="718" type="qcurve"/>
-      <point x="1584" y="718" type="line"/>
-      <point x="1584" y="396"/>
-      <point x="1156" y="-38"/>
+      <point x="747.6260504202" y="-38" type="qcurve" smooth="yes"/>
+      <point x="421.6260504202" y="-38"/>
+      <point x="63.6260504202" y="399"/>
+      <point x="122.6260504202" y="741" type="qcurve"/>
+      <point x="122.6260504202" y="741" type="line"/>
+      <point x="178.6260504202" y="1061"/>
+      <point x="676.6260504202" y="1474"/>
+      <point x="993.6260504202" y="1474" type="qcurve" smooth="yes"/>
+      <point x="1302.6260504202" y="1474"/>
+      <point x="1672.6260504202" y="1035"/>
+      <point x="1610.6260504202" y="691" type="qcurve"/>
+      <point x="1610.6260504202" y="691" type="line"/>
+      <point x="1559.6260504202" y="394"/>
+      <point x="1078.6260504202" y="-38"/>
     </contour>
     <contour>
-      <point x="836" y="130" type="qcurve" smooth="yes"/>
-      <point x="1082" y="130"/>
-      <point x="1390" y="452"/>
-      <point x="1390" y="716" type="qcurve"/>
-      <point x="1390" y="716" type="line"/>
-      <point x="1390" y="972"/>
-      <point x="1074" y="1300"/>
-      <point x="836" y="1300" type="qcurve" smooth="yes"/>
-      <point x="590" y="1300"/>
-      <point x="282" y="980"/>
-      <point x="282" y="716" type="qcurve"/>
-      <point x="282" y="716" type="line"/>
-      <point x="282" y="454"/>
-      <point x="594" y="130"/>
+      <point x="763.6260504202" y="130" type="qcurve" smooth="yes"/>
+      <point x="1009.6260504202" y="130"/>
+      <point x="1374.6260504202" y="452"/>
+      <point x="1421.6260504202" y="716" type="qcurve"/>
+      <point x="1421.6260504202" y="716" type="line"/>
+      <point x="1467.6260504202" y="980"/>
+      <point x="1218.6260504202" y="1300"/>
+      <point x="970.6260504202" y="1300" type="qcurve" smooth="yes"/>
+      <point x="724.6260504202" y="1300"/>
+      <point x="359.6260504202" y="990"/>
+      <point x="313.6260504202" y="716" type="qcurve"/>
+      <point x="313.6260504202" y="716" type="line"/>
+      <point x="266.6260504202" y="454"/>
+      <point x="521.6260504202" y="130"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND100.ufo/glyphs/nine.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND100.ufo/glyphs/nine.glif
@@ -22,7 +22,7 @@
       <point x="585" y="1462" type="qcurve"/>
     </contour>
     <contour>
-      <point x="1026" y="937" type="line"/>
+      <point x="1023" y="937" type="line"/>
       <point x="1120" y="937" type="line"/>
       <point x="1120" y="753"/>
       <point x="946" y="464"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND100.ufo/glyphs/o.glif
@@ -1,44 +1,48 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="o" format="2">
-  <advance width="1354"/>
+  <advance width="1356"/>
   <unicode hex="006F"/>
-  <anchor x="674" y="0" name="bottom"/>
-  <anchor x="677" y="541" name="center"/>
-  <anchor x="895" y="0" name="ogonek"/>
-  <anchor x="676" y="1086" name="top"/>
-  <anchor x="900" y="1084" name="topright"/>
+  <guideline x="1357" y="1062" angle="80" identifier="jeVJCmkYtC"/>
+  <guideline x="1177" y="1127" angle="80" identifier="4qJcJKaSQQ"/>
+  <guideline x="191" y="1134" angle="80" identifier="LuMfENZh2Q"/>
+  <guideline x="380" y="1135" angle="80" identifier="gYxo4LJmMe"/>
+  <anchor x="675.4070080863" y="0" name="bottom"/>
+  <anchor x="678.4070080863" y="541" name="center"/>
+  <anchor x="896.4070080863" y="0" name="ogonek"/>
+  <anchor x="677.4070080863" y="1086" name="top"/>
+  <anchor x="901.4070080863" y="1084" name="topright"/>
   <outline>
     <contour>
-      <point x="676" y="-36" type="qcurve" smooth="yes"/>
-      <point x="422" y="-36"/>
-      <point x="88" y="296"/>
-      <point x="88" y="546" type="qcurve"/>
-      <point x="88" y="546" type="line"/>
-      <point x="88" y="796"/>
-      <point x="422" y="1126"/>
-      <point x="676" y="1126" type="qcurve" smooth="yes"/>
-      <point x="930" y="1126"/>
-      <point x="1266" y="794"/>
-      <point x="1266" y="546" type="qcurve"/>
-      <point x="1266" y="546" type="line"/>
-      <point x="1266" y="296"/>
-      <point x="932" y="-36"/>
+      <point x="586.4070080863" y="-36" type="qcurve" smooth="yes"/>
+      <point x="324.4070080863" y="-36"/>
+      <point x="45.4070080863" y="293"/>
+      <point x="91.4070080863" y="564" type="qcurve"/>
+      <point x="91.4070080863" y="564" type="line"/>
+      <point x="135.4070080863" y="813"/>
+      <point x="503.4070080863" y="1126"/>
+      <point x="770.4070080863" y="1126" type="qcurve" smooth="yes"/>
+      <point x="1024.4070080863" y="1126"/>
+      <point x="1308.4070080863" y="788"/>
+      <point x="1264.4070080863" y="526" type="qcurve"/>
+      <point x="1264.4070080863" y="526" type="line"/>
+      <point x="1220.4070080863" y="276"/>
+      <point x="842.4070080863" y="-36"/>
     </contour>
     <contour>
-      <point x="676" y="130" type="qcurve" smooth="yes"/>
-      <point x="846" y="130"/>
-      <point x="1074" y="362"/>
-      <point x="1074" y="546" type="qcurve"/>
-      <point x="1074" y="546" type="line"/>
-      <point x="1074" y="730"/>
-      <point x="846" y="962"/>
-      <point x="676" y="962" type="qcurve" smooth="yes"/>
-      <point x="506" y="962"/>
-      <point x="276" y="728"/>
-      <point x="276" y="546" type="qcurve"/>
-      <point x="276" y="546" type="line"/>
-      <point x="276" y="364"/>
-      <point x="506" y="130"/>
+      <point x="604.4070080863" y="130" type="qcurve" smooth="yes"/>
+      <point x="774.4070080863" y="130"/>
+      <point x="1042.4070080863" y="355"/>
+      <point x="1074.4070080863" y="539" type="qcurve"/>
+      <point x="1074.4070080863" y="539" type="line"/>
+      <point x="1107.4070080863" y="723"/>
+      <point x="921.4070080863" y="962"/>
+      <point x="751.4070080863" y="962" type="qcurve" smooth="yes"/>
+      <point x="581.4070080863" y="962"/>
+      <point x="309.4070080863" y="728"/>
+      <point x="277.4070080863" y="546" type="qcurve"/>
+      <point x="277.4070080863" y="546" type="line"/>
+      <point x="245.4070080863" y="364"/>
+      <point x="434.4070080863" y="130"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND100.ufo/glyphs/six.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND100.ufo/glyphs/six.glif
@@ -22,7 +22,7 @@
       <point x="615" y="-32" type="qcurve"/>
     </contour>
     <contour>
-      <point x="172" y="493" type="line"/>
+      <point x="169" y="493" type="line"/>
       <point x="80" y="493" type="line"/>
       <point x="77" y="667"/>
       <point x="285" y="1002"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND100.ufo/fontinfo.plist
@@ -114,7 +114,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -122,7 +122,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND100.ufo/glyphs/O_.glif
@@ -2,44 +2,45 @@
 <glyph name="O" format="2">
   <advance width="2108"/>
   <unicode hex="004F"/>
-  <guideline x="799" y="918" angle="90" identifier="vAQBnndVqv"/>
-  <anchor x="1057" y="0" name="bottom"/>
-  <anchor x="1055" y="716" name="center"/>
-  <anchor x="1390" y="0" name="ogonek"/>
-  <anchor x="1057" y="1432" name="top"/>
-  <anchor x="1277" y="1432" name="topright"/>
+  <guideline x="2052" y="1256" angle="80" identifier="vAQBnndVqv"/>
+  <guideline x="400" y="1261" angle="80" identifier="6bc2u6FqfV"/>
+  <anchor x="961" y="0" name="bottom"/>
+  <anchor x="1086" y="716" name="center"/>
+  <anchor x="1294" y="0" name="ogonek"/>
+  <anchor x="1214" y="1432" name="top"/>
+  <anchor x="1434" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1054" y="-50" type="qcurve" smooth="yes"/>
-      <point x="672" y="-50"/>
-      <point x="179" y="383"/>
-      <point x="180" y="718" type="qcurve"/>
-      <point x="180" y="718" type="line"/>
-      <point x="179" y="1053"/>
-      <point x="672" y="1486"/>
-      <point x="1054" y="1486" type="qcurve" smooth="yes"/>
-      <point x="1436" y="1486"/>
-      <point x="1929" y="1053"/>
-      <point x="1928" y="718" type="qcurve"/>
-      <point x="1928" y="718" type="line"/>
-      <point x="1929" y="383"/>
-      <point x="1437" y="-50"/>
+      <point x="949" y="-50" type="qcurve"/>
+      <point x="579" y="-50"/>
+      <point x="152" y="395"/>
+      <point x="210" y="718" type="qcurve"/>
+      <point x="210" y="718" type="line"/>
+      <point x="269" y="1053"/>
+      <point x="837" y="1486"/>
+      <point x="1218" y="1486" type="qcurve"/>
+      <point x="1596" y="1486"/>
+      <point x="2015" y="1048"/>
+      <point x="1957" y="718" type="qcurve"/>
+      <point x="1958" y="718" type="line"/>
+      <point x="1901" y="383"/>
+      <point x="1333" y="-50"/>
     </contour>
     <contour>
-      <point x="1054" y="34" type="qcurve" smooth="yes"/>
-      <point x="1395" y="35"/>
-      <point x="1835" y="417"/>
-      <point x="1835" y="716" type="qcurve"/>
-      <point x="1835" y="716" type="line"/>
-      <point x="1835" y="1014"/>
-      <point x="1395" y="1401"/>
-      <point x="1054" y="1402" type="qcurve" smooth="yes"/>
-      <point x="713" y="1401"/>
-      <point x="273" y="1015"/>
-      <point x="273" y="718" type="qcurve"/>
-      <point x="273" y="718" type="line"/>
-      <point x="273" y="418"/>
-      <point x="713" y="35"/>
+      <point x="963" y="34" type="qcurve"/>
+      <point x="1306" y="35"/>
+      <point x="1813" y="417"/>
+      <point x="1865" y="716" type="qcurve"/>
+      <point x="1865" y="716" type="line"/>
+      <point x="1923" y="1015"/>
+      <point x="1563" y="1402"/>
+      <point x="1205" y="1402" type="qcurve"/>
+      <point x="864" y="1401"/>
+      <point x="360" y="1032"/>
+      <point x="303" y="718" type="qcurve"/>
+      <point x="303" y="718" type="line"/>
+      <point x="249" y="415"/>
+      <point x="614" y="34"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND100.ufo/glyphs/nine.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND100.ufo/glyphs/nine.glif
@@ -22,7 +22,7 @@
       <point x="827" y="1486" type="qcurve"/>
     </contour>
     <contour>
-      <point x="1472" y="929" type="line"/>
+      <point x="1476" y="929" type="line"/>
       <point x="1520" y="929" type="line"/>
       <point x="1520" y="749"/>
       <point x="1339" y="490"/>
@@ -37,8 +37,8 @@
       <point x="565" y="30" type="qcurve"/>
       <point x="1014" y="351" type="line" smooth="yes"/>
       <point x="1093" y="407"/>
-      <point x="1263" y="528"/>
-      <point x="1352" y="609" type="qcurve"/>
+      <point x="1238" y="507"/>
+      <point x="1372" y="624" type="qcurve"/>
     </contour>
     <contour>
       <point x="829" y="1410" type="qcurve"/>
@@ -48,8 +48,8 @@
       <point x="234" y="939" type="qcurve"/>
       <point x="234" y="939" type="line"/>
       <point x="234" y="738"/>
-      <point x="567" y="476"/>
-      <point x="830" y="476" type="qcurve"/>
+      <point x="568" y="475"/>
+      <point x="831" y="475" type="qcurve"/>
       <point x="830" y="476" type="line"/>
       <point x="1096" y="476"/>
       <point x="1427" y="721"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND100.ufo/glyphs/o.glif
@@ -2,44 +2,47 @@
 <glyph name="o" format="2">
   <advance width="1748"/>
   <unicode hex="006F"/>
-  <guideline x="769" y="620" angle="90" identifier="4jR7yfcmiK"/>
-  <anchor x="877" y="0" name="bottom"/>
-  <anchor x="871" y="534" name="center"/>
-  <anchor x="1189" y="0" name="ogonek"/>
-  <anchor x="874" y="1086" name="top"/>
-  <anchor x="1174" y="1086" name="topright"/>
+  <guideline x="1483" y="-45" angle="80" identifier="4jR7yfcmiK"/>
+  <guideline x="1405" y="30" angle="80" identifier="S1PPhALBtK"/>
+  <guideline x="90" y="143" angle="80" identifier="jwwoQ9YMZV"/>
+  <guideline x="170" y="76" angle="80" identifier="g6CFW4giXf"/>
+  <anchor x="781" y="0" name="bottom"/>
+  <anchor x="869" y="534" name="center"/>
+  <anchor x="1093" y="0" name="ogonek"/>
+  <anchor x="969" y="1086" name="top"/>
+  <anchor x="1269" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="874" y="-52" type="qcurve" smooth="yes"/>
-      <point x="562" y="-52"/>
-      <point x="160" y="279"/>
-      <point x="160" y="535" type="qcurve"/>
-      <point x="160" y="535" type="line"/>
-      <point x="160" y="791"/>
-      <point x="562" y="1122"/>
-      <point x="874" y="1122" type="qcurve" smooth="yes"/>
-      <point x="1186" y="1122"/>
-      <point x="1588" y="791"/>
-      <point x="1588" y="535" type="qcurve"/>
-      <point x="1588" y="535" type="line"/>
-      <point x="1588" y="279"/>
-      <point x="1187" y="-52"/>
+      <point x="784" y="-52" type="qcurve" smooth="yes"/>
+      <point x="472" y="-52"/>
+      <point x="114" y="281"/>
+      <point x="160" y="548" type="qcurve"/>
+      <point x="160" y="548" type="line"/>
+      <point x="205" y="804"/>
+      <point x="646" y="1122"/>
+      <point x="970" y="1122" type="qcurve" smooth="yes"/>
+      <point x="1305" y="1122"/>
+      <point x="1628" y="781"/>
+      <point x="1584" y="528" type="qcurve"/>
+      <point x="1584" y="528" type="line"/>
+      <point x="1539" y="272"/>
+      <point x="1105" y="-52"/>
     </contour>
     <contour>
-      <point x="874" y="24" type="qcurve" smooth="yes"/>
-      <point x="1145" y="24"/>
-      <point x="1495" y="312"/>
-      <point x="1495" y="535" type="qcurve"/>
-      <point x="1495" y="535" type="line"/>
-      <point x="1495" y="758"/>
-      <point x="1145" y="1046"/>
-      <point x="874" y="1046" type="qcurve" smooth="yes"/>
-      <point x="602" y="1046"/>
-      <point x="252" y="758"/>
-      <point x="253" y="535" type="qcurve"/>
-      <point x="253" y="535" type="line"/>
-      <point x="252" y="312"/>
-      <point x="602" y="24"/>
+      <point x="790" y="24" type="qcurve" smooth="yes"/>
+      <point x="1077" y="24"/>
+      <point x="1452" y="292"/>
+      <point x="1493" y="532" type="qcurve"/>
+      <point x="1493" y="532" type="line"/>
+      <point x="1536" y="767"/>
+      <point x="1248" y="1046"/>
+      <point x="962" y="1046" type="qcurve" smooth="yes"/>
+      <point x="690" y="1046"/>
+      <point x="294" y="779"/>
+      <point x="251" y="535" type="qcurve"/>
+      <point x="251" y="535" type="line"/>
+      <point x="209" y="300"/>
+      <point x="518" y="24"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND100.ufo/glyphs/six.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND100.ufo/glyphs/six.glif
@@ -38,7 +38,7 @@
       <point x="671" y="1083" type="line" smooth="yes"/>
       <point x="593" y="1027"/>
       <point x="446" y="932"/>
-      <point x="369" y="865" type="qcurve"/>
+      <point x="346" y="841" type="qcurve"/>
     </contour>
     <contour>
       <point x="856" y="22" type="qcurve"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/fontinfo.plist
@@ -114,7 +114,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -122,7 +122,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,47 @@
 <glyph name="O" format="2">
   <advance width="2084"/>
   <unicode hex="004F"/>
-  <anchor x="1041" y="0" name="bottom"/>
-  <anchor x="1041" y="709" name="center"/>
-  <anchor x="1434" y="0" name="ogonek"/>
-  <anchor x="1041" y="1432" name="top"/>
-  <anchor x="1276" y="1432" name="topright"/>
+  <guideline x="1467" y="307" angle="80" identifier="HEQt3zMECI"/>
+  <guideline x="44" y="0" angle="80" identifier="ehzHj5yHAt"/>
+  <guideline x="530" y="282" angle="80" identifier="1a2gOQsyBq"/>
+  <guideline x="1849" y="0" angle="80" identifier="h2jOsBBf1h"/>
+  <anchor x="945" y="0" name="bottom"/>
+  <anchor x="1070" y="709" name="center"/>
+  <anchor x="1338" y="0" name="ogonek"/>
+  <anchor x="1198" y="1432" name="top"/>
+  <anchor x="1433" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1042" y="-67" type="qcurve" smooth="yes"/>
-      <point x="647" y="-67"/>
-      <point x="139" y="370"/>
-      <point x="140" y="708" type="qcurve"/>
-      <point x="140" y="708" type="line"/>
-      <point x="139" y="1049"/>
-      <point x="647" y="1489"/>
-      <point x="1042" y="1489" type="qcurve" smooth="yes"/>
-      <point x="1435" y="1489"/>
-      <point x="1944" y="1049"/>
-      <point x="1944" y="708" type="qcurve"/>
-      <point x="1944" y="708" type="line"/>
-      <point x="1944" y="370"/>
-      <point x="1435" y="-67"/>
+      <point x="975" y="-67" type="qcurve" smooth="yes"/>
+      <point x="545" y="-67"/>
+      <point x="114" y="396"/>
+      <point x="174" y="734" type="qcurve"/>
+      <point x="174" y="734" type="line"/>
+      <point x="233" y="1075"/>
+      <point x="803" y="1489"/>
+      <point x="1176" y="1489" type="qcurve" smooth="yes"/>
+      <point x="1591" y="1489"/>
+      <point x="2033" y="1046"/>
+      <point x="1969" y="682" type="qcurve"/>
+      <point x="1969" y="682" type="line"/>
+      <point x="1912" y="356"/>
+      <point x="1368" y="-67"/>
     </contour>
     <contour>
-      <point x="1040" y="346" type="qcurve" smooth="yes"/>
-      <point x="1244" y="346"/>
-      <point x="1507" y="549"/>
-      <point x="1508" y="706" type="qcurve"/>
-      <point x="1508" y="706" type="line"/>
-      <point x="1507" y="864"/>
-      <point x="1244" y="1070"/>
-      <point x="1040" y="1071" type="qcurve" smooth="yes"/>
-      <point x="837" y="1070"/>
-      <point x="575" y="864"/>
-      <point x="575" y="706" type="qcurve"/>
-      <point x="575" y="706" type="line"/>
-      <point x="575" y="549"/>
-      <point x="837" y="346"/>
+      <point x="1016" y="346" type="qcurve" smooth="yes"/>
+      <point x="1225" y="346"/>
+      <point x="1508" y="540"/>
+      <point x="1537" y="697" type="qcurve"/>
+      <point x="1537" y="697" type="line"/>
+      <point x="1564" y="855"/>
+      <point x="1332" y="1070"/>
+      <point x="1128" y="1071" type="qcurve" smooth="yes"/>
+      <point x="913" y="1072"/>
+      <point x="635" y="873"/>
+      <point x="607" y="715" type="qcurve"/>
+      <point x="607" y="715" type="line"/>
+      <point x="579" y="558"/>
+      <point x="813" y="346"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/O_slash.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="2084"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="287" yOffset="-42"/>
+    <component base="O" identifier="CDF0B5BE"/>
+    <component base="Oslash-bar" xOffset="287" yOffset="-42" identifier="94D58BC4"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>94D58BC4</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>CDF0B5BE</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/nine.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/nine.glif
@@ -22,9 +22,9 @@
       <point x="892" y="1485" type="qcurve"/>
     </contour>
     <contour>
-      <point x="1454" y="897" type="line"/>
-      <point x="1664" y="897" type="line"/>
-      <point x="1664" y="704"/>
+      <point x="1435" y="896" type="line"/>
+      <point x="1665" y="896" type="line"/>
+      <point x="1665" y="703"/>
       <point x="1460" y="379"/>
       <point x="1222" y="215" type="qcurve" smooth="yes"/>
       <point x="998" y="60" type="line" smooth="yes"/>
@@ -36,9 +36,9 @@
       <point x="549" y="256"/>
       <point x="705" y="349" type="qcurve"/>
       <point x="767" y="382" type="line" smooth="yes"/>
-      <point x="859" y="431"/>
-      <point x="1055" y="515"/>
-      <point x="1169" y="561" type="qcurve"/>
+      <point x="796" y="397"/>
+      <point x="950" y="479"/>
+      <point x="985" y="488" type="qcurve"/>
     </contour>
     <contour>
       <point x="910" y="1108" type="qcurve"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1760"/>
   <outline>
-    <component base="nine" xOffset="-30"/>
+    <component base="nine" xOffset="-30" identifier="BC32B806"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>BC32B806</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,47 @@
 <glyph name="o" format="2">
   <advance width="1760"/>
   <unicode hex="006F"/>
-  <anchor x="881" y="0" name="bottom"/>
+  <guideline x="1534" y="0" angle="79.9765" identifier="1SjVzdANgF"/>
+  <guideline x="34" y="0" angle="79.9765" identifier="67nxylOcaC"/>
+  <guideline x="1162" y="122" angle="79.9765" identifier="kdH6L98d2c"/>
+  <guideline x="454" y="144" angle="79.9765" identifier="Sn0XzYeAnu"/>
+  <anchor x="785" y="0" name="bottom"/>
   <anchor x="880" y="548" name="center"/>
-  <anchor x="1241" y="0" name="ogonek"/>
-  <anchor x="880" y="1086" name="top"/>
-  <anchor x="1159" y="1086" name="topright"/>
+  <anchor x="1145" y="0" name="ogonek"/>
+  <anchor x="975" y="1086" name="top"/>
+  <anchor x="1254" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="880" y="-67" type="qcurve" smooth="yes"/>
-      <point x="553" y="-67"/>
-      <point x="130" y="281"/>
-      <point x="130" y="550" type="qcurve"/>
-      <point x="130" y="550" type="line"/>
-      <point x="130" y="814"/>
-      <point x="553" y="1154"/>
-      <point x="880" y="1154" type="qcurve" smooth="yes"/>
-      <point x="1207" y="1154"/>
-      <point x="1630" y="814"/>
-      <point x="1630" y="550" type="qcurve"/>
-      <point x="1630" y="550" type="line"/>
-      <point x="1630" y="281"/>
-      <point x="1207" y="-67"/>
+      <point x="801" y="-67" type="qcurve" smooth="yes"/>
+      <point x="472" y="-67"/>
+      <point x="86" y="299"/>
+      <point x="134" y="568" type="qcurve"/>
+      <point x="134" y="568" type="line"/>
+      <point x="180" y="832"/>
+      <point x="618" y="1154"/>
+      <point x="965" y="1154" type="qcurve" smooth="yes"/>
+      <point x="1303" y="1154"/>
+      <point x="1672" y="786"/>
+      <point x="1626" y="522" type="qcurve"/>
+      <point x="1626" y="522" type="line"/>
+      <point x="1578" y="253"/>
+      <point x="1146" y="-67"/>
     </contour>
     <contour>
-      <point x="880" y="273" type="qcurve" smooth="yes"/>
-      <point x="1035" y="273"/>
-      <point x="1236" y="431"/>
-      <point x="1236" y="552" type="qcurve"/>
-      <point x="1236" y="552" type="line"/>
-      <point x="1236" y="666"/>
-      <point x="1035" y="814"/>
-      <point x="880" y="814" type="qcurve" smooth="yes"/>
-      <point x="725" y="814"/>
-      <point x="524" y="666"/>
-      <point x="524" y="552" type="qcurve"/>
-      <point x="524" y="552" type="line"/>
-      <point x="524" y="431"/>
-      <point x="725" y="273"/>
+      <point x="837" y="273" type="qcurve" smooth="yes"/>
+      <point x="1000" y="273"/>
+      <point x="1213" y="421"/>
+      <point x="1234" y="542" type="qcurve"/>
+      <point x="1234" y="542" type="line"/>
+      <point x="1254" y="656"/>
+      <point x="1078" y="814"/>
+      <point x="926" y="814" type="qcurve" smooth="yes"/>
+      <point x="766" y="814"/>
+      <point x="545" y="665"/>
+      <point x="525" y="551" type="qcurve"/>
+      <point x="525" y="551" type="line"/>
+      <point x="505" y="426"/>
+      <point x="688" y="273"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/oslash.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1760"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="179" yOffset="29"/>
+    <component base="o" identifier="7BD9F402"/>
+    <component base="oslash-bar" xOffset="179" yOffset="29" identifier="74839B4D"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>74839B4D</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>7BD9F402</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/six.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/six.glif
@@ -10,7 +10,7 @@
       <point x="131" y="531" type="qcurve"/>
       <point x="131" y="531" type="line"/>
       <point x="131" y="758"/>
-      <point x="552" y="960"/>
+      <point x="441" y="919"/>
       <point x="888" y="960" type="qcurve"/>
       <point x="888" y="960" type="line"/>
       <point x="1306" y="995"/>
@@ -22,9 +22,9 @@
       <point x="903" y="-57" type="qcurve"/>
     </contour>
     <contour>
-      <point x="362" y="531" type="line"/>
-      <point x="131" y="531" type="line"/>
-      <point x="131" y="724"/>
+      <point x="355" y="532" type="line"/>
+      <point x="130" y="532" type="line"/>
+      <point x="130" y="725"/>
       <point x="334" y="1051"/>
       <point x="573" y="1213" type="qcurve" smooth="yes"/>
       <point x="898" y="1433" type="line" smooth="yes"/>
@@ -36,9 +36,9 @@
       <point x="1347" y="1237"/>
       <point x="1191" y="1144" type="qcurve"/>
       <point x="1028" y="1046" type="line" smooth="yes"/>
-      <point x="960" y="1005"/>
-      <point x="783" y="913"/>
-      <point x="677" y="880" type="qcurve"/>
+      <point x="999" y="1029"/>
+      <point x="845" y="949"/>
+      <point x="810" y="940" type="qcurve"/>
     </contour>
     <contour>
       <point x="885" y="320" type="qcurve"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/six.tf.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1760"/>
   <outline>
-    <component base="six" xOffset="-10"/>
+    <component base="six" xOffset="-10" identifier="38F99D4E"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>38F99D4E</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/fontinfo.plist
@@ -108,7 +108,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -116,7 +116,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/O_.glif
@@ -2,43 +2,45 @@
 <glyph name="O" format="2">
   <advance width="2072"/>
   <unicode hex="004F"/>
-  <anchor x="1036" y="0" name="bottom"/>
-  <anchor x="1048" y="718" name="center"/>
-  <anchor x="1371" y="0" name="ogonek"/>
-  <anchor x="1056" y="1432" name="top"/>
-  <anchor x="1266" y="1432" name="topright"/>
+  <guideline x="1862" y="377" angle="79.9661" identifier="DGu7dGYzqD"/>
+  <guideline x="123" y="215" angle="79.9661" identifier="30wxDxhCYL"/>
+  <anchor x="940" y="0" name="bottom"/>
+  <anchor x="1079" y="718" name="center"/>
+  <anchor x="1275" y="0" name="ogonek"/>
+  <anchor x="1213" y="1432" name="top"/>
+  <anchor x="1423" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="1043" y="-62" type="qcurve" smooth="yes"/>
-      <point x="667" y="-62"/>
-      <point x="181" y="377"/>
-      <point x="181" y="718" type="qcurve"/>
-      <point x="181" y="718" type="line"/>
-      <point x="181" y="1059"/>
-      <point x="667" y="1498"/>
-      <point x="1043" y="1498" type="qcurve" smooth="yes"/>
-      <point x="1413" y="1498"/>
-      <point x="1891" y="1059"/>
-      <point x="1891" y="718" type="qcurve"/>
-      <point x="1891" y="718" type="line"/>
-      <point x="1891" y="377"/>
-      <point x="1413" y="-62"/>
+      <point x="959" y="-62" type="qcurve" smooth="yes"/>
+      <point x="568" y="-62"/>
+      <point x="154" y="388"/>
+      <point x="214" y="729" type="qcurve"/>
+      <point x="214" y="729" type="line"/>
+      <point x="274" y="1070"/>
+      <point x="805" y="1498"/>
+      <point x="1193" y="1498" type="qcurve" smooth="yes"/>
+      <point x="1576" y="1498"/>
+      <point x="1981" y="1048"/>
+      <point x="1921" y="707" type="qcurve"/>
+      <point x="1921" y="707" type="line"/>
+      <point x="1861" y="366"/>
+      <point x="1330" y="-62"/>
     </contour>
     <contour>
-      <point x="1039" y="123" type="qcurve" smooth="yes"/>
-      <point x="1323" y="123"/>
-      <point x="1689" y="458"/>
-      <point x="1689" y="716" type="qcurve"/>
-      <point x="1689" y="716" type="line"/>
-      <point x="1689" y="974"/>
-      <point x="1323" y="1307"/>
-      <point x="1039" y="1307" type="qcurve" smooth="yes"/>
-      <point x="753" y="1307"/>
-      <point x="383" y="974"/>
-      <point x="383" y="716" type="qcurve"/>
-      <point x="383" y="716" type="line"/>
-      <point x="383" y="458"/>
-      <point x="753" y="123"/>
+      <point x="965" y="123" type="qcurve" smooth="yes"/>
+      <point x="1249" y="123"/>
+      <point x="1674" y="458"/>
+      <point x="1720" y="716" type="qcurve"/>
+      <point x="1720" y="716" type="line"/>
+      <point x="1765" y="974"/>
+      <point x="1473" y="1307"/>
+      <point x="1174" y="1307" type="qcurve" smooth="yes"/>
+      <point x="888" y="1307"/>
+      <point x="459" y="974"/>
+      <point x="414" y="716" type="qcurve"/>
+      <point x="414" y="716" type="line"/>
+      <point x="368" y="458"/>
+      <point x="677" y="123"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/O_slash.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="2072"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="369" yOffset="-34"/>
+    <component base="O" identifier="965481C9"/>
+    <component base="Oslash-bar" xOffset="369" yOffset="-34" identifier="23E8D30A"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>23E8D30A</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>965481C9</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/nine.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/nine.glif
@@ -22,7 +22,7 @@
       <point x="747" y="1479" type="qcurve"/>
     </contour>
     <contour>
-      <point x="1301" y="961" type="line"/>
+      <point x="1297" y="961" type="line"/>
       <point x="1405" y="961" type="line"/>
       <point x="1405" y="739"/>
       <point x="1099" y="394"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1991"/>
   <outline>
-    <component base="nine" xOffset="232"/>
+    <component base="nine" xOffset="232" identifier="F6866929"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>F6866929</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,44 @@
 <glyph name="o" format="2">
   <advance width="1681"/>
   <unicode hex="006F"/>
-  <anchor x="838" y="0" name="bottom"/>
+  <guideline x="1508" y="546" angle="79.9284" identifier="dooXMhCbFK"/>
+  <anchor x="743" y="0" name="bottom"/>
   <anchor x="838" y="538" name="center"/>
-  <anchor x="1146" y="0" name="ogonek"/>
-  <anchor x="839" y="1086" name="top"/>
-  <anchor x="1153" y="1086" name="topright"/>
+  <anchor x="1051" y="0" name="ogonek"/>
+  <anchor x="935" y="1086" name="top"/>
+  <anchor x="1249" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="835" y="-56" type="qcurve" smooth="yes"/>
-      <point x="546" y="-56"/>
-      <point x="174" y="283"/>
-      <point x="174" y="546" type="qcurve"/>
-      <point x="174" y="546" type="line"/>
-      <point x="174" y="810"/>
-      <point x="546" y="1150"/>
-      <point x="835" y="1150" type="qcurve" smooth="yes"/>
-      <point x="1128" y="1150"/>
-      <point x="1507" y="810"/>
-      <point x="1507" y="546" type="qcurve"/>
-      <point x="1507" y="546" type="line"/>
-      <point x="1507" y="283"/>
-      <point x="1128" y="-56"/>
+      <point x="750" y="-56" type="qcurve" smooth="yes"/>
+      <point x="461" y="-56"/>
+      <point x="129" y="283"/>
+      <point x="175" y="546" type="qcurve"/>
+      <point x="175" y="546" type="line"/>
+      <point x="224" y="820"/>
+      <point x="637" y="1150"/>
+      <point x="939" y="1150" type="qcurve" smooth="yes"/>
+      <point x="1228" y="1150"/>
+      <point x="1555" y="810"/>
+      <point x="1506" y="537" type="qcurve"/>
+      <point x="1506" y="537" type="line"/>
+      <point x="1460" y="274"/>
+      <point x="1045" y="-56"/>
     </contour>
     <contour>
-      <point x="835" y="118" type="qcurve" smooth="yes"/>
-      <point x="1039" y="118"/>
-      <point x="1304" y="359"/>
-      <point x="1304" y="546" type="qcurve"/>
-      <point x="1304" y="546" type="line"/>
-      <point x="1304" y="733"/>
-      <point x="1039" y="974"/>
-      <point x="835" y="974" type="qcurve" smooth="yes"/>
-      <point x="636" y="974"/>
-      <point x="376" y="733"/>
-      <point x="376" y="546" type="qcurve"/>
-      <point x="376" y="546" type="line"/>
-      <point x="376" y="359"/>
-      <point x="636" y="118"/>
+      <point x="761" y="118" type="qcurve" smooth="yes"/>
+      <point x="967" y="118"/>
+      <point x="1272" y="359"/>
+      <point x="1305" y="546" type="qcurve"/>
+      <point x="1305" y="546" type="line"/>
+      <point x="1338" y="733"/>
+      <point x="1121" y="974"/>
+      <point x="912" y="974" type="qcurve" smooth="yes"/>
+      <point x="706" y="974"/>
+      <point x="411" y="738"/>
+      <point x="377" y="546" type="qcurve"/>
+      <point x="377" y="546" type="line"/>
+      <point x="344" y="359"/>
+      <point x="559" y="118"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/oslash.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1681"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="214" yOffset="17"/>
+    <component base="o" identifier="596BEFAD"/>
+    <component base="oslash-bar" xOffset="214" yOffset="17" identifier="253C1E24"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>253C1E24</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>596BEFAD</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/six.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/six.glif
@@ -22,9 +22,9 @@
       <point x="806" y="-32" type="qcurve"/>
     </contour>
     <contour>
-      <point x="246" y="488" type="line"/>
-      <point x="149" y="486" type="line"/>
-      <point x="149" y="708"/>
+      <point x="247" y="486" type="line"/>
+      <point x="148" y="486" type="line"/>
+      <point x="148" y="708"/>
       <point x="454" y="1054"/>
       <point x="595" y="1171" type="qcurve" smooth="yes"/>
       <point x="950" y="1467" type="line" smooth="yes"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/six.tf.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1991"/>
   <outline>
-    <component base="six" xOffset="206"/>
+    <component base="six" xOffset="206" identifier="AE2178AC"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>AE2178AC</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/fontinfo.plist
@@ -106,7 +106,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -114,7 +114,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="1060"/>
   <unicode hex="004F"/>
   <guideline x="523" y="877" angle="90" identifier="hCn79dkbgY"/>
-  <anchor x="504" y="0" name="bottom"/>
-  <anchor x="523" y="727" name="center"/>
-  <anchor x="664" y="0" name="ogonek"/>
-  <anchor x="521" y="1431" name="top"/>
-  <anchor x="724" y="1432" name="topright"/>
+  <anchor x="409" y="0" name="bottom"/>
+  <anchor x="556" y="727" name="center"/>
+  <anchor x="569" y="0" name="ogonek"/>
+  <anchor x="678" y="1431" name="top"/>
+  <anchor x="881" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="530" y="-26" type="qcurve" smooth="yes"/>
-      <point x="344" y="-26"/>
-      <point x="96" y="304"/>
-      <point x="96" y="718" type="qcurve"/>
-      <point x="96" y="718" type="line"/>
-      <point x="96" y="1120"/>
-      <point x="346" y="1460"/>
-      <point x="530" y="1460" type="qcurve" smooth="yes"/>
-      <point x="714" y="1460"/>
-      <point x="964" y="1122"/>
-      <point x="964" y="718" type="qcurve"/>
-      <point x="964" y="718" type="line"/>
-      <point x="964" y="326"/>
-      <point x="716" y="-26"/>
+      <point x="444" y="-26" type="qcurve" smooth="yes"/>
+      <point x="256" y="-26"/>
+      <point x="56" y="304"/>
+      <point x="129" y="732" type="qcurve"/>
+      <point x="129" y="732" type="line"/>
+      <point x="200" y="1120"/>
+      <point x="495" y="1460"/>
+      <point x="679" y="1460" type="qcurve" smooth="yes"/>
+      <point x="870" y="1460"/>
+      <point x="1063" y="1122"/>
+      <point x="992" y="704" type="qcurve"/>
+      <point x="992" y="704" type="line"/>
+      <point x="923" y="326"/>
+      <point x="637" y="-26"/>
     </contour>
     <contour>
-      <point x="528" y="48" type="qcurve" smooth="yes"/>
-      <point x="686" y="48"/>
-      <point x="876" y="360"/>
-      <point x="876" y="716" type="qcurve"/>
-      <point x="876" y="716" type="line"/>
-      <point x="876" y="1072"/>
-      <point x="682" y="1384"/>
-      <point x="528" y="1384" type="qcurve" smooth="yes"/>
-      <point x="368" y="1384"/>
-      <point x="184" y="1084"/>
-      <point x="184" y="716" type="qcurve"/>
-      <point x="184" y="716" type="line"/>
-      <point x="184" y="358"/>
-      <point x="376" y="48"/>
+      <point x="441" y="48" type="qcurve" smooth="yes"/>
+      <point x="599" y="48"/>
+      <point x="844" y="360"/>
+      <point x="907" y="716" type="qcurve"/>
+      <point x="907" y="716" type="line"/>
+      <point x="970" y="1072"/>
+      <point x="831" y="1384"/>
+      <point x="677" y="1384" type="qcurve" smooth="yes"/>
+      <point x="517" y="1384"/>
+      <point x="280" y="1084"/>
+      <point x="215" y="716" type="qcurve"/>
+      <point x="215" y="716" type="line"/>
+      <point x="152" y="358"/>
+      <point x="289" y="48"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/O_slash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Oslash-bar" format="2">
   <advance width="1286"/>
-  <guideline x="991" y="1446" angle="336.3706222693432" identifier="s271xkKS2H"/>
+  <guideline x="991" y="1446" angle="336.3706" identifier="s271xkKS2H"/>
   <outline>
     <contour>
       <point x="628" y="756" type="line"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/O_slash.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="1060"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="-131" yOffset="7"/>
+    <component base="O" identifier="1EE53835"/>
+    <component base="Oslash-bar" xOffset="-131" yOffset="7" identifier="C7C1AD24"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>1EE53835</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>C7C1AD24</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1034"/>
   <outline>
-    <component base="nine" xOffset="89"/>
+    <component base="nine" xOffset="89" identifier="5D3ED66D"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>5D3ED66D</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/o.glif
@@ -3,43 +3,44 @@
   <advance width="948"/>
   <unicode hex="006F"/>
   <guideline x="473" y="618" angle="90" identifier="575UkyT4Po"/>
-  <anchor x="472" y="0" name="bottom"/>
+  <guideline x="874" y="552" angle="79.9617" identifier="sQiZLEnMeU"/>
+  <anchor x="376" y="0" name="bottom"/>
   <anchor x="473" y="540" name="center"/>
-  <anchor x="582" y="0" name="ogonek"/>
-  <anchor x="473" y="1086" name="top"/>
-  <anchor x="708" y="1086" name="topright"/>
+  <anchor x="486" y="0" name="ogonek"/>
+  <anchor x="569" y="1086" name="top"/>
+  <anchor x="804" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="472" y="-16" type="qcurve" smooth="yes"/>
-      <point x="296" y="-16"/>
-      <point x="76" y="284"/>
-      <point x="76" y="552" type="qcurve"/>
-      <point x="76" y="552" type="line"/>
-      <point x="76" y="822"/>
-      <point x="300" y="1112"/>
-      <point x="472" y="1112" type="qcurve" smooth="yes"/>
-      <point x="646" y="1112"/>
-      <point x="872" y="814"/>
-      <point x="872" y="552" type="qcurve"/>
-      <point x="872" y="552" type="line"/>
-      <point x="872" y="288"/>
-      <point x="654" y="-16"/>
+      <point x="388" y="-16" type="qcurve" smooth="yes"/>
+      <point x="202" y="-16"/>
+      <point x="30" y="283"/>
+      <point x="78" y="552" type="qcurve"/>
+      <point x="78" y="552" type="line"/>
+      <point x="124" y="814"/>
+      <point x="386" y="1112"/>
+      <point x="568" y="1112" type="qcurve" smooth="yes"/>
+      <point x="742" y="1112"/>
+      <point x="923" y="826"/>
+      <point x="873" y="541" type="qcurve"/>
+      <point x="873" y="541" type="line"/>
+      <point x="828" y="290"/>
+      <point x="573" y="-16"/>
     </contour>
     <contour>
-      <point x="474" y="60" type="qcurve" smooth="yes"/>
-      <point x="642" y="60"/>
-      <point x="788" y="330"/>
-      <point x="788" y="552" type="qcurve"/>
-      <point x="788" y="552" type="line"/>
-      <point x="788" y="772"/>
-      <point x="630" y="1036"/>
-      <point x="474" y="1036" type="qcurve" smooth="yes"/>
-      <point x="322" y="1036"/>
-      <point x="160" y="778"/>
-      <point x="160" y="552" type="qcurve"/>
-      <point x="160" y="552" type="line"/>
-      <point x="160" y="326"/>
-      <point x="310" y="60"/>
+      <point x="389" y="60" type="qcurve" smooth="yes"/>
+      <point x="548" y="60"/>
+      <point x="751" y="330"/>
+      <point x="790" y="552" type="qcurve"/>
+      <point x="790" y="552" type="line"/>
+      <point x="829" y="772"/>
+      <point x="724" y="1036"/>
+      <point x="561" y="1036" type="qcurve" smooth="yes"/>
+      <point x="400" y="1036"/>
+      <point x="202" y="778"/>
+      <point x="162" y="552" type="qcurve"/>
+      <point x="162" y="552" type="line"/>
+      <point x="122" y="326"/>
+      <point x="233" y="60"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/oslash.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="948"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-84" yOffset="-10"/>
+    <component base="o" identifier="A30D0D37"/>
+    <component base="oslash-bar" xOffset="-84" yOffset="-10" identifier="B07532F1"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>A30D0D37</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>B07532F1</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/six.tf.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1034"/>
   <outline>
-    <component base="six" xOffset="61"/>
+    <component base="six" xOffset="61" identifier="32126B95"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>32126B95</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/fontinfo.plist
@@ -128,7 +128,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -136,7 +136,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/O_.glif
@@ -3,43 +3,43 @@
   <advance width="1264"/>
   <unicode hex="004F"/>
   <guideline x="632" y="845" angle="90" identifier="AkOzOIbi01"/>
-  <anchor x="630" y="0" name="bottom"/>
-  <anchor x="634" y="718" name="center"/>
-  <anchor x="809" y="0" name="ogonek"/>
-  <anchor x="632" y="1432" name="top"/>
-  <anchor x="826" y="1432" name="topright"/>
+  <anchor x="535" y="0" name="bottom"/>
+  <anchor x="665" y="718" name="center"/>
+  <anchor x="714" y="0" name="ogonek"/>
+  <anchor x="789" y="1432" name="top"/>
+  <anchor x="983" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="632" y="-30" type="qcurve" smooth="yes"/>
-      <point x="406" y="-30"/>
-      <point x="66" y="294"/>
-      <point x="66" y="718" type="qcurve"/>
-      <point x="66" y="718" type="line"/>
-      <point x="66" y="1132"/>
-      <point x="412" y="1464"/>
-      <point x="632" y="1464" type="qcurve" smooth="yes"/>
-      <point x="852" y="1464"/>
-      <point x="1198" y="1126"/>
-      <point x="1198" y="718" type="qcurve"/>
-      <point x="1198" y="718" type="line"/>
-      <point x="1198" y="322"/>
-      <point x="858" y="-30"/>
+      <point x="552" y="-30" type="qcurve" smooth="yes"/>
+      <point x="308" y="-30"/>
+      <point x="32" y="326"/>
+      <point x="101" y="751" type="qcurve"/>
+      <point x="101" y="751" type="line"/>
+      <point x="174" y="1130"/>
+      <point x="530" y="1464"/>
+      <point x="776" y="1464" type="qcurve" smooth="yes"/>
+      <point x="1006" y="1464"/>
+      <point x="1298" y="1126"/>
+      <point x="1226" y="692" type="qcurve"/>
+      <point x="1226" y="692" type="line"/>
+      <point x="1156" y="322"/>
+      <point x="816" y="-30"/>
     </contour>
     <contour>
-      <point x="632" y="368" type="qcurve" smooth="yes"/>
-      <point x="702" y="368"/>
-      <point x="774" y="508"/>
-      <point x="774" y="716" type="qcurve"/>
-      <point x="774" y="716" type="line"/>
-      <point x="774" y="924"/>
-      <point x="698" y="1062"/>
-      <point x="632" y="1062" type="qcurve" smooth="yes"/>
-      <point x="560" y="1062"/>
-      <point x="490" y="936"/>
-      <point x="490" y="716" type="qcurve"/>
-      <point x="490" y="716" type="line"/>
-      <point x="490" y="508"/>
-      <point x="566" y="368"/>
+      <point x="609" y="368" type="qcurve" smooth="yes"/>
+      <point x="679" y="368"/>
+      <point x="768" y="508"/>
+      <point x="805" y="716" type="qcurve"/>
+      <point x="805" y="716" type="line"/>
+      <point x="841" y="924"/>
+      <point x="787" y="1062"/>
+      <point x="717" y="1062" type="qcurve" smooth="yes"/>
+      <point x="644" y="1062"/>
+      <point x="560" y="936"/>
+      <point x="521" y="716" type="qcurve"/>
+      <point x="521" y="716" type="line"/>
+      <point x="484" y="508"/>
+      <point x="538" y="368"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/O_slash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Oslash-bar" format="2">
   <advance width="1492"/>
-  <guideline x="1230" y="1488" angle="336.8857920166732" identifier="507i0lbHVs"/>
+  <guideline x="1230" y="1488" angle="336.8858" identifier="507i0lbHVs"/>
   <outline>
     <contour>
       <point x="587" y="801" type="line"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/O_slash.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="1264"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="-60" yOffset="-39"/>
+    <component base="O" identifier="94556DD7"/>
+    <component base="Oslash-bar" xOffset="-60" yOffset="-39" identifier="D4AF1006"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>94556DD7</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>D4AF1006</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/nine.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/nine.glif
@@ -22,7 +22,7 @@
       <point x="512" y="1455" type="qcurve"/>
     </contour>
     <contour>
-      <point x="793" y="927" type="line"/>
+      <point x="802" y="927" type="line"/>
       <point x="992" y="927" type="line"/>
       <point x="992" y="765"/>
       <point x="901" y="481"/>
@@ -37,8 +37,8 @@
       <point x="297" y="301" type="qcurve"/>
       <point x="414" y="433" type="line" smooth="yes"/>
       <point x="439" y="462"/>
-      <point x="514" y="513"/>
-      <point x="546" y="533" type="qcurve"/>
+      <point x="512" y="519"/>
+      <point x="558" y="552" type="qcurve"/>
     </contour>
     <contour>
       <point x="514" y="1117" type="qcurve"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/nine.tf.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="1168"/>
   <outline>
-    <component base="nine" xOffset="60"/>
+    <component base="nine" xOffset="60" identifier="1D8A9FD8"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>1D8A9FD8</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/o.glif
@@ -3,43 +3,43 @@
   <advance width="1184"/>
   <unicode hex="006F"/>
   <guideline x="591" y="641" angle="90" identifier="zm9FAH9zGL"/>
-  <anchor x="592" y="0" name="bottom"/>
-  <anchor x="591" y="552" name="center"/>
-  <anchor x="801" y="0" name="ogonek"/>
-  <anchor x="592" y="1086" name="top"/>
-  <anchor x="872" y="1086" name="topright"/>
+  <anchor x="497" y="0" name="bottom"/>
+  <anchor x="593" y="552" name="center"/>
+  <anchor x="706" y="0" name="ogonek"/>
+  <anchor x="688" y="1086" name="top"/>
+  <anchor x="968" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="592" y="-36" type="qcurve" smooth="yes"/>
-      <point x="348" y="-36"/>
-      <point x="66" y="280"/>
-      <point x="66" y="553" type="qcurve"/>
-      <point x="66" y="553" type="line"/>
-      <point x="66" y="826"/>
-      <point x="356" y="1138"/>
-      <point x="592" y="1138" type="qcurve" smooth="yes"/>
-      <point x="830" y="1138"/>
-      <point x="1118" y="818"/>
-      <point x="1118" y="553" type="qcurve"/>
-      <point x="1118" y="553" type="line"/>
-      <point x="1118" y="286"/>
-      <point x="838" y="-36"/>
+      <point x="502" y="-36" type="qcurve" smooth="yes"/>
+      <point x="270" y="-36"/>
+      <point x="20" y="280"/>
+      <point x="68" y="553" type="qcurve"/>
+      <point x="68" y="553" type="line"/>
+      <point x="118" y="837"/>
+      <point x="418" y="1138"/>
+      <point x="689" y="1138" type="qcurve" smooth="yes"/>
+      <point x="921" y="1138"/>
+      <point x="1168" y="826"/>
+      <point x="1120" y="553" type="qcurve"/>
+      <point x="1120" y="553" type="line"/>
+      <point x="1072" y="282"/>
+      <point x="778" y="-36"/>
     </contour>
     <contour>
-      <point x="593" y="295" type="qcurve" smooth="yes"/>
-      <point x="678" y="296"/>
-      <point x="724" y="430"/>
-      <point x="725" y="550" type="qcurve"/>
-      <point x="725" y="550" type="line"/>
-      <point x="724" y="672"/>
-      <point x="672" y="800"/>
-      <point x="593" y="800" type="qcurve" smooth="yes"/>
-      <point x="516" y="800"/>
-      <point x="460" y="672"/>
-      <point x="460" y="550" type="qcurve"/>
-      <point x="460" y="550" type="line"/>
-      <point x="460" y="430"/>
-      <point x="508" y="296"/>
+      <point x="550" y="295" type="qcurve" smooth="yes"/>
+      <point x="627" y="296"/>
+      <point x="701" y="411"/>
+      <point x="727" y="550" type="qcurve"/>
+      <point x="727" y="550" type="line"/>
+      <point x="747" y="672"/>
+      <point x="712" y="800"/>
+      <point x="639" y="800" type="qcurve" smooth="yes"/>
+      <point x="562" y="800"/>
+      <point x="486" y="689"/>
+      <point x="462" y="550" type="qcurve"/>
+      <point x="462" y="550" type="line"/>
+      <point x="440" y="430"/>
+      <point x="465" y="294"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/oslash-bar.glif
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="1307"/>
-  <guideline x="504" y="-275" angle="336.3706222693432" identifier="ZjiBHta0Qs"/>
+  <guideline x="504" y="-275" angle="336.3706" identifier="ZjiBHta0Qs"/>
   <guideline x="727" y="130" angle="0" identifier="cKpo9yq9g0"/>
-  <guideline x="553" y="-17" angle="337.4329909221254" identifier="UKzm8VEeQM"/>
+  <guideline x="553" y="-17" angle="337.433" identifier="UKzm8VEeQM"/>
   <outline>
     <contour>
       <point x="543" y="575" type="line"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/oslash.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1184"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-39" yOffset="10"/>
+    <component base="o" identifier="FC4B13B7"/>
+    <component base="oslash-bar" xOffset="-39" yOffset="10" identifier="0DE6E2FA"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>0DE6E2FA</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>FC4B13B7</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/six.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/six.glif
@@ -22,7 +22,7 @@
       <point x="520" y="-30" type="qcurve"/>
     </contour>
     <contour>
-      <point x="224" y="498" type="line"/>
+      <point x="236" y="498" type="line"/>
       <point x="40" y="498" type="line"/>
       <point x="40" y="660"/>
       <point x="131" y="944"/>
@@ -37,8 +37,8 @@
       <point x="735" y="1124" type="qcurve"/>
       <point x="618" y="992" type="line" smooth="yes"/>
       <point x="593" y="963"/>
-      <point x="518" y="912"/>
-      <point x="486" y="892" type="qcurve"/>
+      <point x="521" y="909"/>
+      <point x="479" y="882" type="qcurve"/>
     </contour>
     <contour>
       <point x="518" y="308" type="qcurve"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/six.tf.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="1168"/>
   <outline>
-    <component base="six" xOffset="75"/>
+    <component base="six" xOffset="75" identifier="38B71929"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>38B71929</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/fontinfo.plist
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/fontinfo.plist
@@ -60,7 +60,7 @@
     <key>openTypeOS2StrikeoutSize</key>
     <integer>168</integer>
     <key>openTypeOS2SubscriptXOffset</key>
-    <integer>-26</integer>
+    <integer>0</integer>
     <key>openTypeOS2SubscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SubscriptYOffset</key>
@@ -68,7 +68,7 @@
     <key>openTypeOS2SubscriptYSize</key>
     <integer>1200</integer>
     <key>openTypeOS2SuperscriptXOffset</key>
-    <integer>124</integer>
+    <integer>0</integer>
     <key>openTypeOS2SuperscriptXSize</key>
     <integer>1300</integer>
     <key>openTypeOS2SuperscriptYOffset</key>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/glyphs/O_.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/glyphs/O_.glif
@@ -3,43 +3,47 @@
   <advance width="1070"/>
   <unicode hex="004F"/>
   <guideline x="535" y="1047" angle="90" identifier="tLfkLAtCfI"/>
-  <anchor x="512" y="0" name="bottom"/>
-  <anchor x="534" y="707" name="center"/>
-  <anchor x="681" y="0" name="ogonek"/>
-  <anchor x="536" y="1432" name="top"/>
-  <anchor x="732" y="1432" name="topright"/>
+  <guideline x="1076" y="1229" angle="80" identifier="nzUH3hO6JK"/>
+  <guideline x="885" y="1245" angle="80" identifier="GjPGo5tBJj"/>
+  <guideline x="181" y="1270" angle="80" identifier="b2LPYr4uif"/>
+  <guideline x="368" y="1229" angle="80" identifier="PonpmlqOWY"/>
+  <anchor x="416.9383561644" y="0" name="bottom"/>
+  <anchor x="562.9383561644" y="707" name="center"/>
+  <anchor x="585.9383561644" y="0" name="ogonek"/>
+  <anchor x="692.9383561644" y="1432" name="top"/>
+  <anchor x="888.9383561644" y="1432" name="topright"/>
   <outline>
     <contour>
-      <point x="536" y="-26" type="qcurve" smooth="yes"/>
-      <point x="312" y="-26"/>
-      <point x="84" y="348"/>
-      <point x="84" y="718" type="qcurve"/>
-      <point x="84" y="718" type="line"/>
-      <point x="84" y="1084"/>
-      <point x="315" y="1460"/>
-      <point x="536" y="1460" type="qcurve" smooth="yes"/>
-      <point x="757" y="1460"/>
-      <point x="986" y="1085"/>
-      <point x="986" y="718" type="qcurve"/>
-      <point x="986" y="718" type="line"/>
-      <point x="986" y="358"/>
-      <point x="751" y="-26"/>
+      <point x="449.9383561644" y="-26" type="qcurve" smooth="yes"/>
+      <point x="214.9383561644" y="-26"/>
+      <point x="52.9383561644" y="368"/>
+      <point x="117.9383561644" y="738" type="qcurve"/>
+      <point x="117.9383561644" y="738" type="line"/>
+      <point x="182.9383561644" y="1104"/>
+      <point x="465.9383561644" y="1460"/>
+      <point x="690.9383561644" y="1460" type="qcurve" smooth="yes"/>
+      <point x="911.9383561644" y="1460"/>
+      <point x="1078.9383561644" y="1079"/>
+      <point x="1012.9383561644" y="703" type="qcurve"/>
+      <point x="1012.9383561644" y="703" type="line"/>
+      <point x="950.9383561644" y="337"/>
+      <point x="682.9383561644" y="-26"/>
     </contour>
     <contour>
-      <point x="534" y="142" type="qcurve" smooth="yes"/>
-      <point x="668" y="142"/>
-      <point x="792" y="421"/>
-      <point x="792" y="716" type="qcurve"/>
-      <point x="792" y="716" type="line"/>
-      <point x="792" y="1007"/>
-      <point x="667" y="1286"/>
-      <point x="534" y="1286" type="qcurve" smooth="yes"/>
-      <point x="404" y="1286"/>
-      <point x="278" y="1013"/>
-      <point x="278" y="716" type="qcurve"/>
-      <point x="278" y="716" type="line"/>
-      <point x="278" y="425"/>
-      <point x="403" y="142"/>
+      <point x="463.9383561644" y="142" type="qcurve" smooth="yes"/>
+      <point x="597.9383561644" y="142"/>
+      <point x="769.9383561644" y="417"/>
+      <point x="824.9383561644" y="723" type="qcurve"/>
+      <point x="824.9383561644" y="723" type="line"/>
+      <point x="875.9383561644" y="1014"/>
+      <point x="797.9383561644" y="1286"/>
+      <point x="664.9383561644" y="1286" type="qcurve" smooth="yes"/>
+      <point x="528.9383561644" y="1286"/>
+      <point x="358.9383561644" y="1013"/>
+      <point x="306.9383561644" y="716" type="qcurve"/>
+      <point x="306.9383561644" y="716" type="line"/>
+      <point x="255.9383561644" y="425"/>
+      <point x="332.9383561644" y="142"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/glyphs/O_slash-bar.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/glyphs/O_slash-bar.glif
@@ -19,7 +19,7 @@
       <point x="322" y="44" type="qcurve"/>
       <point x="628" y="773" type="line"/>
       <point x="752" y="720" type="line"/>
-      <point x="447" y="-5" type="line"/>
+      <point x="447" y="-5" type="line" smooth="yes"/>
       <point x="426" y="-56"/>
       <point x="426" y="-56"/>
       <point x="363" y="-29" type="qcurve"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/glyphs/nine.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/glyphs/nine.glif
@@ -37,8 +37,8 @@
       <point x="236" y="100" type="qcurve" smooth="yes"/>
       <point x="367" y="317" type="line" smooth="yes"/>
       <point x="420" y="404"/>
-      <point x="609" y="663"/>
-      <point x="661" y="716" type="qcurve"/>
+      <point x="527" y="528"/>
+      <point x="587" y="596" type="qcurve"/>
     </contour>
     <contour>
       <point x="435" y="1305" type="qcurve"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/glyphs/o.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/glyphs/o.glif
@@ -2,43 +2,43 @@
 <glyph name="o" format="2">
   <advance width="964"/>
   <unicode hex="006F"/>
-  <anchor x="481" y="0" name="bottom"/>
-  <anchor x="482" y="536" name="center"/>
-  <anchor x="621" y="0" name="ogonek"/>
-  <anchor x="482" y="1086" name="top"/>
-  <anchor x="555" y="1086" name="topright"/>
+  <anchor x="385.5468164794" y="0" name="bottom"/>
+  <anchor x="480.5468164794" y="536" name="center"/>
+  <anchor x="525.5468164794" y="0" name="ogonek"/>
+  <anchor x="577.5468164794" y="1086" name="top"/>
+  <anchor x="650.5468164794" y="1086" name="topright"/>
   <outline>
     <contour>
-      <point x="482" y="-26" type="qcurve" smooth="yes"/>
-      <point x="299" y="-26"/>
-      <point x="80" y="283"/>
-      <point x="80" y="546" type="qcurve"/>
-      <point x="80" y="546" type="line"/>
-      <point x="80" y="807"/>
-      <point x="297" y="1108"/>
-      <point x="482" y="1108" type="qcurve" smooth="yes"/>
-      <point x="667" y="1108"/>
-      <point x="884" y="806"/>
-      <point x="884" y="546" type="qcurve"/>
-      <point x="884" y="546" type="line"/>
-      <point x="884" y="282"/>
-      <point x="667" y="-26"/>
+      <point x="395.5468164794" y="-26" type="qcurve" smooth="yes"/>
+      <point x="206.5468164794" y="-26"/>
+      <point x="33.5468164794" y="267"/>
+      <point x="80.5468164794" y="546" type="qcurve"/>
+      <point x="80.5468164794" y="546" type="line"/>
+      <point x="126.5468164794" y="807"/>
+      <point x="386.5468164794" y="1108"/>
+      <point x="571.5468164794" y="1108" type="qcurve" smooth="yes"/>
+      <point x="756.5468164794" y="1108"/>
+      <point x="929.5468164794" y="817"/>
+      <point x="884.5468164794" y="546" type="qcurve"/>
+      <point x="884.5468164794" y="546" type="line"/>
+      <point x="837.5468164794" y="273"/>
+      <point x="589.5468164794" y="-26"/>
     </contour>
     <contour>
-      <point x="484" y="146" type="qcurve" smooth="yes"/>
-      <point x="596" y="146"/>
-      <point x="696" y="334"/>
-      <point x="696" y="546" type="qcurve"/>
-      <point x="696" y="546" type="line"/>
-      <point x="696" y="747"/>
-      <point x="593" y="938"/>
-      <point x="484" y="938" type="qcurve" smooth="yes"/>
-      <point x="374" y="938"/>
-      <point x="268" y="745"/>
-      <point x="268" y="546" type="qcurve"/>
-      <point x="268" y="546" type="line"/>
-      <point x="268" y="337"/>
-      <point x="371" y="146"/>
+      <point x="413.5468164794" y="146" type="qcurve" smooth="yes"/>
+      <point x="525.5468164794" y="146"/>
+      <point x="659.5468164794" y="334"/>
+      <point x="696.5468164794" y="546" type="qcurve"/>
+      <point x="696.5468164794" y="546" type="line"/>
+      <point x="731.5468164794" y="747"/>
+      <point x="662.5468164794" y="938"/>
+      <point x="553.5468164794" y="938" type="qcurve" smooth="yes"/>
+      <point x="443.5468164794" y="938"/>
+      <point x="303.5468164794" y="745"/>
+      <point x="268.5468164794" y="546" type="qcurve"/>
+      <point x="268.5468164794" y="546" type="line"/>
+      <point x="231.5468164794" y="337"/>
+      <point x="300.5468164794" y="146"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/glyphs/oslash-bar.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/glyphs/oslash-bar.glif
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="1176"/>
-  <guideline x="424" y="-389" angle="336.4767909795404" identifier="852Fprj1LG"/>
-  <guideline x="902" y="1065" angle="337.16634582208246" identifier="6K0ZYl92Mt"/>
+  <guideline x="424" y="-389" angle="336.4767909795" identifier="852Fprj1LG"/>
+  <guideline x="902" y="1065" angle="337.1663458221" identifier="6K0ZYl92Mt"/>
   <outline>
     <contour>
       <point x="537" y="571" type="line"/>

--- a/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/glyphs/six.glif
+++ b/sources/italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo/glyphs/six.glif
@@ -10,10 +10,10 @@
       <point x="75" y="453" type="qcurve"/>
       <point x="75" y="453" type="line"/>
       <point x="75" y="662"/>
-      <point x="267" y="937"/>
+      <point x="276" y="937"/>
       <point x="439" y="937" type="qcurve"/>
       <point x="439" y="937" type="line"/>
-      <point x="618" y="947"/>
+      <point x="628" y="937"/>
       <point x="803" y="699"/>
       <point x="803" y="465" type="qcurve"/>
       <point x="803" y="465" type="line"/>
@@ -22,7 +22,7 @@
       <point x="439" y="-29" type="qcurve"/>
     </contour>
     <contour>
-      <point x="175" y="453" type="line"/>
+      <point x="165" y="453" type="line"/>
       <point x="75" y="453" type="line"/>
       <point x="75" y="637"/>
       <point x="153" y="864"/>
@@ -37,8 +37,8 @@
       <point x="654" y="1353" type="qcurve" smooth="yes"/>
       <point x="509" y="1113" type="line" smooth="yes"/>
       <point x="457" y="1026"/>
-      <point x="299" y="801"/>
-      <point x="217" y="710" type="qcurve"/>
+      <point x="365" y="895"/>
+      <point x="316" y="841" type="qcurve"/>
     </contour>
     <contour>
       <point x="443" y="125" type="qcurve"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/O_slash-bar.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/O_slash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="Oslash-bar" format="2">
   <advance width="2357"/>
-  <guideline x="439" y="-157" angle="301.8907918018457" identifier="vwuCpxsvTS"/>
+  <guideline x="439" y="-157" angle="301.8908" identifier="vwuCpxsvTS"/>
   <outline>
     <contour>
       <point x="1162" y="782" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="2457"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="25" yOffset="4"/>
+    <component base="O" identifier="2D302E44"/>
+    <component base="Oslash-bar" xOffset="25" yOffset="4" identifier="C7BC3342"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>2D302E44</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>C7BC3342</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="2072"/>
   <outline>
-    <component base="nine" xOffset="139" yOffset="-1"/>
+    <component base="nine" xOffset="139" yOffset="-1" identifier="D2C921A1"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>D2C921A1</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/oslash-bar.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/oslash-bar.glif
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="oslash-bar" format="2">
   <advance width="1705"/>
-  <guideline x="1583" y="749" angle="302.0053832080835" identifier="IZ2gBd8vPo"/>
+  <guideline x="1583" y="749" angle="302.0054" identifier="IZ2gBd8vPo"/>
   <outline>
     <contour>
       <point x="815" y="565" type="line"/>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="1802"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="50" yOffset="7"/>
+    <component base="o" identifier="BEC39845"/>
+    <component base="oslash-bar" xOffset="50" yOffset="7" identifier="CF8208D2"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>BEC39845</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>CF8208D2</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth151-wght400-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="2072"/>
   <outline>
-    <component base="six" xOffset="224"/>
+    <component base="six" xOffset="224" identifier="0EC49475"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>0EC49475</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/O_slash.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/O_slash.glif
@@ -3,8 +3,8 @@
   <advance width="750"/>
   <unicode hex="00D8"/>
   <outline>
-    <component base="O"/>
-    <component base="Oslash-bar" xOffset="40" yOffset="13"/>
+    <component base="O" identifier="5E188C53"/>
+    <component base="Oslash-bar" xOffset="40" yOffset="13" identifier="D5FC2337"/>
   </outline>
   <lib>
     <dict>
@@ -12,6 +12,19 @@
       <string>O</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>O</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>5E188C53</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>D5FC2337</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/nine.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/nine.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="nine.tf" format="2">
   <advance width="648"/>
   <outline>
-    <component base="nine" xOffset="-11" yOffset="-1"/>
+    <component base="nine" xOffset="-11" yOffset="-1" identifier="98D43B98"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>98D43B98</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/oslash.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/oslash.glif
@@ -3,7 +3,24 @@
   <advance width="606"/>
   <unicode hex="00F8"/>
   <outline>
-    <component base="o"/>
-    <component base="oslash-bar" xOffset="-61" yOffset="-1"/>
+    <component base="o" identifier="9455AFAE"/>
+    <component base="oslash-bar" xOffset="-61" yOffset="-1" identifier="7A9392ED"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>7A9392ED</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+        <key>9455AFAE</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>

--- a/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/six.tf.glif
+++ b/sources/regular/GoogleSansFlex-opsz18-wdth25-wght1-ROND0.ufo/glyphs/six.tf.glif
@@ -2,6 +2,18 @@
 <glyph name="six.tf" format="2">
   <advance width="648"/>
   <outline>
-    <component base="six" xOffset="-9"/>
+    <component base="six" xOffset="-9" identifier="5EE140B2"/>
   </outline>
+  <lib>
+    <dict>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>5EE140B2</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
 </glyph>


### PR DESCRIPTION
Creating this PR to demonstrate how the import workflow currently handles the italics branch (`it-ad-wip-italic-v1.002`) so we can see if any adjustments are needed. The good news is that it ran without errors etc., so that's positive!

Workflow run can be found [here](https://github.com/googlefonts/googlesans-flex/actions/runs/5209545511/jobs/9399519365)