### PR TITLE
Stop clearing feature imports

### DIFF
--- a/scripts/glyphs_to_ds.py
+++ b/scripts/glyphs_to_ds.py
@@ -67,10 +67,6 @@ if __name__ == "__main__":
             if layer._is_brace_layer():
                 layer.name = layer._brace_layer_name()
 
-    # Clear feature imports.
-    # Motivation: glyphsLib tries to export disabled features
-    font.featurePrefixes = []
-
     ###############
     ### Convert ###
     ###############


### PR DESCRIPTION
This is no longer required; see #776.

## Results

From testing locally, the `family.fea` from V1 that remains in `sources/` is adopted and compiles correctly, and a sample of random features that I tested worked correctly (including the Romanian shaping referenced in #769).

To replicate this on the CI, we must merge this PR and re-import, as:
* The action that runs on this branch will use the workflow in `main`, not the adjusted workflow in this branch; and
* The sources will not contain any reference to `family.fea` until we do an import with the new workflow.