### PR TITLE
Remove proof generation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,8 +46,6 @@ jobs:
         uses: f-actions/opentype-sanitizer@v2
         with:
           path: "fonts/variable/*.ttf"
-      - name: proof
-        run: make proof
       - name: Analyze file size
         uses: ./.github/actions/file-size
         continue-on-error: true

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -102,8 +102,6 @@ jobs:
         uses: f-actions/opentype-sanitizer@v2
         with:
           path: "fonts/variable/*.ttf"
-      - name: proof
-        run: cd "$GITHUB_WORKSPACE/target" && make proof
       - name: Analyze file size
         uses: ./main/.github/actions/file-size
         with:

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,6 @@ test: build.stamp
 # -venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-shaping-report.html \
 #	qa/check-shaping.py fonts/variable/GoogleSansFlex[ROND,opsz,slnt,wdth,wght].ttf
 
-proof: venv build.stamp
-	. venv/bin/activate; mkdir -p out/proof; diffenator2 proof $(shell find fonts/variable -type f) -o out/proof
-
 images: venv build.stamp $(DRAWBOT_OUTPUT)
 	git add documentation/*.png && git commit -m "Rebuild images" documentation/*.png
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Fonts are built by triggering the build workflow in the [Actions tab](https://gi
 
 * `make build` will produce font files.
 * `make test` will run [FontBakery](https://github.com/googlefonts/fontbakery)'s quality assurance tests.
-* `make proof` will generate HTML proof files.
 
 ## Releasing
 


### PR DESCRIPTION
I believe this is a leftover part of the template that we don't use

Unfortunately the changes in #740 break build & import because proofing requires `diffenator2`, which is no longer installed

Instead of re-bloating our requirements, I vote we remove proofing since AFAIK we don't use it