### PR TITLE
Fix breakages caused by `vharfbuzz` v0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,8 @@ glyph-hunt: venv
 	. venv/bin/activate && python scripts/glyph-hunt.py --glyph-list .github/actions/import/glyph-list.txt --ds sources/regular/GoogleSansFlex.designspace
 
 shaperglot: venv build
-	venv/bin/pip install -U shaperglot
+# FIXME: shaperglot pulls in vharfbuzz v0.3 by default, which it doesn't support
+# remove this when https://github.com/googlefonts/shaperglot/issues/41 is closed
+	venv/bin/pip install -U shaperglot "vharfbuzz<0.3.0"
 	mkdir -p out
 	xargs venv/bin/shaperglot check fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf < qa/target_langs.txt | tee out/shaperglot.txt

--- a/scripts/fontbakery.sh
+++ b/scripts/fontbakery.sh
@@ -32,7 +32,8 @@ venv_bakery/bin/pip install -U setuptools wheel pip
 # Install latest version of fontbakery on every run, isolated from build dependencies
 # fonttools[interpolatable] makes com.google.fonts/check/interpolation_issues around 5x faster
 # TODO: Remove version pin after fonttools/fontbakery#4479 is fixed.
-venv_bakery/bin/pip install -U "fontbakery[googlefonts]<=0.10.9" "fonttools[interpolatable]"
+# TODO: Remove vharfbuzz constraint after https://github.com/fonttools/fontbakery/issues/4499 is solved and we unpin fontbakery
+venv_bakery/bin/pip install -U "fontbakery[googlefonts]<=0.10.9" "fonttools[interpolatable]" "vharfbuzz<0.3.0"
 [ -n "$GITHUB_RUN_ID" ] && echo "::endgroup::"
 mkdir -p out/fontbakery
 


### PR DESCRIPTION
Fontbakery was getting an ERROR, and Shaperglot also wasn't running

Tracking issues on their respective repositories:
- https://github.com/fonttools/fontbakery/issues/4499
- https://github.com/googlefonts/shaperglot/issues/41