### PR TITLE
Update skip list to allow latest changes to be imported on the CI

### DIFF
--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -58,12 +58,12 @@ jobs:
           rm -rf "$GITHUB_WORKSPACE"/target/sources/*.{ufo,designspace}
       - name: Run import script
         run: |
-          cd "$GITHUB_WORKSPACE/target"
+          cd "$GITHUB_WORKSPACE/main"
           echo "::group::setup venv"
           make venv
           echo "::endgroup::"
           echo "Running glyphs_to_ds.py"
-          venv/bin/python scripts/glyphs_to_ds.py "$GITHUB_WORKSPACE"/source/sources-v2_0/GSF-full.glyphspackage sources/GoogleSansFlex.designspace
+          venv/bin/python scripts/glyphs_to_ds.py "$GITHUB_WORKSPACE"/source/sources-v2_0/GSF-full.glyphspackage "$GITHUB_WORKSPACE"/target/sources/GoogleSansFlex.designspace
       - name: Commit & push changes
         env:
           SOURCE_REF: ${{ github.event.inputs.branch }}

--- a/scripts/glyphs_to_ds.py
+++ b/scripts/glyphs_to_ds.py
@@ -24,7 +24,43 @@ from tempfile import TemporaryDirectory
 from argparse import ArgumentParser
 
 # Incompatible glyphs, that should not be included in the final build.
-INCOMPATIBLE = set(["z", "zacute", "zcaron", "zdotaccent"])
+INCOMPATIBLE = set(
+    [
+        "acircumflex.alt",
+        "acircumflex",
+        "Acircumflex",
+        "circumflex",
+        "circumflexcomb",
+        "ecircumflex",
+        "Ecircumflex",
+        "four.denominator",
+        "four.numerator",
+        "four.sinf",
+        "four.tf",
+        "foursubscript",
+        "foursuperior",
+        "foursuperscript",
+        "hungarumlaut",
+        "hungarumlautcomb",
+        "icircumflex",
+        "Icircumflex",
+        "ocircumflex",
+        "Ocircumflex",
+        "ohungarumlaut",
+        "Ohungarumlaut",
+        "onequarter",
+        "t",
+        "threequarters",
+        "ucircumflex",
+        "Ucircumflex",
+        "uhungarumlaut",
+        "Uhungarumlaut",
+        "wcircumflex",
+        "Wcircumflex",
+        "ycircumflex",
+        "Ycircumflex",
+    ]
+)
 
 if __name__ == "__main__":
     parser = ArgumentParser()


### PR DESCRIPTION
This PR:

- Updates the incompatible glyph list, to allow for the latest commit on `it-ad-wip-v2.0` to be imported and built on the CI
- Updates the import action to use the latest import script from `main`, instead of from the (potentially outdated) target branch

Together, these changes will allow us to import Octavio's team's full sources on the CI and see FontBakery output, avoiding the errors we saw in [yesterday's action run](https://github.com/googlefonts/googlesans-flex/actions/runs/7019979647/job/19098673223#step:10:92).

(we still expect to see some table differences with V1 until #731 is complete)