### PR TITLE
GitHub workflow improvements

### DIFF
--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -26,45 +26,8 @@ runs:
         echo "::error title=Built fonts not found::No built fonts in ${{ inputs.repo-path }}/fonts/variable"
         exit 1
       fi
-      
-      # Mostly copied from Makefile
-      test -d venv_bakery || python3 -m venv venv_bakery
-      venv_bakery/bin/pip install -U setuptools wheel pip
-      venv_bakery/bin/pip install -U fontbakery[googlefonts] fonttools[interpolatable]
-      mkdir -p out/fontbakery
-      # All checks invocations are chained into `|| failed+=("test name")` so that:
-      # 1. we know if any of the tests failed
-      # 2. we don't immediately exit thanks to set -e
-      # 3. we can give a nice error message later
-      failed=()
-      find "${{ inputs.repo-path }}/sources/" -name "*.ufo" | xargs venv_bakery/bin/fontbakery \
-        check-profile -l WARN --auto-jobs --succinct \
-        --html out/fontbakery/fontbakery-sources-report.html \
-        qa/check-sources.py \
-        sources/GoogleSansFlex.designspace \
-        sources/regular/GoogleSansFlex.designspace \
-        sources/italic/GoogleSansFlex-Italic.designspace \
-        || failed+=("check-sources")
-      venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct \
-        --html out/fontbakery/fontbakery-outlines-report.html \
-        fontbakery.profiles.outline \
-        fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf \
-        || failed+=("fontbakery.profiles.outline")
-      venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct \
-        --html out/fontbakery/fontbakery-googlesans-report.html \
-        qa/check-googlesans.py \
-        fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf \
-        || failed+=("check-googlesans")
-      venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct \
-        --html out/fontbakery/fontbakery-fea-report.html \
-        qa/check-fea.py \
-        fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf \
-        || failed+=("check-fea")
-      
-      if [[ ${#failed[@]} -gt 0 ]]; then
-        echo "::error title=Fontbakery fails::The following Fontbakery profiles had fails/errors: ${failed[@]}"
-        exit 1
-      fi
+
+      scripts/fontbakery.sh "${{ inputs.repo-path }}"
   - name: Check with OT Sanitizer
     uses: f-actions/opentype-sanitizer@v2
     with:

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -16,6 +16,7 @@ runs:
       python-version-file: ${{ inputs.repo-path }}/.github/workflows/python-version.txt
       cache: pip
   - name: Run Fontbakery
+    id: fontbakery
     shell: bash
     run: |
       if [ -d "${{ inputs.repo-path }}/fonts/variable" ]; then
@@ -25,7 +26,45 @@ runs:
         echo "::error title=Built fonts not found::No built fonts in ${{ inputs.repo-path }}/fonts/variable"
         exit 1
       fi
-      make --directory ${{ inputs.repo-path }} test
+      
+      # Mostly copied from Makefile
+      test -d venv_bakery || python3 -m venv venv_bakery
+      venv_bakery/bin/pip install -U setuptools wheel pip
+      venv_bakery/bin/pip install -U fontbakery[googlefonts] fonttools[interpolatable]
+      mkdir -p out/fontbakery
+      # All checks invocations are chained into `|| failed+=("test name")` so that:
+      # 1. we know if any of the tests failed
+      # 2. we don't immediately exit thanks to set -e
+      # 3. we can give a nice error message later
+      failed=()
+      find "${{ inputs.repo-path }}/sources/" -name "*.ufo" | xargs venv_bakery/bin/fontbakery \
+        check-profile -l WARN --auto-jobs --succinct \
+        --html out/fontbakery/fontbakery-sources-report.html \
+        qa/check-sources.py \
+        sources/GoogleSansFlex.designspace \
+        sources/regular/GoogleSansFlex.designspace \
+        sources/italic/GoogleSansFlex-Italic.designspace \
+        || failed+=("check-sources")
+      venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct \
+        --html out/fontbakery/fontbakery-outlines-report.html \
+        fontbakery.profiles.outline \
+        fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf \
+        || failed+=("fontbakery.profiles.outline")
+      venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct \
+        --html out/fontbakery/fontbakery-googlesans-report.html \
+        qa/check-googlesans.py \
+        fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf \
+        || failed+=("check-googlesans")
+      venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct \
+        --html out/fontbakery/fontbakery-fea-report.html \
+        qa/check-fea.py \
+        fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf \
+        || failed+=("check-fea")
+      
+      if [[ ${#failed[@]} -gt 0 ]]; then
+        echo "::error title=Fontbakery fails::The following Fontbakery profiles had fails/errors: ${failed[@]}"
+        exit 1
+      fi
   - name: Check with OT Sanitizer
     uses: f-actions/opentype-sanitizer@v2
     with:
@@ -35,6 +74,10 @@ runs:
     run: make --directory ${{ inputs.repo-path }} font-size
   - name: Upload Fontbakery reports
     uses: actions/upload-artifact@v3
+    # Always upload reports (even during a pipeline fail), so long as Fontbakery completed
+    # https://docs.github.com/en/actions/learn-github-actions/expressions#always
+    # https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
+    if: ${{ !cancelled() && (steps.fontbakery.conclusion == 'success' || steps.fontbakery.conclusion == 'failure') }}
     with:
       name: Fontbakery reports
       path: ${{ inputs.repo-path }}/out/fontbakery

--- a/.github/workflows/build-glyphs.yml
+++ b/.github/workflows/build-glyphs.yml
@@ -12,19 +12,19 @@ jobs:
     runs-on: [linux, googlefonts-64cores-256GB]
     timeout-minutes: 60
     steps:
-    - name: Log & validate inputs
-      run: |
-        echo "git-ref: ${{ github.event.inputs.git-ref }}"
-        echo "python-version-file: $(head -n 1 -z .github/workflows/python-version.txt)"
-        if [[ "${{ github.ref_name }}" != "main" ]]; then
-          echo "::error title=Pipeline not run on main::Build from Glyphs workflow should always be run from main"
-          exit 1
-        fi
     - name: Checkout main
       uses: actions/checkout@v4
       with:
         ref: main
         path: main
+    - name: Log & validate inputs
+      run: |
+        echo "git-ref: ${{ github.event.inputs.git-ref }}"
+        echo "python-version-file: $(head -n 1 -z ./main/.github/workflows/python-version.txt)"
+        if [[ "${{ github.ref_name }}" != "main" ]]; then
+          echo "::error title=Pipeline not run on main::Build from Glyphs workflow should always be run from main"
+          exit 1
+        fi
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Download built fonts
       uses: actions/download-artifact@v3
       with:
-        name: ${{ needs.build-variable.outputs.artifact-name }}
+        name: ${{ needs.build.outputs.artifact-name }}
         path: fonts/variable
     - name: Run tests
       uses: ./.github/actions/tests

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,10 +7,11 @@ on:
         description: The branch to build from
         required: true
   push:
+    branches:
+      - main
     tags:
-    branches-ignore:
-    - fb-wip
-    - it-ad-wip-*
+  pull_request:
+    types: [opened, synchronize, reopened]
   release:
     # A release, pre-release, or draft of a release was published
     types: [published]
@@ -20,10 +21,11 @@ jobs:
     runs-on: [linux, googlefonts-64cores-256GB]
     timeout-minutes: 60
     steps:
-    - name: Checkout ${{ inputs.git-ref || github.ref_name }}
+    # on: pull_request uses head_ref for branch name, on: push uses ref_name
+    - name: Checkout ${{ inputs.git-ref || github.head_ref || github.ref_name }}
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.git-ref || github.ref_name }}
+        ref: ${{ inputs.git-ref || github.head_ref || github.ref_name }}
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,11 @@ on:
       git-ref:
         description: The branch to build from
         required: true
+  push:
+    tags:
+    branches-ignore:
+    - fb-wip
+    - it-ad-wip-*
   release:
     # A release, pre-release, or draft of a release was published
     types: [published]
@@ -15,10 +20,10 @@ jobs:
     runs-on: [linux, googlefonts-64cores-256GB]
     timeout-minutes: 60
     steps:
-    - name: Checkout ${{ inputs.git-ref || 'main' }}
+    - name: Checkout ${{ inputs.git-ref || github.ref_name }}
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.git-ref || 'main' }}
+        ref: ${{ inputs.git-ref || github.ref_name }}
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/Makefile
+++ b/Makefile
@@ -43,32 +43,7 @@ venv/touchfile: requirements.txt
 	touch venv/touchfile
 
 test: build.stamp
-# Install latest version of fontbakery on every run, isolated from build dependencies
-	test -d venv_bakery || python3 -m venv venv_bakery
-	venv_bakery/bin/pip install -U setuptools wheel pip
-# fonttools[interpolatable] makes com.google.fonts/check/interpolation_issues around 5x faster
-	venv_bakery/bin/pip install -U fontbakery[googlefonts] fonttools[interpolatable]
-
-	# Run fontbakery tests
-	mkdir -p out/fontbakery
-	-venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-sources-report.html \
-		qa/check-sources.py \
-			sources/GoogleSansFlex.designspace \
-			$(shell find sources -name "*.ufo")
-# TODO: Re-enable if additional designspaces are restored.
-#			sources/regular/GoogleSansFlex.designspace
-#			sources/italic/GoogleSansFlex-Italic.designspace
-	-venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-outlines-report.html \
-		fontbakery.profiles.outline fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
-	-venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-googlesans-report.html \
-		qa/check-googlesans.py fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
-	-venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-fea-report.html \
-		qa/check-fea.py fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
-# NOTE: The following checks can be activated after the sources are stable:
-# -venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-charset-report.html \
-#	qa/check-charset.py fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
-# -venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-shaping-report.html \
-#	qa/check-shaping.py fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+	@scripts/fontbakery.sh
 
 images: venv build.stamp $(DRAWBOT_OUTPUT)
 	git add documentation/*.png && git commit -m "Rebuild images" documentation/*.png

--- a/scripts/fontbakery.sh
+++ b/scripts/fontbakery.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Google Sans Project Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script co-ordinates the running of all Fontbakery check profiles, and
+# exiting non-zero if any of the suites failed. The name of the check profiles
+# that failed are also printed
+
+# Operates relative to the current working directory unless a positional
+# argument is given
+
+set -e
+
+BIGGEST_TTF_PATH="fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf"
+
+[[ -d "$1" ]] && cd "$1"
+
+# Setup venv with dependencies
+[ -n "$GITHUB_RUN_ID" ] && echo "::group::Set up venv"
+test -d venv_bakery || python3 -m venv venv_bakery
+venv_bakery/bin/pip install -U setuptools wheel pip
+# Install latest version of fontbakery on every run, isolated from build dependencies
+# fonttools[interpolatable] makes com.google.fonts/check/interpolation_issues around 5x faster
+venv_bakery/bin/pip install -U "fontbakery[googlefonts]" "fonttools[interpolatable]"
+[ -n "$GITHUB_RUN_ID" ] && echo "::endgroup::"
+mkdir -p out/fontbakery
+
+# All checks invocations are chained into `|| failed+=("test name")` so that:
+# 1. we know if any of the tests failed
+# 2. we don't immediately exit thanks to set -e
+# 3. we can give a nice error message later
+failed=()
+
+find sources/ -name "*.ufo" -print0 | xargs -0 venv_bakery/bin/fontbakery \
+    check-profile -l WARN --auto-jobs --succinct --no-progress \
+    --html out/fontbakery/fontbakery-sources-report.html \
+    qa/check-sources.py \
+    sources/GoogleSansFlex.designspace \
+    || failed+=("check-sources")
+
+venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
+    --html out/fontbakery/fontbakery-outlines-report.html \
+    fontbakery.profiles.outline "$BIGGEST_TTF_PATH" \
+    || failed+=("fontbakery.profiles.outline")
+
+venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
+    --html out/fontbakery/fontbakery-googlesans-report.html \
+    qa/check-googlesans.py "$BIGGEST_TTF_PATH" \
+    || failed+=("check-googlesans")
+
+venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
+    --html out/fontbakery/fontbakery-fea-report.html \
+    qa/check-fea.py "$BIGGEST_TTF_PATH" \
+    || failed+=("check-fea")
+
+# NOTE: The following checks can be activated after the sources are stable:
+# -venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-charset-report.html \
+#	qa/check-charset.py fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+# -venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-shaping-report.html \
+#	qa/check-shaping.py fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    # If on GitHub actions, make a posh GHA error
+    [ -n "$GITHUB_RUN_ID" ] && echo -n "::error title=Fontbakery fails::"
+    echo "The following Fontbakery profiles had fails/errors:" "${failed[@]}"
+    exit 1
+fi


### PR DESCRIPTION
* Fail pipeline if there are Fontbakery fails/errors
* Ensure all tests are run regardless of whether any fail
* Ensure reports are still uploaded even if the pipeline is going to fail
* Run the build (& test) workflow on pull requests & pushes to main
* Fix build workflow artifact name when downloading to run tests
* Fix debugging logging for `build-glyphs`
* Move Fontbakery logic into a script that can be used by both the Makefile and GitHub Actions