### PR TITLE
Use hotfix branch of glyphslib & update sources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -148,8 +148,9 @@ gitpython==3.1.41
     # via font-v
 glyphsets==0.6.5
     # via gftools
-glyphslib==6.4.1
+glyphslib @ git+https://github.com/googlefonts/glyphsLib@no-width-linking-of-bracelayers
     # via
+    #   https://github.com/googlefonts/googlesans-flex/issues/855
     #   -r requirements.in
     #   babelfont
     #   bumpfontversion

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs.{6, 100, 699, 0, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs.{6, 100, 699, 0, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="1115"/>
+  <advance width="1122"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs.{6, 100, 700, 0, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/glyphs.{6, 100, 700, 0, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="1115"/>
+  <advance width="1122"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs.{6, 100, 699, 100, 0, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs.{6, 100, 699, 100, 0, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="1115"/>
+  <advance width="1122"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs.{6, 100, 700, 100, 0, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/glyphs.{6, 100, 700, 100, 0, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="1115"/>
+  <advance width="1122"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs.{6, 100, 699, 100, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs.{6, 100, 699, 100, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="1115"/>
+  <advance width="1122"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs.{6, 100, 700, 100, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/glyphs.{6, 100, 700, 100, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="1115"/>
+  <advance width="1122"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs.{6, 151, 699, 0, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs.{6, 151, 699, 0, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="1400"/>
+  <advance width="1489"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs.{6, 151, 700, 0, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/glyphs.{6, 151, 700, 0, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="1400"/>
+  <advance width="1489"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs.{6, 151, 699, 100, 0, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs.{6, 151, 699, 100, 0, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="1400"/>
+  <advance width="1489"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs.{6, 151, 700, 100, 0, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/glyphs.{6, 151, 700, 100, 0, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="1400"/>
+  <advance width="1489"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs.{6, 151, 699, 100, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs.{6, 151, 699, 100, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="1400"/>
+  <advance width="1489"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs.{6, 151, 700, 100, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/glyphs.{6, 151, 700, 100, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="1400"/>
+  <advance width="1489"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs.{144, 25, 699, 0, 100, -10}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs.{144, 25, 699, 0, 100, -10}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="464"/>
+  <advance width="707"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs.{144, 25, 700, 0, 100, -10}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/glyphs.{144, 25, 700, 0, 100, -10}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="464"/>
+  <advance width="707"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs.{144, 25, 699, 0, 100, 0}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs.{144, 25, 699, 0, 100, 0}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="438"/>
+  <advance width="604"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs.{144, 25, 699, 0, 100, 0}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs.{144, 25, 699, 0, 100, 0}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="472"/>
+  <advance width="708"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs.{144, 25, 700, 0, 100, 0}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs.{144, 25, 700, 0, 100, 0}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="438"/>
+  <advance width="604"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs.{144, 25, 700, 0, 100, 0}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/glyphs.{144, 25, 700, 0, 100, 0}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="472"/>
+  <advance width="708"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs.{144, 25, 699, 100, 0, -10}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs.{144, 25, 699, 100, 0, -10}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="464"/>
+  <advance width="707"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs.{144, 25, 700, 100, 0, -10}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/glyphs.{144, 25, 700, 100, 0, -10}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="464"/>
+  <advance width="707"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs.{144, 25, 699, 100, 0, 0}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs.{144, 25, 699, 100, 0, 0}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="438"/>
+  <advance width="604"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs.{144, 25, 699, 100, 0, 0}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs.{144, 25, 699, 100, 0, 0}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="472"/>
+  <advance width="708"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs.{144, 25, 700, 100, 0, 0}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs.{144, 25, 700, 100, 0, 0}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="438"/>
+  <advance width="604"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs.{144, 25, 700, 100, 0, 0}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/glyphs.{144, 25, 700, 100, 0, 0}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="472"/>
+  <advance width="708"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs.{144, 25, 699, 100, 100, -10}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs.{144, 25, 699, 100, 100, -10}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="464"/>
+  <advance width="707"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs.{144, 25, 700, 100, 100, -10}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/glyphs.{144, 25, 700, 100, 100, -10}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="464"/>
+  <advance width="707"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs.{144, 25, 699, 100, 100, 0}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs.{144, 25, 699, 100, 100, 0}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="438"/>
+  <advance width="604"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs.{144, 25, 699, 100, 100, 0}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs.{144, 25, 699, 100, 100, 0}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="472"/>
+  <advance width="708"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs.{144, 25, 700, 100, 100, 0}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs.{144, 25, 700, 100, 100, 0}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="438"/>
+  <advance width="604"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs.{144, 25, 700, 100, 100, 0}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/glyphs.{144, 25, 700, 100, 100, 0}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="472"/>
+  <advance width="708"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs.{18, 25, 699, 0, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs.{18, 25, 699, 0, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="590"/>
+  <advance width="973"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs.{18, 25, 699, 0, 100, -10}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs.{18, 25, 699, 0, 100, -10}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="629"/>
+  <advance width="856"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs.{18, 25, 700, 0, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs.{18, 25, 700, 0, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="590"/>
+  <advance width="973"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs.{18, 25, 700, 0, 100, -10}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/glyphs.{18, 25, 700, 0, 100, -10}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="629"/>
+  <advance width="856"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs.{18, 25, 699, 0, 100, 0}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs.{18, 25, 699, 0, 100, 0}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="590"/>
+  <advance width="974"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs.{18, 25, 699, 0, 100, 0}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs.{18, 25, 699, 0, 100, 0}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="636"/>
+  <advance width="839"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs.{18, 25, 700, 0, 100, 0}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs.{18, 25, 700, 0, 100, 0}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="590"/>
+  <advance width="974"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs.{18, 25, 700, 0, 100, 0}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/glyphs.{18, 25, 700, 0, 100, 0}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="636"/>
+  <advance width="839"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs.{18, 25, 699, 100, 0, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs.{18, 25, 699, 100, 0, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="590"/>
+  <advance width="973"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs.{18, 25, 699, 100, 0, -10}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs.{18, 25, 699, 100, 0, -10}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="629"/>
+  <advance width="856"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs.{18, 25, 700, 100, 0, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs.{18, 25, 700, 100, 0, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="590"/>
+  <advance width="973"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs.{18, 25, 700, 100, 0, -10}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/glyphs.{18, 25, 700, 100, 0, -10}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="629"/>
+  <advance width="856"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs.{18, 25, 699, 100, 0, 0}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs.{18, 25, 699, 100, 0, 0}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="590"/>
+  <advance width="974"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs.{18, 25, 699, 100, 0, 0}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs.{18, 25, 699, 100, 0, 0}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="636"/>
+  <advance width="839"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs.{18, 25, 700, 100, 0, 0}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs.{18, 25, 700, 100, 0, 0}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="590"/>
+  <advance width="974"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs.{18, 25, 700, 100, 0, 0}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/glyphs.{18, 25, 700, 100, 0, 0}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="636"/>
+  <advance width="839"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs.{18, 25, 699, 100, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs.{18, 25, 699, 100, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="590"/>
+  <advance width="973"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs.{18, 25, 699, 100, 100, -10}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs.{18, 25, 699, 100, 100, -10}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="629"/>
+  <advance width="856"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs.{18, 25, 700, 100, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs.{18, 25, 700, 100, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="590"/>
+  <advance width="973"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs.{18, 25, 700, 100, 100, -10}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/glyphs.{18, 25, 700, 100, 100, -10}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="629"/>
+  <advance width="856"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs.{18, 25, 699, 100, 100, 0}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs.{18, 25, 699, 100, 100, 0}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="590"/>
+  <advance width="974"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs.{18, 25, 699, 100, 100, 0}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs.{18, 25, 699, 100, 100, 0}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="636"/>
+  <advance width="839"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs.{18, 25, 700, 100, 100, 0}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs.{18, 25, 700, 100, 100, 0}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="590"/>
+  <advance width="974"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs.{18, 25, 700, 100, 100, 0}/dollar.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/glyphs.{18, 25, 700, 100, 100, 0}/dollar.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dollar" format="2">
-  <advance width="636"/>
+  <advance width="839"/>
   <unicode hex="0024"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs.{6, 25, 699, 0, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs.{6, 25, 699, 0, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="991"/>
+  <advance width="1062"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs.{6, 25, 700, 0, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/glyphs.{6, 25, 700, 0, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="991"/>
+  <advance width="1062"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs.{6, 25, 699, 100, 0, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs.{6, 25, 699, 100, 0, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="991"/>
+  <advance width="1062"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs.{6, 25, 700, 100, 0, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/glyphs.{6, 25, 700, 100, 0, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="991"/>
+  <advance width="1062"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs.{6, 25, 699, 100, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs.{6, 25, 699, 100, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="991"/>
+  <advance width="1062"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs.{6, 25, 700, 100, 100, -10}/cent.glif
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/glyphs.{6, 25, 700, 100, 100, -10}/cent.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cent" format="2">
-  <advance width="991"/>
+  <advance width="1062"/>
   <unicode hex="00A2"/>
   <outline>
     <contour>

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -298,9 +298,6 @@ feature calt {
 } calt;
 
 feature ss01 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Single-story a";
         name 1 "Single-story a";
@@ -309,9 +306,6 @@ featureNames {
 } ss01;
 
 feature ss02 {
-featureNames {
-  name "";
-};
 	featureNames {
         name "Double-story g";
         name 1 "Double-story g";


### PR DESCRIPTION
Updated our requirements.txt to use the [`no-width-linking-of-bracelayers` branch](https://github.com/googlefonts/glyphsLib/tree/no-width-linking-of-bracelayers)

I then re-did the most recent import to update the sources with only the changes caused by the different glyphslib. You can see a lot of glyph widths changing (yay!) as well as some empty feature blocks getting removed

Fixes #811 and closes #855 🎉 