### PR TITLE
Tests: fix downloading built fonts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
-        path: ${{ inputs.repo-path }}/fonts/variable
+        path: fonts/variable
     - name: Avoid re-building fonts
       shell: bash
       run: |


### PR DESCRIPTION
Remove reference to `repo-path` which no longer exists

Sorry for missing this! Removing `repo-path` was one of the more last minute simplifications and so wasn't as thoroughly tested

Note the pipeline for this PR will fail as the tests workflow that's run is always the one from `main`. Merging this PR however will fix the issue