### PR TITLE
GitHub Actions: update 3rd party actions to Node 20

### DIFF
--- a/.github/actions/build-ufos-py/action.yml
+++ b/.github/actions/build-ufos-py/action.yml
@@ -41,7 +41,7 @@ runs:
       overrides: |
         build-glyphs: glyphs
   - name: Upload archive
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: ${{ steps.zip-name.outputs.artifact-name }}
       path: ${{ inputs.repo-path }}/fonts/variable

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
   - name: Set up Python
-    uses: actions/setup-python@v4
+    uses: actions/setup-python@v5
     with:
       python-version-file: ${{ inputs.repo-path }}/.github/workflows/python-version.txt
       cache: pip

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -28,7 +28,7 @@ runs:
         exit 1
       fi
   - name: Check with OT Sanitizer
-    uses: f-actions/opentype-sanitizer@v2
+    uses: f-actions/opentype-sanitizer@v3
     with:
       path: ${{ inputs.repo-path }}/fonts/variable/*.ttf
   - name: Analyze TTF file size

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -40,7 +40,7 @@ runs:
       touch "${{ inputs.repo-path }}/build.stamp"
       make --directory "${{ inputs.repo-path }}" shaperglot
   - name: Upload shaperglot report
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: Shaperglot report
       path: ${{ inputs.repo-path }}/out/shaperglot.txt
@@ -49,7 +49,7 @@ runs:
     shell: bash
     run: "${{ inputs.repo-path }}/scripts/fontbakery.sh"
   - name: Upload Fontbakery reports
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     # Always upload reports (even during a pipeline fail), so long as Fontbakery completed
     # https://docs.github.com/en/actions/learn-github-actions/expressions#always
     # https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context

--- a/.github/workflows/build-glyphs.yml
+++ b/.github/workflows/build-glyphs.yml
@@ -26,7 +26,7 @@ jobs:
           exit 1
         fi
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version-file: ./main/.github/workflows/python-version.txt
         cache: pip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
       with:
         ref: ${{ inputs.git-ref || github.head_ref || github.ref_name }}
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version-file: ./.github/workflows/python-version.txt
         cache: pip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Checkout main
       uses: actions/checkout@v4
     - name: Download built fonts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ needs.build.outputs.artifact-name }}
         path: fonts/variable
@@ -63,7 +63,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Download artifact files
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ needs.build.outputs.artifact-name }}
         path: ${{ needs.build.outputs.artifact-name }}

--- a/.github/workflows/burndown.yml
+++ b/.github/workflows/burndown.yml
@@ -26,7 +26,7 @@ jobs:
           PROGRESS_BURNDOWN_CACHING: 1
         run: make progress-chart
       - name: Upload chart
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gs-flex-progress
           path: gs-flex-progress.png

--- a/.github/workflows/burndown.yml
+++ b/.github/workflows/burndown.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all so we get access to all tags, etc.
       - name: Set up Python 3.x
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
           cache: pip

--- a/.github/workflows/diffenator.yaml
+++ b/.github/workflows/diffenator.yaml
@@ -19,7 +19,7 @@ jobs:
           cache: 'pip'
       - name: Build fonts
         run: make build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: variable-fonts
           path: 'fonts/variable'
@@ -39,7 +39,7 @@ jobs:
         with:
           python-version: '3.x'
           cache: 'pip'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: variable-fonts
           path: 'fonts/variable'
@@ -67,7 +67,7 @@ jobs:
         with:
           python-version: '3.x'
           cache: 'pip'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: variable-fonts
           path: 'fonts/variable'

--- a/.github/workflows/diffenator.yaml
+++ b/.github/workflows/diffenator.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v3
       - name: Set up Python v3.x environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -35,7 +35,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v3
       - name: Set up Python v3.x environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
           cache: 'pip'
@@ -63,7 +63,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v3
       - name: Set up Python v3.x environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
           cache: 'pip'

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -30,7 +30,7 @@ jobs:
           ref: main
           path: main
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version-file: ./main/.github/workflows/python-version.txt
           cache: pip
@@ -58,7 +58,7 @@ jobs:
         with:
           ref: ${{ needs.import-branch.outputs.import-branch }}
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version-file: ./.github/workflows/python-version.txt
           cache: pip

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -79,7 +79,7 @@ jobs:
         with:
           ref: ${{ needs.import-branch.outputs.import-branch }}
       - name: Download built fonts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build-variable.outputs.variable-artifact }}
           path: fonts/variable


### PR DESCRIPTION
GitHub has deprecated actions that run using Node 16, so we should look to move off of them

I'll keep this PR in draft until I've managed to get all our actions moved updated. A lot of big actions (e.g. `actions/download-artifact`) haven't finished migrating yet

- [x] `actions/setup-python`
- [x] `actions/upload-artifact`
- [x] `actions/download-artifact`
- [x] `f-actions/opentype-sanitizer` (https://github.com/f-actions/opentype-sanitizer/pull/79)