### PR TITLE
Revert STAT changes & use range for ExtraExpanded

### DIFF
--- a/sources/config.yaml
+++ b/sources/config.yaml
@@ -112,6 +112,9 @@ stat:
         - flags: 0
           name: ExtraExpanded
           value: 150.0
+          rangeMinValue: 150.0
+          nominalValue: 150.0
+          rangeMaxValue: 151.0
     - name: Weight
       tag: wght
       values:

--- a/sources/config.yaml
+++ b/sources/config.yaml
@@ -119,6 +119,9 @@ stat:
       tag: wght
       values:
         - flags: 0
+          name: Hairline
+          value: 1.0
+        - flags: 0
           name: Thin
           value: 100.0
         - flags: 0
@@ -146,6 +149,9 @@ stat:
         - flags: 0
           name: Black
           value: 900.0
+        - flags: 0
+          name: UltraBlack
+          value: 1000.0
     - name: Grade
       tag: GRAD
       values:
@@ -158,6 +164,9 @@ stat:
         - flags: 2
           name: Default
           value: 0.0
+        - flags: 0
+          name: Rounded
+          value: 100.0
     - name: Slant
       tag: slnt
       values:

--- a/sources/config.yaml
+++ b/sources/config.yaml
@@ -111,13 +111,10 @@ stat:
           value: 125.0
         - flags: 0
           name: ExtraExpanded
-          value: 151.0
+          value: 150.0
     - name: Weight
       tag: wght
       values:
-        - flags: 0
-          name: Hairline
-          value: 1.0
         - flags: 0
           name: Thin
           value: 100.0
@@ -146,27 +143,18 @@ stat:
         - flags: 0
           name: Black
           value: 900.0
-        - flags: 0
-          name: UltraBlack
-          value: 1000.0
     - name: Grade
       tag: GRAD
       values:
         - flags: 2
           name: Normal
           value: 0.0
-        - flags: 0
-          name: Grade
-          value: 100.0
     - name: Roundness
       tag: ROND
       values:
         - flags: 2
           name: Default
           value: 0.0
-        - flags: 0
-          name: Round
-          value: 100.0
     - name: Slant
       tag: slnt
       values:


### PR DESCRIPTION
Reverts #834 except for 6pt opsz

Also, adds a range to the ExtraExpanded wght extreme. This is in a separate commit if we decide against this

Related issues: #774 & #835 