### PR TITLE
GitHub workflows: fix tests rebuilding

### DIFF
--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -36,7 +36,9 @@ runs:
     run: make --directory "${{ inputs.repo-path }}" font-size
   - name: Run shaperglot
     shell: bash
-    run: make --directory "${{ inputs.repo-path }}" shaperglot
+    run: |
+      touch "${{ inputs.repo-path }}/build.stamp"
+      make --directory "${{ inputs.repo-path }}" shaperglot
   - name: Upload shaperglot report
     uses: actions/upload-artifact@v3
     with:

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -18,6 +18,8 @@ runs:
   - name: Avoid re-building fonts
     shell: bash
     run: |
+      python -m venv "${{ inputs.repo-path }}/venv"
+      touch "${{ inputs.repo-path }}/venv/touchfile"
       if [ -d "${{ inputs.repo-path }}/fonts/variable" ]; then
         # Trick make into not re-building the fonts
         touch "${{ inputs.repo-path }}/build.stamp"


### PR DESCRIPTION
The tests are meant to download the fonts from the previous build step, but for *reasons* they've started being re-built by `make`. This two commits mitigate the issue. Should reduce CI time :)