### PR TITLE
Reduce log spam from `com.google.fonts/check/googlesansflex/sources/suspicious_kerning_values`

### DIFF
--- a/qa/check-sources.py
+++ b/qa/check-sources.py
@@ -59,7 +59,10 @@ def check_same_tabular_widths(ufo_font: Font) -> CheckStatus:
             width_glyph = next(iter(tabulars))
         width = layer[width_glyph].width
         if width is None:
-            yield FAIL, f"layer {layer.name}: {width_glyph} has no width, stopping check"
+            yield (
+                FAIL,
+                f"layer {layer.name}: {width_glyph} has no width, stopping check",
+            )
             return
 
         for name in tabulars:
@@ -150,7 +153,10 @@ def check_same_kerning_groups(ds: DesignSpaceDocument) -> CheckStatus:
         if source.font.groups == reference:
             yield PASS, f"{source.filename} has same kerning groups as default source"
         else:
-            yield WARN, f"{source.filename} does not have the same kerning groups as default source"
+            yield (
+                WARN,
+                f"{source.filename} does not have the same kerning groups as default source",
+            )
 
 
 @check(id="com.google.fonts/check/googlesansflex/sources/kerning_present")
@@ -180,9 +186,15 @@ def check_kerning_present(ds: DesignSpaceDocument) -> CheckStatus:
             effective_kerning[(first, second)] = value
 
         if effective_kerning:
-            yield INFO, f"{source.filename}: Found {len(effective_kerning)} kerning pairs (not counting exceptions)"
+            yield (
+                INFO,
+                f"{source.filename}: Found {len(effective_kerning)} kerning pairs (not counting exceptions)",
+            )
         else:
-            yield WARN, f"{source.filename}: Found no kerning pairs (not counting exceptions)"
+            yield (
+                WARN,
+                f"{source.filename}: Found no kerning pairs (not counting exceptions)",
+            )
 
 
 profile.auto_register(globals())

--- a/qa/check-sources.py
+++ b/qa/check-sources.py
@@ -21,6 +21,7 @@ from fontbakery.fonts_profile import profile_factory
 from fontbakery.message import Message
 from fontbakery.section import Section
 from fontbakery.status import FAIL, INFO, PASS, SKIP, WARN, Status
+from fontbakery import utils
 from fontTools.designspaceLib import DesignSpaceDocument
 from ufoLib2 import Font
 
@@ -84,7 +85,7 @@ def check_same_tabular_widths(ufo_font: Font) -> CheckStatus:
 
 
 @check(id="com.google.fonts/check/googlesansflex/sources/suspicious_kerning_values")
-def check_suspicious_kerning_values(ufo_font: Font) -> CheckStatus:
+def check_suspicious_kerning_values(ufo_font: Font, config) -> CheckStatus:
     """Check for small and large kerning values outside a range and other
     things."""
 
@@ -121,19 +122,24 @@ def check_suspicious_kerning_values(ufo_font: Font) -> CheckStatus:
     if not suspicious_kerning:
         yield PASS, "No suspicion raised"
     else:
-        txt = [
-            f"Kerning values outside the accepted range of [{threshold_low}, {threshold_high}]:",
-            "",
-            *(
-                f"* Pair {pair} (e.g. {example}): {value}"
-                for (pair, example, value) in suspicious_kerning
+        yield (
+            WARN,
+            Message(
+                "suspicious-kerning-values",
+                f"Kerning values outside the accepted range of [{threshold_low}, {threshold_high}]:\n\n"
+                f"""{utils.bullet_list(
+                    config,
+                    [
+                        f"Pair {pair} (e.g. {example}): {value}"
+                        for (pair, example, value) in suspicious_kerning
+                    ],
+                )}""",
             ),
-        ]
-        yield WARN, "\n".join(txt)
+        )
 
 
 @check(id="com.google.fonts/check/googlesansflex/sources/same_kerning_groups")
-def check_same_kerning_groupss(ds: DesignSpaceDocument) -> CheckStatus:
+def check_same_kerning_groups(ds: DesignSpaceDocument) -> CheckStatus:
     """Confirms that all sources have the same kerning groups per Designspace."""
 
     default_source = ds.findDefault()

--- a/qa/check-sources.py
+++ b/qa/check-sources.py
@@ -44,7 +44,7 @@ def ds(designspace: str) -> DesignSpaceDocument:
 
 
 @check(id="com.google.fonts/check/googlesansflex/sources/same_tabular_width")
-def check_same_tabular_widths(ufo_font: Font) -> CheckStatus:
+def check_same_tabular_widths(ufo_font: Font, config) -> CheckStatus:
     """Confirms that tabular glyphs have the same width within the same master."""
 
     warnings_by_layer = {}
@@ -76,15 +76,15 @@ def check_same_tabular_widths(ufo_font: Font) -> CheckStatus:
         yield PASS, "Tabular glyphs, if they exist, have the same width"
     else:
         for layer_name, warnings in warnings_by_layer.items():
-            txt = [
-                f"layer '{layer_name}':",
-                "",
-                *(
-                    f"* {name} ({width}) has different width than {ref_name} ({ref_width})"
-                    for (name, width, ref_name, ref_width) in warnings
+            yield (
+                FAIL,
+                Message(
+                    "mismatching-tabular-widths",
+                    f"layer '{layer_name}':\n\n"
+                    f"""{utils.bullet_list(config, [f"{name} ({width}) has different width than {ref_name} ({ref_width})"
+                     for (name, width, ref_name, ref_width) in warnings])}""",
                 ),
-            ]
-            yield FAIL, "\n".join(txt)
+            )
 
 
 @check(id="com.google.fonts/check/googlesansflex/sources/suspicious_kerning_values")


### PR DESCRIPTION
Use Fontbakery's built-in list utility so that it limits the number of items printed by default. This should massively reduce the ~12k log lines we've been seeing of late