### PR TITLE
Removed unused dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-gftools[qa]
+gftools
 drawbot-skia>=0.4.8
 sh>=1.14.2
 bumpfontversion>=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,28 +17,16 @@ attrs==23.1.0
     # via
     #   cattrs
     #   fontmake
-    #   outcome
     #   statmake
-    #   trio
     #   ufolib2
 axisregistry==0.4.4
-    # via
-    #   fontbakery
-    #   gftools
+    # via gftools
 babelfont==3.0.1
-    # via
-    #   fontbakery
-    #   gftools
+    # via gftools
 beautifulsoup4==4.12.2
-    # via
-    #   fontbakery
-    #   gftools
-beziers==0.5.0
-    # via fontbakery
-blackrenderer[skia]==0.6.0
-    # via
-    #   diffenator2
-    #   drawbot-skia
+    # via gftools
+blackrenderer==0.6.0
+    # via drawbot-skia
 booleanoperations==0.9.0
     # via
     #   afdko
@@ -57,12 +45,9 @@ bumpfontversion==0.4.1
 cattrs==23.1.2
     # via statmake
 certifi==2023.7.22
-    # via
-    #   requests
-    #   selenium
+    # via requests
 cffi==1.16.0
     # via
-    #   cmarkgfm
     #   cryptography
     #   pygit2
     #   pynacl
@@ -72,14 +57,8 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via hyperglot
-cmarkgfm==2022.10.27
-    # via fontbakery
-collidoscope==0.6.5
-    # via fontbakery
 colorlog==6.7.0
     # via hyperglot
-commandlines==0.4.1
-    # via ufolint
 compreffor==0.5.5
     # via ufo2ft
 contourpy==1.2.0
@@ -93,27 +72,15 @@ cycler==0.12.1
 defcon[lxml,pens]==0.10.3
     # via
     #   afdko
-    #   fontbakery
     #   fontparts
     #   glyphsets
     #   mutatormath
     #   ufoprocessor
-dehinter==4.0.0
-    # via fontbakery
 deprecated==1.2.14
     # via pygithub
-diffenator2==0.3.3
-    # via gftools
-docopt==0.6.2
-    # via num2words
 drawbot-skia==0.5.0
     # via -r requirements.in
 font-v==2.1.0
-    # via
-    #   -r requirements.in
-    #   fontbakery
-    #   gftools
-fontbakery[googlefonts]==0.10.3
     # via
     #   -r requirements.in
     #   gftools
@@ -143,15 +110,11 @@ fonttools[lxml,ufo,unicode,woff]==4.44.0
     #   booleanoperations
     #   bumpfontversion
     #   cffsubr
-    #   collidoscope
     #   compreffor
     #   cu2qu
     #   defcon
-    #   dehinter
-    #   diffenator2
     #   drawbot-skia
     #   font-v
-    #   fontbakery
     #   fontfeatures
     #   fontmake
     #   fontmath
@@ -161,7 +124,6 @@ fonttools[lxml,ufo,unicode,woff]==4.44.0
     #   glyphsets
     #   glyphslib
     #   hyperglot
-    #   kurbopy
     #   matplotlib
     #   mutatormath
     #   nanoemoji
@@ -169,35 +131,23 @@ fonttools[lxml,ufo,unicode,woff]==4.44.0
     #   statmake
     #   ufo2ft
     #   ufolib2
-    #   ufolint
     #   ufoprocessor
     #   vharfbuzz
     #   vttlib
-freetype-py==2.3.0
-    # via
-    #   diffenator2
-    #   fontbakery
 fs==2.4.16
     # via
     #   fontfeatures
     #   fonttools
 gflanguages==0.5.7
-    # via
-    #   diffenator2
-    #   fontbakery
-    #   gftools
-    #   shaperglot
-gftools[qa]==0.9.36
+    # via gftools
+gftools==0.9.36
     # via -r requirements.in
 gitdb==4.0.11
     # via gitpython
 gitpython==3.1.40
     # via font-v
 glyphsets==0.6.5
-    # via
-    #   diffenator2
-    #   fontbakery
-    #   gftools
+    # via gftools
 glyphslib==6.4.1
     # via
     #   -r requirements.in
@@ -206,22 +156,14 @@ glyphslib==6.4.1
     #   fontmake
     #   gftools
     #   glyphsets
-h11==0.14.0
-    # via wsproto
 hyperglot==0.4.5
     # via gftools
 idna==3.4
-    # via
-    #   requests
-    #   trio
+    # via requests
 jinja2==3.1.2
-    # via
-    #   diffenator2
-    #   gftools
+    # via gftools
 kiwisolver==1.4.5
     # via matplotlib
-kurbopy==0.10.40
-    # via collidoscope
 lxml==4.9.3
     # via
     #   afdko
@@ -237,21 +179,14 @@ matplotlib==3.8.1
     # via -r requirements.in
 mdurl==0.1.2
     # via markdown-it-py
-munkres==1.1.4
-    # via fontbakery
 mutatormath==3.0.1
     # via ufoprocessor
 nanoemoji==0.15.1
     # via gftools
 ninja==1.11.1.1
-    # via
-    #   diffenator2
-    #   nanoemoji
-num2words==0.5.13
-    # via shaperglot
+    # via nanoemoji
 numpy==1.26.1
     # via
-    #   blackrenderer
     #   contourpy
     #   drawbot-skia
     #   matplotlib
@@ -262,50 +197,33 @@ openstep-plist==0.3.1
     #   bumpfontversion
     #   glyphslib
 opentype-sanitizer==9.1.0
-    # via
-    #   fontbakery
-    #   gftools
-opentypespec==1.9.1
-    # via fontbakery
+    # via gftools
 orjson==3.9.10
     # via babelfont
-outcome==1.3.0.post0
-    # via trio
 packaging==23.2
     # via
-    #   fontbakery
     #   gftools
     #   matplotlib
 picosvg==0.22.1
     # via nanoemoji
 pillow==10.1.0
     # via
-    #   diffenator2
     #   gftools
     #   matplotlib
     #   nanoemoji
-pip-api==0.0.30
-    # via fontbakery
 pngquant-cli==2.17.0.post5
     # via nanoemoji
 protobuf==3.20.3
     # via
     #   axisregistry
-    #   diffenator2
-    #   fontbakery
     #   gflanguages
     #   gftools
-    #   shaperglot
 psautohint==2.4.0
     # via afdko
-pyahocorasick==2.0.0
-    # via diffenator2
 pybind11==2.11.1
     # via skia-python
 pyclipper==1.3.0.post5
-    # via
-    #   beziers
-    #   booleanoperations
+    # via booleanoperations
 pycparser==2.21
     # via cffi
 pygit2==1.13.2
@@ -324,12 +242,8 @@ pyparsing==3.1.1
     # via
     #   matplotlib
     #   vttlib
-pysocks==1.7.1
-    # via urllib3
 python-bidi==0.4.2
-    # via
-    #   diffenator2
-    #   drawbot-skia
+    # via drawbot-skia
 python-dateutil==2.8.2
     # via
     #   matplotlib
@@ -337,31 +251,20 @@ python-dateutil==2.8.2
     #   strictyaml
 pyyaml==6.0.1
     # via
-    #   fontbakery
     #   gftools
     #   hyperglot
 regex==2023.10.3
     # via nanoemoji
 requests==2.31.0
     # via
-    #   fontbakery
     #   gftools
     #   pygithub
-    #   youseedee
 resvg-cli==0.22.0.post3
     # via nanoemoji
 rich==13.6.0
-    # via
-    #   fontbakery
-    #   gftools
-rstr==3.2.2
-    # via stringbrewer
-selenium==4.15.2
-    # via diffenator2
+    # via gftools
 sh==2.0.6
     # via -r requirements.in
-shaperglot==0.3.1
-    # via fontbakery
 six==1.16.0
     # via
     #   fs
@@ -369,60 +272,32 @@ six==1.16.0
     #   python-dateutil
 skia-pathops==0.8.0.post1
     # via
-    #   collidoscope
     #   gftools
     #   picosvg
 skia-python==87.5
-    # via
-    #   blackrenderer
-    #   drawbot-skia
+    # via drawbot-skia
 smmap==5.0.1
     # via gitdb
-sniffio==1.3.0
-    # via trio
-sortedcontainers==2.4.0
-    # via trio
 soupsieve==2.5
     # via beautifulsoup4
-sre-yield==1.2
-    # via stringbrewer
 statmake==0.6.0
     # via gftools
 strictyaml==1.7.3
-    # via
-    #   gftools
-    #   shaperglot
-stringbrewer==0.0.1
-    # via fontbakery
+    # via gftools
 tabulate==0.9.0
     # via gftools
-termcolor==2.3.0
-    # via shaperglot
 toml==0.10.2
-    # via
-    #   fontbakery
-    #   nanoemoji
+    # via nanoemoji
 tqdm==4.66.1
-    # via
-    #   afdko
-    #   collidoscope
-    #   diffenator2
-trio==0.23.1
-    # via
-    #   selenium
-    #   trio-websocket
-trio-websocket==0.11.1
-    # via selenium
+    # via afdko
 ttfautohint-py==0.5.1
     # via gftools
 typing-extensions==4.8.0
     # via pygithub
 ufo2ft[cffsubr,compreffor]==2.33.4
     # via
-    #   fontbakery
     #   fontmake
     #   nanoemoji
-    #   shaperglot
     #   ufo2ft
 ufolib2==0.16.0
     # via
@@ -432,8 +307,6 @@ ufolib2==0.16.0
     #   glyphslib
     #   nanoemoji
     #   vttlib
-ufolint==1.2.0
-    # via fontbakery
 ufonormalizer==0.6.1
     # via afdko
 ufoprocessor==1.9.0
@@ -441,44 +314,30 @@ ufoprocessor==1.9.0
 uharfbuzz==0.37.3
     # via
     #   blackrenderer
-    #   collidoscope
-    #   diffenator2
     #   drawbot-skia
     #   vharfbuzz
 unicodedata2==15.1.0
     # via
-    #   diffenator2
     #   drawbot-skia
     #   fonttools
     #   glyphsets
     #   hyperglot
 unidecode==1.3.7
     # via gftools
-urllib3[socks]==2.0.7
+urllib3==2.0.7
     # via
     #   pygithub
     #   requests
-    #   selenium
 vharfbuzz==0.2.0
-    # via
-    #   fontbakery
-    #   gftools
-    #   shaperglot
+    # via gftools
 vttlib==0.12.0
     # via gftools
 wrapt==1.16.0
     # via deprecated
-wsproto==1.2.0
-    # via trio-websocket
-youseedee==0.3.0
-    # via
-    #   diffenator2
-    #   shaperglot
 zopfli==0.2.3
     # via
     #   fonttools
     #   nanoemoji
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
 # setuptools


### PR DESCRIPTION
As far as we can tell, we weren't using any of the extra QA features of `gftools`, so removing this requirement means that the build pipelines don't have to pull in diffenator2 and fontbakery (now that fontbakery gets its own venv)

This should save some space & time for everyone just wanted to do a quick `make build`

Was going to be a part of #722 but you were too fast @MariannaPaszkowska 😉 