### PR TITLE
Change build workflow to be manually triggered

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,11 @@
 name: Build font and specimen
 
 on:
-  push:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: The Git reference to import from (branch name or 7 character commit reference)
+        required: true
   release:
     types: [published] # A release, pre-release, or draft of a release was published.
 
@@ -10,7 +14,10 @@ jobs:
     runs-on: [linux, googlefonts-64cores-256GB]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - name: Get sources
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
@@ -21,7 +28,7 @@ jobs:
           key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements*.txt') }}
           restore-keys: |
             ${{ runner.os }}-venv-
-      - name: gen zip file name
+      - name: Generate zip file name
         id: zip-name
         shell: bash
         # Set the archive name to repo name + "-assets" e.g "MavenPro-assets"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 
 ## Building
 
-Fonts are built automatically by GitHub Actions - take a look in the "Actions" tab for the latest build.
+### On GitHub
 
-If you want to build fonts manually on your own computer:
+Fonts are built by triggering the build workflow in the [Actions tab](https://github.com/googlefonts/googlesans-flex/actions) of the repository.
+
+1. Go to the [Actions tab](https://github.com/googlefonts/googlesans-flex/actions)
+2. Click [Build font and specimen](https://github.com/googlefonts/googlesans-flex/actions/workflows/build.yaml)
+3. Click the grey "Run workflow" dropdown button
+4. Enter the name of the branch or commit you want to build in the text box
+5. Press the green "Run workflow" button
+
+## On your computer
 
 * `make build` will produce font files.
 * `make test` will run [FontBakery](https://github.com/googlefonts/fontbakery)'s quality assurance tests.


### PR DESCRIPTION
@MariannaPaszkowska as requested

Once merged, builds will be triggered manually, as well as when releases are created