### PR TITLE
Update list of incompatible glyphs (only skip /five.denominator)

### DIFF
--- a/scripts/glyphs_to_ds.py
+++ b/scripts/glyphs_to_ds.py
@@ -24,43 +24,7 @@ from tempfile import TemporaryDirectory
 from argparse import ArgumentParser
 
 # Incompatible glyphs, that should not be included in the final build.
-INCOMPATIBLE = set(
-    [
-        "acircumflex.alt",
-        "acircumflex",
-        "Acircumflex",
-        "circumflex",
-        "circumflexcomb",
-        "ecircumflex",
-        "Ecircumflex",
-        "four.denominator",
-        "four.numerator",
-        "four.sinf",
-        "four.tf",
-        "foursubscript",
-        "foursuperior",
-        "foursuperscript",
-        "hungarumlaut",
-        "hungarumlautcomb",
-        "icircumflex",
-        "Icircumflex",
-        "ocircumflex",
-        "Ocircumflex",
-        "ohungarumlaut",
-        "Ohungarumlaut",
-        "onequarter",
-        "t",
-        "threequarters",
-        "ucircumflex",
-        "Ucircumflex",
-        "uhungarumlaut",
-        "Uhungarumlaut",
-        "wcircumflex",
-        "Wcircumflex",
-        "ycircumflex",
-        "Ycircumflex",
-    ]
-)
+INCOMPATIBLE = set(["five.denominator"])
 
 if __name__ == "__main__":
     parser = ArgumentParser()


### PR DESCRIPTION
As of at least 5c2badbb7ff74dc8d03575a6e78571547d242037, only /five.denominator is incompatible; this PR removes all other glyphs from the skip list in preparation for merging V2 sources into `main`.