### PR TITLE
Skip full designspace on import

### DIFF
--- a/.github/actions/import/entrypoint.py
+++ b/.github/actions/import/entrypoint.py
@@ -50,6 +50,9 @@ def main():
     file_text = (SOURCE_DIR / CONFIG_FILE).read_text()
     gftools_config = yaml.safe_load(file_text)
     for designspace_path in gftools_config["sources"]:
+        if designspace_path == "GoogleSansFlex-Full.designspace":
+            # Skip this designspace because italics is already imported by italic/GoogleSansFlex-Italic.designspace
+            continue
         logging.info(f"Merging {designspace_path}")
         designspace_path_target = designspace_path.replace("roman/", "regular/", 1)
         merge_designspace(


### PR DESCRIPTION
According to Nikolaus because italic is mentioned in multiple designspaces that the import workflow tries to merge, it could cause problems. This PR avoids that issue by ignoring the full designspace for the import workflow