### PR TITLE
Fix Fontbakery hang & reduce max job durations

### DIFF
--- a/.github/workflows/build-glyphs.yml
+++ b/.github/workflows/build-glyphs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   convert-build-test:
     runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 60
+    timeout-minutes: 50
     steps:
     - name: Checkout main
       uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   build:
     runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 60
+    timeout-minutes: 15
     steps:
     # on: pull_request uses head_ref for branch name, on: push uses ref_name
     - name: Checkout ${{ inputs.git-ref || github.head_ref || github.ref_name }}
@@ -38,7 +38,7 @@ jobs:
       artifact-name: ${{ steps.build-ufos.outputs.artifact-name }}
   test:
     runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 60
+    timeout-minutes: 20
     needs:
     - build
     steps:

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   import-branch:
     runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 60
+    timeout-minutes: 15
     steps:
       - name: Log & validate inputs
         run: |
@@ -50,7 +50,7 @@ jobs:
       import-branch: ${{ steps.create-update-import.outputs.import-branch }}
   build-variable:
     runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 60
+    timeout-minutes: 15
     needs: import-branch
     steps:
       - name: Checkout ${{ needs.import-branch.outputs.import-branch }}
@@ -69,7 +69,7 @@ jobs:
       variable-artifact: ${{ steps.build-ufos.outputs.artifact-name }}
   test:
     runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 60
+    timeout-minutes: 20
     needs:
       - import-branch
       - build-variable

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -62,6 +62,7 @@ excluded_check_ids = [
     "com.google.fonts/check/STAT_strings",  # we're intentionally calling slant italic https://github.com/googlefonts/googlesans-flex/issues/774#issuecomment-1921326716
     "com.google.fonts/check/STAT",  # https://github.com/googlefonts/googlesans-flex/issues/835#issuecomment-1930057206
     "com.google.fonts/check/fontbakery_version",  # ignore this while we have Fontbakery pinned
+    "com.google.fonts/check/metadata/unreachable_subsetting",  # causes hang: https://github.com/googlefonts/googlesans-flex/issues/854
 ]
 
 # Each VF we build will have one of these suffixes depending on whether it


### PR DESCRIPTION
Related to #854 

Follow-up with better fix to come, issue is likely caused by pinning only Fontbakery and not its dependencies