### PR TITLE
Build from Glyphs package: fix fontbakery invocation

### DIFF
--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -27,7 +27,7 @@ runs:
         exit 1
       fi
 
-      "${{ inputs.repo-path }}/scripts/fontbakery.sh" "${{ inputs.repo-path }}"
+      "${{ inputs.repo-path }}/scripts/fontbakery.sh"
   - name: Check with OT Sanitizer
     uses: f-actions/opentype-sanitizer@v2
     with:

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -27,7 +27,7 @@ runs:
         exit 1
       fi
 
-      scripts/fontbakery.sh "${{ inputs.repo-path }}"
+      "${{ inputs.repo-path }}/scripts/fontbakery.sh" "${{ inputs.repo-path }}"
   - name: Check with OT Sanitizer
     uses: f-actions/opentype-sanitizer@v2
     with:

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -34,7 +34,7 @@ runs:
       path: ${{ inputs.repo-path }}/fonts/variable/*.ttf
   - name: Analyze TTF file size
     shell: bash
-    run: make --directory ${{ inputs.repo-path }} font-size
+    run: make --directory "${{ inputs.repo-path }}" font-size
   - name: Upload Fontbakery reports
     uses: actions/upload-artifact@v3
     # Always upload reports (even during a pipeline fail), so long as Fontbakery completed

--- a/scripts/fontbakery.sh
+++ b/scripts/fontbakery.sh
@@ -16,14 +16,14 @@
 # exiting non-zero if any of the suites failed. The name of the check profiles
 # that failed are also printed
 
-# Operates relative to the current working directory unless a positional
-# argument is given
+# Assumes the repository is in the parent folder of where the script lives
 
 set -e
 
 BIGGEST_TTF_PATH="fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf"
 
-[[ -d "$1" ]] && cd "$1"
+# Switch to repo path by going to the parent folder of where this script is
+cd "$(dirname "${BASH_SOURCE[0]}" | xargs dirname)"
 
 # Setup venv with dependencies
 [ -n "$GITHUB_RUN_ID" ] && echo "::group::Set up venv"


### PR DESCRIPTION
Fixes the script not being found when using the `build-glyphs` workflow by providing the correct path

Also made a small improvement to the `fontbakery.sh` script itself, it's now slightly smarter 🧠 

All tested to work!