### PR TITLE
Work on metadata of VFs

### DIFF
--- a/.github/actions/import/scripts/fix_metadata_in_sources.py
+++ b/.github/actions/import/scripts/fix_metadata_in_sources.py
@@ -37,6 +37,17 @@ INSTANCE_LOCATIONS = {
     "ExtraBold": dict(wght=800.0, wdth=100.0),
     "Black": dict(wght=900.0, wdth=100.0),
 }
+INSTANCE_LOCATIONS_ITALICS = {
+    "Thin Italic": dict(wght=100.0, wdth=100.0),
+    "ExtraLight Italic": dict(wght=200.0, wdth=100.0),
+    "Light Italic": dict(wght=300.0, wdth=100.0),
+    "Italic": dict(wght=400.0, wdth=100.0),
+    "Medium Italic": dict(wght=500.0, wdth=100.0),
+    "SemiBold Italic": dict(wght=600.0, wdth=100.0),
+    "Bold Italic": dict(wght=700.0, wdth=100.0),
+    "ExtraBold Italic": dict(wght=800.0, wdth=100.0),
+    "Black Italic": dict(wght=900.0, wdth=100.0),
+}
 POSTSCRIPT_NAMES = "public.postscriptNames"
 
 
@@ -50,9 +61,14 @@ def main(args: Optional[Sequence[str]] = None) -> None:
 def fix_metadata(designspace_path: Path) -> None:
     designspace = DesignSpaceDocument.fromfile(designspace_path)
     designspace.loadSourceFonts(Font.open)
+    is_italic = "Italic" in designspace_path.stem
+
     designspace.instances.clear()
     tag2name = {a.tag: a.name for a in designspace.axes}
-    for name, location in INSTANCE_LOCATIONS.items():
+    new_instance_locations = (
+        INSTANCE_LOCATIONS_ITALICS if is_italic else INSTANCE_LOCATIONS
+    )
+    for name, location in new_instance_locations.items():
         # TODO: Add directly as user coordinates when we adopt DS5.
         # The instance locations use tags for canonicality, rename to axis names
         # as designspaceLib expects.
@@ -101,7 +117,10 @@ def fix_metadata(designspace_path: Path) -> None:
         ufo.info.copyright = "Copyright 2015 Google LLC. All Rights Reserved."
         ufo.info.familyName = "Google Sans Flex"
         if source is default_location:
-            ufo.info.styleName = "Regular"
+            if is_italic:
+                ufo.info.styleName = "Italic"
+            else:
+                ufo.info.styleName = "Regular"
             ufo.info.openTypeOS2Panose = [2, 11, 5, 3, 3, 5, 2, 4, 2, 4]
         ufo.info.trademark = "Google Sans is a trademark of Google."
         ufo.info.openTypeNameManufacturer = "Google LLC"
@@ -115,11 +134,17 @@ def fix_metadata(designspace_path: Path) -> None:
         ufo.info.openTypeHheaLineGap = 0
         ufo.info.openTypeOS2StrikeoutPosition = 612
         ufo.info.openTypeOS2StrikeoutSize = 168
-        ufo.info.openTypeOS2SubscriptXOffset = 0
+        if is_italic:
+            ufo.info.openTypeOS2SubscriptXOffset = -26
+        else:
+            ufo.info.openTypeOS2SubscriptXOffset = 0
         ufo.info.openTypeOS2SubscriptXSize = 1300
         ufo.info.openTypeOS2SubscriptYOffset = 150
         ufo.info.openTypeOS2SubscriptYSize = 1200
-        ufo.info.openTypeOS2SuperscriptXOffset = 0
+        if is_italic:
+            ufo.info.openTypeOS2SuperscriptXOffset = 124
+        else:
+            ufo.info.openTypeOS2SuperscriptXOffset = 0
         ufo.info.openTypeOS2SuperscriptXSize = 1300
         ufo.info.openTypeOS2SuperscriptYOffset = 700
         ufo.info.openTypeOS2SuperscriptYSize = 1200
@@ -128,10 +153,6 @@ def fix_metadata(designspace_path: Path) -> None:
         ufo.info.openTypeOS2TypoLineGap = 0
         ufo.info.postscriptUnderlinePosition = -320
         ufo.info.postscriptUnderlineThickness = 168
-
-        # TODO: Adapt once the italic is being imported
-        ufo.info.openTypeHheaCaretSlopeRise = 1
-        ufo.info.openTypeHheaCaretSlopeRun = 0
 
         # Use the xHeight from the "z" if not a sparse UFO:
         if (glyph_z := ufo.get("z")) is not None:

--- a/.github/actions/import/scripts/gs_merge_designspace.py
+++ b/.github/actions/import/scripts/gs_merge_designspace.py
@@ -362,6 +362,15 @@ def merge_designspace(
         # Write global public.skipExportGlyphs list to all UFOs.
         target_font.lib[SKIP_EXPORT_GLYPHS_KEY] = skip_export_glyphs
 
+        # Import a limited set of font info.
+        target_font.info.italicAngle = import_font.info.italicAngle or 0
+        target_font.info.openTypeHheaCaretSlopeRise = (
+            import_font.info.openTypeHheaCaretSlopeRise
+        ) or 1
+        target_font.info.openTypeHheaCaretSlopeRun = (
+            import_font.info.openTypeHheaCaretSlopeRun
+        ) or 0
+
     # Avoid typos:
     del target_font
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ build.stamp: venv sources/config.yaml $(SOURCES)
 	venv/bin/python scripts/prune_font_binary.py fonts/variable/*.ttf
 	venv/bin/python scripts/set-overlap-bits.py sources/regular/glyphs-with-overlap.txt sources/regular/GoogleSansFlex.designspace fonts/variable/GoogleSansFlex[ROND,opsz,wdth,wght].ttf
 	venv/bin/python scripts/set-overlap-bits.py sources/italic/glyphs-with-overlap.txt sources/italic/GoogleSansFlex-Italic.designspace fonts/variable/GoogleSansFlex-Italic[ROND,opsz,wdth,wght].ttf
+	venv/bin/python scripts/set-overlap-bits.py sources/regular/glyphs-with-overlap.txt sources/GoogleSansFlex-Full.designspace fonts/variable/GoogleSansFlex-Full[ROND,opsz,slnt,wdth,wght].ttf
 	touch build.stamp
 
 venv/touchfile: requirements.txt

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -223,8 +223,10 @@ def com_google_fonts_check_googlesansflex_axis_names(ttFont):
 
     for axis in fvar.axes:
         name = names.getDebugName(axis.axisNameID)
-        expected = AXIS_NAMES[axis.axisTag]
-        if name == expected:
+        expected = AXIS_NAMES.get(axis.axisTag)
+        if expected is None:
+            yield WARN, f"Font has unexpected axis tagged {axis.axisTag}"
+        elif name == expected:
             yield PASS, f"Axis tagged {axis.axisTag} has expected name {expected}"
         else:
             yield WARN, f"Axis tagged {axis.axisTag} has name {name} but should be named {expected}"
@@ -242,8 +244,10 @@ def com_google_fonts_check_googlesansflex_variable_fvar_default(ttFont):
     """Confirms that the variable font builds include correct fvar default."""
     for axis in ttFont["fvar"].axes:
         tag = axis.axisTag
-        expected = AXIS_DEFAULTS[tag]
-        if axis.defaultValue != expected:
+        expected = AXIS_DEFAULTS.get(tag)
+        if expected is None:
+            yield FAIL, f"Font has unexpected axis tagged {tag}"
+        elif axis.defaultValue != expected:
             yield FAIL, (
                 f"Font does not include the correct "
                 f"fvar {tag} axis default.\n"

--- a/sources/GoogleSansFlex-Full.designspace
+++ b/sources/GoogleSansFlex-Full.designspace
@@ -5,7 +5,7 @@
     <axis tag="wdth" name="Width" minimum="25" maximum="151" default="100"/>
     <axis tag="opsz" name="Optical Size" minimum="6" maximum="144" default="18"/>
     <axis tag="ROND" name="Roundness" minimum="0" maximum="100" default="0"/>
-    <axis tag="slnt" name="Slant" minimum="0" maximum="10" default="0"/>
+    <axis tag="slnt" name="Slant" minimum="-10" maximum="0" default="0"/>
   </axes>
   <sources>
     <source filename="regular/GoogleSansFlex-opsz6-wdth25-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="opsz6-wdth25-wght1">
@@ -1170,7 +1170,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth25-wght400">
@@ -1179,7 +1179,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth25-wght449-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth25-wght449" layer="foreground">
@@ -1188,7 +1188,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth25-wght450-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth25-wght450" layer="foreground">
@@ -1197,7 +1197,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth25-wght579-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth25-wght579" layer="foreground">
@@ -1206,7 +1206,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth25-wght580-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth25-wght580" layer="foreground">
@@ -1215,7 +1215,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth25-wght1000">
@@ -1224,7 +1224,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth85-wght1000-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth85-wght1000-ROND0-SPARSE" layer="foreground">
@@ -1233,7 +1233,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth100-wght1">
@@ -1242,7 +1242,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth100-wght400">
@@ -1251,7 +1251,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth100-wght699-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth100-wght699-ROND0-SPARSE" layer="foreground">
@@ -1260,7 +1260,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth100-wght700-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth100-wght700-ROND0-SPARSE" layer="foreground">
@@ -1269,7 +1269,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth100-wght1000">
@@ -1278,7 +1278,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth151-wght1">
@@ -1287,7 +1287,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth151-wght400">
@@ -1296,7 +1296,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth151-wght579-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth151-wght579" layer="foreground">
@@ -1305,7 +1305,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth151-wght580-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth151-wght580" layer="foreground">
@@ -1314,7 +1314,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth151-wght1000">
@@ -1323,7 +1323,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz17.999-wdth25-wght1">
@@ -1332,7 +1332,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="17.999"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz17.999-wdth25-wght400">
@@ -1341,7 +1341,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="17.999"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz17.999-wdth25-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz17.999-wdth25-wght1000">
@@ -1350,7 +1350,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="17.999"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth25-wght1">
@@ -1359,7 +1359,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth25-wght400">
@@ -1368,7 +1368,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth25-wght449-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth100-wght449-ROND0-SPARSE" layer="foreground">
@@ -1377,7 +1377,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth25-wght450-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth25-wght450-ROND0-SPARSE" layer="foreground">
@@ -1386,7 +1386,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth25-wght579-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth25-wght579" layer="foreground">
@@ -1395,7 +1395,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth25-wght580-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth25-wght580" layer="foreground">
@@ -1404,7 +1404,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth25-wght699-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth25-wght699" layer="foreground">
@@ -1413,7 +1413,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth25-wght700-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth25-wght700" layer="foreground">
@@ -1422,7 +1422,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth25-wght1000">
@@ -1431,7 +1431,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth39-wght1-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth39-wght1-ROND0-SPARSE" layer="foreground">
@@ -1440,7 +1440,7 @@
         <dimension name="Width" xvalue="39.999"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth40-wght1-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth40-wght1-ROND0-SPARSE" layer="foreground">
@@ -1449,7 +1449,7 @@
         <dimension name="Width" xvalue="40"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth39-wght400-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth39-wght400-ROND0-SPARSE" layer="foreground">
@@ -1458,7 +1458,7 @@
         <dimension name="Width" xvalue="39.999"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth40-wght400-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth40-wght400-ROND0-SPARSE" layer="foreground">
@@ -1467,7 +1467,7 @@
         <dimension name="Width" xvalue="40"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth39-wght699-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth39-wght699-ROND0-SPARSE" layer="foreground">
@@ -1476,7 +1476,7 @@
         <dimension name="Width" xvalue="39.999"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth39-wght700-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth39-wght700-ROND0-SPARSE" layer="foreground">
@@ -1485,7 +1485,7 @@
         <dimension name="Width" xvalue="39.999"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth39-wght1000-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth39-wght1000-ROND0-SPARSE" layer="foreground">
@@ -1494,7 +1494,7 @@
         <dimension name="Width" xvalue="39.999"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth40-wght698-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth40-wght698-ROND0-SPARSE" layer="foreground">
@@ -1503,7 +1503,7 @@
         <dimension name="Width" xvalue="40"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth40-wght699-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth40-wght699-ROND0-SPARSE" layer="foreground">
@@ -1512,7 +1512,7 @@
         <dimension name="Width" xvalue="40"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth40-wght700-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth40-wght700-ROND0-SPARSE" layer="foreground">
@@ -1521,7 +1521,7 @@
         <dimension name="Width" xvalue="40"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth50-wght699-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth50-wght699-ROND0-SPARSE" layer="foreground">
@@ -1530,7 +1530,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth50-wght700-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth50-wght700-ROND0-SPARSE" layer="foreground">
@@ -1539,7 +1539,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth40-wght1000-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth40-wght1000-ROND0-SPARSE" layer="foreground">
@@ -1548,7 +1548,7 @@
         <dimension name="Width" xvalue="40"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth151-wght699-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth151-wght699-ROND0-SPARSE" layer="foreground">
@@ -1557,7 +1557,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth151-wght700-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth151-wght700-ROND0-SPARSE" layer="foreground">
@@ -1566,7 +1566,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth50-wght1">
@@ -1575,7 +1575,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth50-wght400">
@@ -1584,7 +1584,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth50-wght1000">
@@ -1593,7 +1593,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth85-wght1">
@@ -1602,7 +1602,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth85-wght400">
@@ -1611,7 +1611,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth85-wght1000">
@@ -1620,7 +1620,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth100-wght1">
@@ -1629,7 +1629,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth100-wght400">
@@ -1642,7 +1642,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth100-wght579-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth100-wght579-ROND0-SPARSE" layer="foreground">
@@ -1651,7 +1651,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth100-wght580-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth100-wght580-ROND0-SPARSE" layer="foreground">
@@ -1660,7 +1660,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth100-wght699-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth100-wght699-ROND0-SPARSE" layer="foreground">
@@ -1669,7 +1669,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth100-wght700-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth100-wght700-ROND0-SPARSE" layer="foreground">
@@ -1678,7 +1678,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth100-wght1000">
@@ -1687,7 +1687,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth151-wght1">
@@ -1696,7 +1696,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth151-wght400">
@@ -1705,7 +1705,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth151-wght579-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth151-wght579-ROND0-SPARSE" layer="foreground">
@@ -1714,7 +1714,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth151-wght580-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth151-wght580-ROND0-SPARSE" layer="foreground">
@@ -1723,7 +1723,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth151-wght1000">
@@ -1732,7 +1732,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth25-wght1">
@@ -1741,7 +1741,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth25-wght400">
@@ -1750,7 +1750,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth25-wght449-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth25-wght449" layer="foreground">
@@ -1759,7 +1759,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth25-wght450-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth25-wght450" layer="foreground">
@@ -1768,7 +1768,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth25-wght579-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth25-wght579" layer="foreground">
@@ -1777,7 +1777,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth25-wght580-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth25-wght580" layer="foreground">
@@ -1786,7 +1786,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth25-wght1000">
@@ -1795,7 +1795,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth39-wght1-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth39-wght1-ROND0-SPARSE" layer="foreground">
@@ -1804,7 +1804,7 @@
         <dimension name="Width" xvalue="39.999"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth39-wght400-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth39-wght400-ROND0-SPARSE" layer="foreground">
@@ -1813,7 +1813,7 @@
         <dimension name="Width" xvalue="39.999"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth40-wght1-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth40-wght1-ROND0-SPARSE" layer="foreground">
@@ -1822,7 +1822,7 @@
         <dimension name="Width" xvalue="40"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth40-wght400-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth40-wght400-ROND0-SPARSE" layer="foreground">
@@ -1831,7 +1831,7 @@
         <dimension name="Width" xvalue="40"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth100-wght699-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth100-wght699-ROND0-SPARSE" layer="foreground">
@@ -1840,7 +1840,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth100-wght700-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth100-wght700-ROND0-SPARSE" layer="foreground">
@@ -1849,7 +1849,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth50-wght1">
@@ -1858,7 +1858,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth50-wght400">
@@ -1867,7 +1867,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth50-wght1000">
@@ -1876,7 +1876,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth85-wght1">
@@ -1885,7 +1885,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth85-wght400">
@@ -1894,7 +1894,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth85-wght1000">
@@ -1903,7 +1903,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth100-wght1">
@@ -1912,7 +1912,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth100-wght400">
@@ -1921,7 +1921,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth100-wght1000">
@@ -1930,7 +1930,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth151-wght1">
@@ -1939,7 +1939,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth151-wght400">
@@ -1948,7 +1948,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND0.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth151-wght1000">
@@ -1957,7 +1957,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth25-wght1">
@@ -1966,7 +1966,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth25-wght400">
@@ -1975,7 +1975,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz6-wdth25-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth25-wght1000">
@@ -1984,7 +1984,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/GoogleSansFlexItalic-opsz6-wdth85-wght1000-ROND0-SPARSE.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth85-wght1000-ROND100-SPARSE" layer="foreground">
@@ -1993,7 +1993,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth100-wght1">
@@ -2002,7 +2002,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth100-wght400">
@@ -2011,7 +2011,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz6-wdth100-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth100-wght1000">
@@ -2020,7 +2020,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth151-wght1">
@@ -2029,7 +2029,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth151-wght400">
@@ -2038,7 +2038,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz6-wdth151-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz6-wdth151-wght1000">
@@ -2047,7 +2047,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="6"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth25-wght1">
@@ -2056,7 +2056,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth25-wght400">
@@ -2065,7 +2065,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth25-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth25-wght1000">
@@ -2074,7 +2074,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth100-wght1">
@@ -2083,7 +2083,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth100-wght400">
@@ -2092,7 +2092,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth100-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth100-wght1000">
@@ -2101,7 +2101,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth151-wght1">
@@ -2110,7 +2110,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth151-wght400">
@@ -2119,7 +2119,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth151-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth151-wght1000">
@@ -2128,7 +2128,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth25-wght1">
@@ -2137,7 +2137,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth25-wght400">
@@ -2146,7 +2146,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth25-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth25-wght1000">
@@ -2155,7 +2155,7 @@
         <dimension name="Width" xvalue="25"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth100-wght1">
@@ -2164,7 +2164,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth100-wght400">
@@ -2173,7 +2173,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth100-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth100-wght1000">
@@ -2182,7 +2182,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth151-wght1">
@@ -2191,7 +2191,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth151-wght400">
@@ -2200,7 +2200,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth151-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth151-wght1000">
@@ -2209,7 +2209,7 @@
         <dimension name="Width" xvalue="151"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth85-wght1000-ROND100">
@@ -2218,7 +2218,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth85-wght400-ROND100">
@@ -2227,7 +2227,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth85-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth85-wght1-ROND100">
@@ -2236,7 +2236,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth50-wght1-ROND100">
@@ -2245,7 +2245,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth50-wght400-ROND100">
@@ -2254,7 +2254,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz144-wdth50-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz144-wdth50-wght1000-ROND100">
@@ -2263,7 +2263,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="144"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth85-wght1000-ROND100">
@@ -2272,7 +2272,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth85-wght400-ROND100">
@@ -2281,7 +2281,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth85-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth85-wght1-ROND100">
@@ -2290,7 +2290,7 @@
         <dimension name="Width" xvalue="85"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1000-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth50-wght1000-ROND100">
@@ -2299,7 +2299,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght400-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth50-wght400-ROND100">
@@ -2308,7 +2308,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
     <source filename="italic/ROND100/GoogleSansFlexItalic-opsz18-wdth50-wght1-ROND100.ufo" familyname="GoogleSansFlex" stylename="ital1-opsz18-wdth50-wght1-ROND100">
@@ -2317,7 +2317,7 @@
         <dimension name="Width" xvalue="50"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="100"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
     </source>
   </sources>
@@ -2427,7 +2427,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
       <kerning/>
       <info/>
@@ -2438,7 +2438,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
       <kerning/>
       <info/>
@@ -2449,7 +2449,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
       <kerning/>
       <info/>
@@ -2460,7 +2460,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
       <kerning/>
       <info/>
@@ -2471,7 +2471,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
       <kerning/>
       <info/>
@@ -2482,7 +2482,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
       <kerning/>
       <info/>
@@ -2493,7 +2493,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
       <kerning/>
       <info/>
@@ -2504,7 +2504,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
       <kerning/>
       <info/>
@@ -2515,7 +2515,7 @@
         <dimension name="Width" xvalue="100"/>
         <dimension name="Optical Size" xvalue="18"/>
         <dimension name="Roundness" xvalue="0"/>
-        <dimension name="Slant" xvalue="10"/>
+        <dimension name="Slant" xvalue="-10"/>
       </location>
       <kerning/>
       <info/>

--- a/sources/config.yaml
+++ b/sources/config.yaml
@@ -155,12 +155,12 @@ stat:
       tag: slnt
       values:
         - flags: 2
-          name: Roman
+          name: Default
           value: 0
-          linkedValue: 1
+          linkedValue: -10
         - flags: 0
-          name: Italic
-          value: 1
+          name: Slanted
+          value: -10
   "GoogleSansFlex[ROND,opsz,wdth,wght].ttf":
     - name: Weight
       tag: wght


### PR DESCRIPTION
This changes the import scripts to fix up the metadata on the italic sources better when importing a fresh batch.

You should be able to install upright and italic font at the same time, but not the "Full" font, which I suppose is temporary?

@MariannaPaszkowska 