### PR TITLE
Add release target to cut statics

### DIFF
--- a/.github/workflows/build-glyphs.yml
+++ b/.github/workflows/build-glyphs.yml
@@ -77,6 +77,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ./.github/workflows/python-version.txt
+        cache: pip
     - name: Build fonts
       id: build-ufos
       uses: ./.github/actions/build-ufos-py

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,12 +9,8 @@ on:
   push:
     branches:
       - main
-    tags:
   pull_request:
     types: [opened, synchronize, reopened]
-  release:
-    # A release, pre-release, or draft of a release was published
-    types: [published]
 
 jobs:
   build:
@@ -43,33 +39,3 @@ jobs:
     with:
       branch: ${{ inputs.git-ref || github.head_ref || github.ref_name }}
       artifact-name: ${{ needs.build.outputs.artifact-name }}
-  release:
-    # Only run if the commit is tagged...
-    if: github.event_name == 'release'
-    # ... and it builds successfully
-    needs:
-    - build
-    - test
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@v4
-    - name: Download artifact files
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ needs.build.outputs.artifact-name }}
-        path: ${{ needs.build.outputs.artifact-name }}
-    - name: Create release archive
-      run: |
-        release_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/}.zip"
-        echo "RELEASE_ZIP_NAME=$release_zip_name" >> "$GITHUB_ENV"
-        cd "${{ needs.build.outputs.artifact-name }}" && zip "../$release_zip_name" *.ttf
-    - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ env.RELEASE_ZIP_NAME }}
-        asset_name: ${{ env.RELEASE_ZIP_NAME }}
-        tag: ${{ github.ref }}
-        overwrite: true
-        body: "Production ready fonts"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release variable & statics
+
+on:
+  release:
+    # A release, pre-release, or draft of a release was published
+    types: [published]
+
+jobs:
+  build-variable:
+    runs-on: [linux, googlefonts-64cores-256GB]
+    timeout-minutes: 15
+    steps:
+    - name: Checkout ${{ github.ref_name }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref_name }}
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: ./.github/workflows/python-version.txt
+        cache: pip
+    - name: Build font
+      id: build-ufos
+      uses: ./.github/actions/build-ufos-py
+    outputs:
+      artifact-name: ${{ steps.build-ufos.outputs.artifact-name }}
+  cut-instances:
+    needs:
+    - build-variable
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Checkout ${{ github.ref_name }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref_name }}
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: ./.github/workflows/python-version.txt
+        cache: pip
+    - name: Download artifact files
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ needs.build-variable.outputs.artifact-name }}
+        path: fonts/variable
+    - name: Set up venv
+      run: make venv
+    - name: Cut instances
+      run: |
+        touch build.stamp # don't rebuild fonts
+        . venv/bin/activate && make release
+    - name: Generate archive name
+      id: zip-name
+      uses: alpha-tango-kilo/gha-artifact-name@v1
+      with:
+        repo-name: Google Sans Flex
+        overrides: "release: statics"
+    - name: Upload archive
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.zip-name.outputs.artifact-name }}
+        path: fonts/ttf
+        compression-level: 9
+        if-no-files-found: error
+    outputs:
+      artifact-name: ${{ steps.zip-name.outputs.artifact-name }}
+  test-variable:
+    needs:
+    - build-variable
+    uses: googlefonts/googlesans-flex/.github/workflows/tests.yml@main
+    with:
+      branch: ${{ github.ref_name }}
+      artifact-name: ${{ needs.build-variable.outputs.artifact-name }}
+  # test-statics:
+  #   needs:
+  #   - cut-instances
+  upload-to-release:
+    needs:
+    - build-variable
+    - cut-instances
+    - test-variable
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Download variable fonts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ needs.build-variable.outputs.artifact-name }}
+        path: ${{ needs.build-variable.outputs.artifact-name }}
+    - name: Download static fonts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ needs.cut-instances.outputs.artifact-name }}
+        path: ${{ needs.cut-instances.outputs.artifact-name }}
+    - name: Create release archives
+      id: release-archives
+      run: |
+        # Note: unsupported characters (such as spaces) are changes for periods
+        #       when uploading to the release
+        variable_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/}.zip"
+        echo "variable-zip-name=$variable_zip_name" >> "$GITHUB_OUTPUT"
+        cd "$GITHUB_WORKSPACE/${{ needs.build-variable.outputs.artifact-name }}" \
+          && zip -9 "../$variable_zip_name" *.ttf
+
+        statics_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} workspace statics.zip"
+        echo "statics-zip-name=$statics_zip_name" >> "$GITHUB_OUTPUT"
+        cd "$GITHUB_WORKSPACE/${{ needs.cut-instances.outputs.artifact-name }}" \
+          && zip -9 "../$statics_zip_name" *.ttf
+    - name: Upload variable font archive to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        file: ${{ steps.release-archives.outputs.variable-zip-name }}
+        overwrite: true
+        body: "Production ready fonts"
+    - name: Upload static fonts archive to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        file: ${{ steps.release-archives.outputs.statics-zip-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,14 +72,47 @@ jobs:
     with:
       branch: ${{ github.ref_name }}
       artifact-name: ${{ needs.build-variable.outputs.artifact-name }}
-  # test-statics:
-  #   needs:
-  #   - cut-instances
+  test-statics:
+    needs:
+    - cut-instances
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - name: Checkout ${{ github.ref_name }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref_name }}
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: ./.github/workflows/python-version.txt
+        cache: pip
+    - name: Download static fonts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ needs.cut-instances.outputs.artifact-name }}
+        path: fonts/ttf
+    - name: Run Fontbakery
+      id: fontbakery-statics
+      env:
+        SKIP_SOURCES: 1
+      run: scripts/fontbakery.sh
+    - name: Upload Fontbakery reports
+      uses: actions/upload-artifact@v4
+      # Always upload reports (even during a pipeline fail), so long as Fontbakery completed
+      # https://docs.github.com/en/actions/learn-github-actions/expressions#always
+      # https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
+      if: ${{ !cancelled() && (steps.fontbakery-statics.conclusion == 'success' || steps.fontbakery-statics.conclusion == 'failure') }}
+      with:
+        name: Fontbakery statics reports
+        path: out/fontbakery
+        if-no-files-found: error
   upload-to-release:
     needs:
     - build-variable
     - cut-instances
     - test-variable
+    - test-statics
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   cut-instances:
     needs:
     - build-variable
-    runs-on: ubuntu-latest
+    runs-on: [linux, googlefonts-64cores-256GB]
     timeout-minutes: 10
     steps:
     - name: Checkout ${{ github.ref_name }}
@@ -75,8 +75,8 @@ jobs:
   test-statics:
     needs:
     - cut-instances
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    runs-on: [linux, googlefonts-64cores-256GB]
+    timeout-minutes: 20
     steps:
     - name: Checkout ${{ github.ref_name }}
       uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,13 @@ venv/touchfile: requirements.txt
 test: build.stamp
 	@scripts/fontbakery.sh
 
+release: build.stamp
+	-@rm fonts/ttf/*.ttf
+	python scripts/cut_instances.py \
+		fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf \
+		sources/GoogleSansFlex.designspace \
+		fonts/ttf
+
 run-collidoscope: build.stamp
 # Install latest version of fontbakery on every run, isolated from build dependencies
 	test -d venv_bakery || python3 -m venv venv_bakery

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -62,7 +62,10 @@ excluded_check_ids = [
     "com.google.fonts/check/STAT_strings",  # we're intentionally calling slant italic https://github.com/googlefonts/googlesans-flex/issues/774#issuecomment-1921326716
     "com.google.fonts/check/STAT",  # https://github.com/googlefonts/googlesans-flex/issues/835#issuecomment-1930057206
     "com.google.fonts/check/fontbakery_version",  # ignore this while we have Fontbakery pinned
-    "com.google.fonts/check/glyphsets/shape_languages",  # we do our own shpaerglot check
+    "com.google.fonts/check/glyphsets/shape_languages",  # we do our own shaperglot check
+    "com.google.fonts/check/family/single_directory",  # conflicts with gftools' folder structure
+    "com.adobe.fonts/check/family/consistent_family_name",  # intended with our statics
+    "com.google.fonts/check/name/family_and_style_max_length",  # we know our statics exceed this limit and it's okay
 ]
 
 # Each VF we build will have one of these suffixes depending on whether it

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -85,10 +85,6 @@ TARGET_INSTANCES: dict[str, WorkspaceInstance] = {
     },
 }
 
-# As of 76995cc95c, all UFO masters use these PANOSE values
-# Inspect what masters use what PANOSE with scripts/one-off/panose_info.py
-DEFAULT_PANOSE = [2, 11, 5, 3, 3, 5, 2, 4, 2, 4]
-
 # Global Google Sans attributes, in 1000 upM font units.
 # These need to be kept in sync with qa/check-googlesans.py to avoid FB fails
 GS_OS2_ATTRIBUTES_UPRIGHT = {
@@ -117,7 +113,6 @@ GS_OS2_ATTRIBUTES_ITALIC = {
 def cut_instance(
     variable_font: Path,
     user_location: GoogleSansFlexInstance,
-    panose_values: list[int],
     family_name: str | None,
     style_name: str | None,
     output_file: Path,
@@ -142,18 +137,7 @@ def cut_instance(
 
     font["OS/2"].recalcAvgCharWidth(font)
 
-    panose = Panose()
-    panose.bFamilyType = panose_values[0]
-    panose.bSerifStyle = panose_values[1]
-    panose.bWeight = panose_values[2]
-    panose.bProportion = panose_values[3]
-    panose.bContrast = panose_values[4]
-    panose.bStrokeVariation = panose_values[5]
-    panose.bArmStyle = panose_values[6]
-    panose.bLetterForm = panose_values[7]
-    panose.bMidline = panose_values[8]
-    panose.bXHeight = panose_values[9]
-    font["OS/2"].panose = panose
+    font["OS/2"].panose = generate_panose_entries(user_location)
 
     info = {
         "familyName": family_name,
@@ -254,6 +238,33 @@ def build_name_entries(info: dict[str, Any], name: Any) -> None:
         name.setName(nameVal, nameId, platformId, platEncId, langId)
 
 
+def generate_panose_entries(location: GoogleSansFlexInstance) -> Panose:
+    """Generates PANOSE values based on location
+
+    Logic explained here: https://github.com/googlefonts/googlesans-flex/issues/903#issuecomment-2015273322
+    """
+    WIDTH_PROPORTION = {
+        150: 5,
+        100: 3,
+        50: 7,
+        25: 8,
+    }
+
+    panose = Panose()
+    panose.bFamilyType = 2
+    panose.bSerifStyle = 11 if location["ROND"] == 0 else 15
+    panose.bWeight = int(location["wght"] // 100) + 1
+    panose.bProportion = WIDTH_PROPORTION[location["wdth"]]
+    panose.bContrast = 3
+    panose.bStrokeVariation = 5
+    panose.bArmStyle = 2
+    panose.bLetterForm = 4 if location["slnt"] == 0 else 11
+    panose.bMidline = 2
+    panose.bXHeight = 4
+    # print(vars(panose))
+    return panose
+
+
 def fontv_sha1(ttf_path: Path) -> None:
     fv = FontVersion(ttf_path)
     fv.set_state_git_commit_sha1()
@@ -319,11 +330,6 @@ def main(args: list[str] | None = None) -> int:
                 **workspace_instance,
             }
 
-            if "panose" in custom_parameters:
-                panose = custom_parameters["panose"]
-            else:
-                panose = DEFAULT_PANOSE
-
             ttf_name = (
                 family_name.replace(" ", "")
                 + "-"
@@ -339,7 +345,6 @@ def main(args: list[str] | None = None) -> int:
                     [
                         variable_font,  # variable_font: Path
                         coordinates,  # user_location: dict[str, float | int]
-                        panose,  # panose_values: list[int]
                         family_name,  # family_name: str | None
                         style_name,  # style_name: str | None
                         ttf_path,  # output_file: Path

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -34,6 +34,7 @@ from ufo2ft.fontInfoData import (
 
 from prune_font_binary import main as prune_font_binary_main
 from fontv.libfv import FontVersion
+import fontTools.otlLib.optimize.gpos
 
 
 class GoogleSansFlexInstance(TypedDict):
@@ -218,14 +219,25 @@ def fontv_sha1(ttf_path: Path) -> None:
     fv.set_state_git_commit_sha1()
 
 
+def otlib_optimise_gpos(ttf_path: Path) -> None:
+    ttf = TTFont(ttf_path)
+    fontTools.otlLib.optimize.gpos.compact(ttf, 5)
+
+
 def cut_then_post_process(cut_instance_args: list[Any]) -> None:
     ttf_path: Path = cut_instance_args[-1]
+
     print(f"Cutting {ttf_path.name}")
     cut_instance(*cut_instance_args)
+
     print(f"Pruning {ttf_path.name}")
     prune_font_binary_main([str(ttf_path)])
+
     print(f"Running font-v on {ttf_path.name}")
     fontv_sha1(ttf_path)
+
+    print(f"Running otlLib GPOS optimisation on {ttf_path.name}")
+    otlib_optimise_gpos(ttf_path)
 
 
 def main(args: list[str] | None = None) -> int:

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -1,0 +1,262 @@
+# Copyright 2024 Google Sans Flex authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, TypedDict
+
+import ufoLib2
+from fontTools.designspaceLib import DesignSpaceDocument
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables.O_S_2f_2 import Panose
+from ufo2ft.fontInfoData import (
+    getAttrWithFallback,
+    intListToNum,
+    normalizeStringForPostscript,
+)
+
+
+class WorkspaceInstance(TypedDict):
+    opsz: int
+    wdth: int
+    ROND: int
+
+
+# These are then produced at each weight instance defined in the Designspace
+TARGET_INSTANCES: dict[str, WorkspaceInstance] = {
+    "Google Sans Flex": {
+        "opsz": 144,
+        "wdth": 100,
+        "ROND": 0,
+    },
+    "Google Sans Flex UltraCondensed": {
+        "opsz": 144,
+        "wdth": 50,
+        "ROND": 0,
+    },
+    "Google Sans Flex SuperCondensed": {
+        "opsz": 144,
+        "wdth": 25,
+        "ROND": 0,
+    },
+    "Google Sans Flex Rounded": {
+        "opsz": 144,
+        "wdth": 100,
+        "ROND": 100,
+    },
+    "Google Sans Flex Text": {
+        "opsz": 12,
+        "wdth": 100,
+        "ROND": 0,
+    },
+    "Google Sans Flex ExtraExpanded": {
+        "opsz": 144,
+        "wdth": 150,
+        "ROND": 0,
+    },
+}
+
+DEFAULT_PANOSE = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+
+def cut_instance(
+    variable_font: Path,
+    user_location: dict[str, float | int],
+    panose_values: list[int],
+    family_name: str | None,
+    style_name: str | None,
+    stylemap_family_name: str | None,
+    stylemap_style_name: str | None,
+    output_file: Path,
+) -> None:
+    user_location_args = [f"{k}={v}" for k, v in user_location.items()]
+
+    # Create output directory in case it doesn't exist yet on CI, when passing
+    # artifacts around.
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    subprocess.check_call(
+        [
+            "fonttools",
+            "varLib.instancer",
+            "--quiet",
+            "--remove-overlaps",
+            "--update-name-table",
+            "-o",
+            str(output_file),
+            str(variable_font),
+            *user_location_args,
+        ]
+    )
+
+    font = TTFont(output_file)
+
+    font["OS/2"].recalcAvgCharWidth(font)
+
+    panose = Panose()
+    panose.bFamilyType = panose_values[0]
+    panose.bSerifStyle = panose_values[1]
+    panose.bWeight = panose_values[2]
+    panose.bProportion = panose_values[3]
+    panose.bContrast = panose_values[4]
+    panose.bStrokeVariation = panose_values[5]
+    panose.bArmStyle = panose_values[6]
+    panose.bLetterForm = panose_values[7]
+    panose.bMidline = panose_values[8]
+    panose.bXHeight = panose_values[9]
+    font["OS/2"].panose = panose
+
+    info = {
+        "familyName": family_name,
+        "styleName": style_name,
+        "styleMapFamilyName": stylemap_family_name,
+        "styleMapStyleName": stylemap_style_name,
+    }
+    build_name_entries(info, font["name"])
+
+    # style mapping
+    styleMapStyleName = font["name"].getName(2, 3, 1, 0x409).toStr().lower()
+    macStyle = []
+    if styleMapStyleName == "bold":
+        macStyle = [0]
+    elif styleMapStyleName == "bold italic":
+        macStyle = [0, 1]
+    elif styleMapStyleName == "italic":
+        macStyle = [1]
+    font["head"].macStyle = intListToNum(macStyle, 0, 16)
+
+    selection = font["OS/2"].fsSelection
+    selection &= ~(1 << 0)
+    selection &= ~(1 << 5)
+    selection &= ~(1 << 6)
+    if styleMapStyleName == "regular":
+        selection |= 1 << 6
+    elif styleMapStyleName == "bold":
+        selection |= 1 << 5
+    elif styleMapStyleName == "italic":
+        selection |= 1 << 0
+    elif styleMapStyleName == "bold italic":
+        selection |= 1 << 0
+        selection |= 1 << 5
+    font["OS/2"].fsSelection = selection
+
+    font.save(output_file)
+
+
+def build_name_entries(info: dict[str, Any], name: Any) -> None:
+    info = ufoLib2.objects.Info(**info)
+
+    familyName = getAttrWithFallback(info, "styleMapFamilyName")
+    styleName = getAttrWithFallback(info, "styleMapStyleName").title()
+    preferredFamilyName = getAttrWithFallback(info, "openTypeNamePreferredFamilyName")
+    preferredSubfamilyName = getAttrWithFallback(
+        info, "openTypeNamePreferredSubfamilyName"
+    )
+    fullName = f"{preferredFamilyName} {preferredSubfamilyName}"
+
+    nameVals = {
+        1: familyName,
+        2: styleName,
+        4: fullName,
+        6: getAttrWithFallback(info, "postscriptFontName"),
+        16: preferredFamilyName,
+        17: preferredSubfamilyName,
+    }
+
+    # don't add typographic names if they are the same as the legacy ones
+    if nameVals[1] == nameVals[16]:
+        del nameVals[16]
+        name.removeNames(nameID=16, platformID=3, platEncID=1, langID=0x409)
+    if nameVals[2] == nameVals[17]:
+        del nameVals[17]
+        name.removeNames(nameID=17, platformID=3, platEncID=1, langID=0x409)
+    # postscript font name
+    if nameVals[6]:
+        nameVals[6] = normalizeStringForPostscript(nameVals[6])
+
+    for nameId in sorted(nameVals.keys()):
+        nameVal = nameVals[nameId]
+        if not nameVal:
+            continue
+        platformId = 3
+        platEncId = 1
+        langId = 0x409
+        name.setName(nameVal, nameId, platformId, platEncId, langId)
+
+
+def main(args: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Cut workspace statics (not designspace static instances!) from the big VF",
+    )
+    parser.add_argument(
+        "variable_font", type=Path, help="Variable font to cut instances from."
+    )
+    parser.add_argument(
+        "designspace",
+        type=DesignSpaceDocument.fromfile,
+        help="Designspace to take instance weights from.",
+    )
+    parser.add_argument("output_dir", type=Path, help="Output directory.")
+    parsed_args = parser.parse_args(args)
+    designspace: DesignSpaceDocument = parsed_args.designspace
+    output_dir: Path = parsed_args.output_dir
+    variable_font: Path = parsed_args.variable_font
+
+    for (family_name, workspace_instance), instance in itertools.product(
+        TARGET_INSTANCES.items(), designspace.instances
+    ):
+        weight = instance.getFullUserLocation(designspace)["Weight"]
+        coordinates = dict(workspace_instance)
+        coordinates["wght"] = weight
+
+        custom_parameters = dict(
+            instance.lib.get("com.schriftgestaltung.customParameters", ())
+        )
+        style_name = custom_parameters.get("preferredSubfamilyName", instance.styleName)
+
+        print(
+            f"Cutting {family_name} {style_name} {coordinates} from {variable_font.name}"
+        )
+
+        if "panose" in custom_parameters:
+            panose = custom_parameters["panose"]
+        else:
+            print(f"WARN: panose isn't set for instance {instance.name}, using default")
+            panose = DEFAULT_PANOSE
+
+        ttf_name = (
+            family_name.replace(" ", "") + "-" + style_name.replace(" ", "") + ".ttf"
+        )
+
+        cut_instance(
+            variable_font,
+            coordinates,
+            panose,
+            family_name,
+            style_name,
+            instance.styleMapFamilyName,
+            instance.styleMapStyleName,
+            output_dir / ttf_name,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -85,7 +85,9 @@ TARGET_INSTANCES: dict[str, WorkspaceInstance] = {
     },
 }
 
-DEFAULT_PANOSE = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+# As of 76995cc95c, all UFO masters use these PANOSE values
+# Inspect what masters use what PANOSE with scripts/one-off/panose_info.py
+DEFAULT_PANOSE = [2, 11, 5, 3, 3, 5, 2, 4, 2, 4]
 
 
 def cut_instance(
@@ -255,6 +257,8 @@ def main(args: list[str] | None = None) -> int:
     output_dir: Path = parsed_args.output_dir
     variable_font: Path = parsed_args.variable_font
 
+    output_dir.mkdir(parents=True, exist_ok=True)
+
     with multiprocessing.Pool() as pool:
         for (family_name, workspace_instance), instance in itertools.product(
             TARGET_INSTANCES.items(), designspace.instances
@@ -277,9 +281,6 @@ def main(args: list[str] | None = None) -> int:
             if "panose" in custom_parameters:
                 panose = custom_parameters["panose"]
             else:
-                print(
-                    f"WARN: panose isn't set for instance {instance.name}, using default"
-                )
                 panose = DEFAULT_PANOSE
 
             ttf_name = (
@@ -295,12 +296,12 @@ def main(args: list[str] | None = None) -> int:
                 (
                     # cut_instance args
                     [
-                        variable_font,
-                        coordinates,
-                        panose,
-                        family_name,
-                        style_name,
-                        ttf_path,
+                        variable_font,  # variable_font: Path
+                        coordinates,  # user_location: dict[str, float | int]
+                        panose,  # panose_values: list[int]
+                        family_name,  # family_name: str | None
+                        style_name,  # style_name: str | None
+                        ttf_path,  # output_file: Path
                     ],
                 ),
             )

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -89,10 +89,34 @@ TARGET_INSTANCES: dict[str, WorkspaceInstance] = {
 # Inspect what masters use what PANOSE with scripts/one-off/panose_info.py
 DEFAULT_PANOSE = [2, 11, 5, 3, 3, 5, 2, 4, 2, 4]
 
+# Global Google Sans attributes, in 1000 upM font units.
+# These need to be kept in sync with qa/check-googlesans.py to avoid FB fails
+GS_OS2_ATTRIBUTES_UPRIGHT = {
+    "sTypoAscender": 966,  # set to match hhea metrics values
+    "sTypoDescender": -286,
+    "sTypoLineGap": 0,
+    "yStrikeoutPosition": 306,
+    "yStrikeoutSize": 84,
+    "ySubscriptXOffset": 0,
+    # Commented out values have been intentionally changed
+    # "ySubscriptXSize": 650,
+    # "ySubscriptYOffset": 75,
+    "ySubscriptYSize": 600,
+    "ySuperscriptXOffset": 0,
+    # "ySuperscriptXSize": 650,
+    # "ySuperscriptYOffset": 350,
+    "ySuperscriptYSize": 600,
+}
+GS_OS2_ATTRIBUTES_ITALIC = {
+    **GS_OS2_ATTRIBUTES_UPRIGHT,
+    "ySubscriptXOffset": -13,
+    "ySuperscriptXOffset": 62,
+}
+
 
 def cut_instance(
     variable_font: Path,
-    user_location: dict[str, float | int],
+    user_location: GoogleSansFlexInstance,
     panose_values: list[int],
     family_name: str | None,
     style_name: str | None,
@@ -162,6 +186,23 @@ def cut_instance(
         selection |= 1 << 0
         selection |= 1 << 5
     font["OS/2"].fsSelection = selection
+
+    # fudge global font unit attributes as they change for some reason
+    os2 = font["OS/2"]
+    upm_scale = font["head"].unitsPerEm / 1000
+    # before = {attr: getattr(os2, attr) for attr in GS_OS2_ATTRIBUTES_UPRIGHT.keys()}
+    if user_location["slnt"] == 0:
+        for attr, val in GS_OS2_ATTRIBUTES_UPRIGHT.items():
+            assert hasattr(os2, attr), f"don't have {attr}"
+            setattr(os2, attr, int(val * upm_scale))
+    elif user_location["slnt"] == -10:
+        for attr, val in GS_OS2_ATTRIBUTES_ITALIC.items():
+            assert hasattr(os2, attr), f"don't have {attr}"
+            setattr(os2, attr, int(val * upm_scale))
+    # for attr, before_val in before.items():
+    #     after_val = int(getattr(os2, attr))
+    #     if before_val != after_val:
+    #         print(f"{attr}: {before_val} -> {after_val}")
 
     font.save(output_file)
 
@@ -304,6 +345,7 @@ def main(args: list[str] | None = None) -> int:
                         ttf_path,  # output_file: Path
                     ],
                 ),
+                error_callback=lambda err: print(f"cut_then_post_process error: {err}"),
             )
         pool.close()
         pool.join()

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -94,15 +94,9 @@ def cut_instance(
     panose_values: list[int],
     family_name: str | None,
     style_name: str | None,
-    stylemap_family_name: str | None,
-    stylemap_style_name: str | None,
     output_file: Path,
 ) -> None:
     user_location_args = [f"{k}={v}" for k, v in user_location.items()]
-
-    # Create output directory in case it doesn't exist yet on CI, when passing
-    # artifacts around.
-    output_file.parent.mkdir(parents=True, exist_ok=True)
 
     subprocess.check_call(
         [
@@ -138,8 +132,6 @@ def cut_instance(
     info = {
         "familyName": family_name,
         "styleName": style_name,
-        "styleMapFamilyName": stylemap_family_name,
-        "styleMapStyleName": stylemap_style_name,
     }
     build_name_entries(info, font["name"])
 
@@ -177,6 +169,12 @@ def build_name_entries(info: dict[str, Any], name: Any) -> None:
 
     familyName = getAttrWithFallback(info, "styleMapFamilyName")
     styleName = getAttrWithFallback(info, "styleMapStyleName").title()
+    # Manually fix ufo2ft's output
+    if familyName.endswith(" Italic"):
+        familyName = familyName[: -len(" Italic")]
+        assert " Bold" not in familyName, "build_name_entries can't handle this yet"
+        styleName = "Italic"
+
     preferredFamilyName = getAttrWithFallback(info, "openTypeNamePreferredFamilyName")
     preferredSubfamilyName = getAttrWithFallback(
         info, "openTypeNamePreferredSubfamilyName"
@@ -302,8 +300,6 @@ def main(args: list[str] | None = None) -> int:
                         panose,
                         family_name,
                         style_name,
-                        instance.styleMapFamilyName,
-                        instance.styleMapStyleName,
                         ttf_path,
                     ],
                 ),

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import itertools
+import multiprocessing
 import subprocess
 import sys
 from pathlib import Path
@@ -218,42 +219,55 @@ def main(args: list[str] | None = None) -> int:
     output_dir: Path = parsed_args.output_dir
     variable_font: Path = parsed_args.variable_font
 
-    for (family_name, workspace_instance), instance in itertools.product(
-        TARGET_INSTANCES.items(), designspace.instances
-    ):
-        weight = instance.getFullUserLocation(designspace)["Weight"]
-        coordinates = dict(workspace_instance)
-        coordinates["wght"] = weight
+    with multiprocessing.Pool() as pool:
+        for (family_name, workspace_instance), instance in itertools.product(
+            TARGET_INSTANCES.items(), designspace.instances
+        ):
+            weight = instance.getFullUserLocation(designspace)["Weight"]
+            coordinates = dict(workspace_instance)
+            coordinates["wght"] = weight
 
-        custom_parameters = dict(
-            instance.lib.get("com.schriftgestaltung.customParameters", ())
-        )
-        style_name = custom_parameters.get("preferredSubfamilyName", instance.styleName)
+            custom_parameters = dict(
+                instance.lib.get("com.schriftgestaltung.customParameters", ())
+            )
+            style_name = custom_parameters.get(
+                "preferredSubfamilyName", instance.styleName
+            )
 
-        print(
-            f"Cutting {family_name} {style_name} {coordinates} from {variable_font.name}"
-        )
+            print(
+                f"Cutting {family_name} {style_name} {coordinates} from {variable_font.name}"
+            )
 
-        if "panose" in custom_parameters:
-            panose = custom_parameters["panose"]
-        else:
-            print(f"WARN: panose isn't set for instance {instance.name}, using default")
-            panose = DEFAULT_PANOSE
+            if "panose" in custom_parameters:
+                panose = custom_parameters["panose"]
+            else:
+                print(
+                    f"WARN: panose isn't set for instance {instance.name}, using default"
+                )
+                panose = DEFAULT_PANOSE
 
-        ttf_name = (
-            family_name.replace(" ", "") + "-" + style_name.replace(" ", "") + ".ttf"
-        )
+            ttf_name = (
+                family_name.replace(" ", "")
+                + "-"
+                + style_name.replace(" ", "")
+                + ".ttf"
+            )
 
-        cut_instance(
-            variable_font,
-            coordinates,
-            panose,
-            family_name,
-            style_name,
-            instance.styleMapFamilyName,
-            instance.styleMapStyleName,
-            output_dir / ttf_name,
-        )
+            pool.apply_async(
+                cut_instance,
+                (
+                    variable_font,
+                    coordinates,
+                    panose,
+                    family_name,
+                    style_name,
+                    instance.styleMapFamilyName,
+                    instance.styleMapStyleName,
+                    output_dir / ttf_name,
+                ),
+            )
+        pool.close()
+        pool.join()
 
     return 0
 

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -32,6 +32,14 @@ from ufo2ft.fontInfoData import (
     normalizeStringForPostscript,
 )
 
+class GoogleSansFlexInstance(TypedDict):
+    wght: float
+    wdth: int
+    opsz: int
+    GRAD: int
+    ROND: int
+    slnt: int
+
 
 class WorkspaceInstance(TypedDict):
     opsz: int
@@ -223,16 +231,20 @@ def main(args: list[str] | None = None) -> int:
         for (family_name, workspace_instance), instance in itertools.product(
             TARGET_INSTANCES.items(), designspace.instances
         ):
-            weight = instance.getFullUserLocation(designspace)["Weight"]
-            coordinates = dict(workspace_instance)
-            coordinates["wght"] = weight
-
             custom_parameters = dict(
                 instance.lib.get("com.schriftgestaltung.customParameters", ())
             )
-            style_name = custom_parameters.get(
+            style_name: str = custom_parameters.get(
                 "preferredSubfamilyName", instance.styleName
             )
+
+            weight = instance.getFullUserLocation(designspace)["Weight"]
+            coordinates: GoogleSansFlexInstance = {
+                "wght": weight,
+                "slnt": -10 if style_name.endswith("Italic") else 0,
+                "GRAD": 0,
+                **workspace_instance,
+            }
 
             print(
                 f"Cutting {family_name} {style_name} {coordinates} from {variable_font.name}"

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -32,6 +32,9 @@ from ufo2ft.fontInfoData import (
     normalizeStringForPostscript,
 )
 
+from prune_font_binary import main as prune_font_binary_main
+
+
 class GoogleSansFlexInstance(TypedDict):
     wght: float
     wdth: int
@@ -209,6 +212,14 @@ def build_name_entries(info: dict[str, Any], name: Any) -> None:
         name.setName(nameVal, nameId, platformId, platEncId, langId)
 
 
+def cut_then_post_process(cut_instance_args: list[Any]) -> None:
+    ttf_path: Path = cut_instance_args[-1]
+    print(f"Cutting {ttf_path.name}")
+    cut_instance(*cut_instance_args)
+    print(f"Pruning {ttf_path.name}")
+    prune_font_binary_main([str(ttf_path)])
+
+
 def main(args: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Cut workspace statics (not designspace static instances!) from the big VF",
@@ -246,10 +257,6 @@ def main(args: list[str] | None = None) -> int:
                 **workspace_instance,
             }
 
-            print(
-                f"Cutting {family_name} {style_name} {coordinates} from {variable_font.name}"
-            )
-
             if "panose" in custom_parameters:
                 panose = custom_parameters["panose"]
             else:
@@ -264,18 +271,22 @@ def main(args: list[str] | None = None) -> int:
                 + style_name.replace(" ", "")
                 + ".ttf"
             )
+            ttf_path = output_dir / ttf_name
 
             pool.apply_async(
-                cut_instance,
+                cut_then_post_process,
                 (
-                    variable_font,
-                    coordinates,
-                    panose,
-                    family_name,
-                    style_name,
-                    instance.styleMapFamilyName,
-                    instance.styleMapStyleName,
-                    output_dir / ttf_name,
+                    # cut_instance args
+                    [
+                        variable_font,
+                        coordinates,
+                        panose,
+                        family_name,
+                        style_name,
+                        instance.styleMapFamilyName,
+                        instance.styleMapStyleName,
+                        ttf_path,
+                    ],
                 ),
             )
         pool.close()

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -22,19 +22,18 @@ import sys
 from pathlib import Path
 from typing import Any, TypedDict
 
+import fontTools.otlLib.optimize.gpos
 import ufoLib2
 from fontTools.designspaceLib import DesignSpaceDocument
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables.O_S_2f_2 import Panose
+from fontv.libfv import FontVersion
+from prune_font_binary import main as prune_font_binary_main
 from ufo2ft.fontInfoData import (
     getAttrWithFallback,
     intListToNum,
     normalizeStringForPostscript,
 )
-
-from prune_font_binary import main as prune_font_binary_main
-from fontv.libfv import FontVersion
-import fontTools.otlLib.optimize.gpos
 
 
 class GoogleSansFlexInstance(TypedDict):

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -33,6 +33,7 @@ from ufo2ft.fontInfoData import (
 )
 
 from prune_font_binary import main as prune_font_binary_main
+from fontv.libfv import FontVersion
 
 
 class GoogleSansFlexInstance(TypedDict):
@@ -212,12 +213,19 @@ def build_name_entries(info: dict[str, Any], name: Any) -> None:
         name.setName(nameVal, nameId, platformId, platEncId, langId)
 
 
+def fontv_sha1(ttf_path: Path) -> None:
+    fv = FontVersion(ttf_path)
+    fv.set_state_git_commit_sha1()
+
+
 def cut_then_post_process(cut_instance_args: list[Any]) -> None:
     ttf_path: Path = cut_instance_args[-1]
     print(f"Cutting {ttf_path.name}")
     cut_instance(*cut_instance_args)
     print(f"Pruning {ttf_path.name}")
     prune_font_binary_main([str(ttf_path)])
+    print(f"Running font-v on {ttf_path.name}")
+    fontv_sha1(ttf_path)
 
 
 def main(args: list[str] | None = None) -> int:

--- a/scripts/fontbakery.sh
+++ b/scripts/fontbakery.sh
@@ -17,10 +17,11 @@
 # that failed are also printed
 
 # Assumes the repository is in the parent folder of where the script lives
+# Set env var SKIP_SOURCES if you don't want to check sources
 
 set -e
 
-BIGGEST_TTF_PATH="fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf"
+all_ttfs="$(find fonts/ -name '*.ttf')"
 
 # Switch to repo path by going to the parent folder of where this script is
 cd "$(dirname "${BASH_SOURCE[0]}" | xargs dirname)"
@@ -47,26 +48,33 @@ mkdir -p out/fontbakery
 # 3. we can give a nice error message later
 failed=()
 
-find sources/ -name "*.ufo" -print0 | xargs -0 venv_bakery/bin/fontbakery \
-    check-profile -l WARN --auto-jobs --succinct --no-progress \
-    --html out/fontbakery/fontbakery-sources-report.html \
-    qa/check-sources.py \
-    sources/GoogleSansFlex.designspace \
-    || failed+=("check-sources")
+# Source checks
+if [ -z "$SKIP_SOURCES" ]; then
+    find sources/ -name "*.ufo" -print0 | xargs -0 venv_bakery/bin/fontbakery \
+        check-profile -l WARN --auto-jobs --succinct --no-progress \
+        --html out/fontbakery/fontbakery-sources-report.html \
+        qa/check-sources.py \
+        sources/GoogleSansFlex.designspace \
+        || failed+=("check-sources")
+fi
 
-venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
+# Compiled font tests
+echo "$all_ttfs" \
+    | xargs venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
     --html out/fontbakery/fontbakery-outlines-report.html \
-    fontbakery.profiles.outline "$BIGGEST_TTF_PATH" \
+    fontbakery.profiles.outline {} \
     || failed+=("fontbakery.profiles.outline")
 
-venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
+echo "$all_ttfs" \
+    | xargs venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
     --html out/fontbakery/fontbakery-googlesans-report.html \
-    qa/check-googlesans.py "$BIGGEST_TTF_PATH" \
+    qa/check-googlesans.py {} \
     || failed+=("check-googlesans")
 
-venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
+echo "$all_ttfs" \
+    | xargs venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
     --html out/fontbakery/fontbakery-fea-report.html \
-    qa/check-fea.py "$BIGGEST_TTF_PATH" \
+    qa/check-fea.py {} \
     || failed+=("check-fea")
 
 # NOTE: The following checks can be activated after the sources are stable:

--- a/scripts/one-off/panose_info.py
+++ b/scripts/one-off/panose_info.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from ufoLib2 import Font
+
+from collections import defaultdict
+
+results = defaultdict(list)
+for ufo_path in Path("sources").glob("*.ufo"):
+    font = Font.open(ufo_path, validate=False)
+    results[tuple(font.info.openTypeOS2Panose)].append(ufo_path.name)
+
+for panose, ufos in results.items():
+    print(panose)
+    for ufo in ufos:
+        print(f"  - {ufo}")
+    print()


### PR DESCRIPTION
Closes #897 

Uses a modified version of [`cut-instances.py`](https://github.com/googlefonts/googlesans/blob/main/scripts/internal/cut-instances.py) from Google Sans, but this one instead programmatically generated the instances to cut instead of reading them from the Designspace. It also produces all the TTFs in a single invocation, instead of one TTF per invocation

Example statics package: [GS Flex statics.zip](https://github.com/googlefonts/googlesans-flex/files/14726151/GoogleSansFlex-v3.20.workspace.statics.zip)


Next steps:
1. do we want to add this to the GitHub workflow for releases only? That way, the artifact zip can automatically be included
2. if so, do we also want to Fontbakery check the produced statics before they're uploaded?

~~(Pipeline is failing because #899 hasn't been merged yet)~~

---

Update: progress list:

- [x] add `release` target to Makefile to build statics
- [x] add statics package to releases automatically
- [x] run Fontbakery on statics before releasing
- [x] fix Fontbakery fails directly related to instancing/slicing
  - [x] `com.google.fonts/check/googlesansflex/opentype/global_fu_attributes`
  - [x] `com.google.fonts/check/name/family_and_style_max_length` (ignore)
  - [x] `com.google.fonts/check/mac_style`
  - [x] `com.google.fonts/check/fsselection`
  - [x] `com.adobe.fonts/check/family/max_4_fonts_per_family_name`
  - [x] `com.adobe.fonts/check/family/consistent_family_name`
  - [x] `com.google.fonts/check/name/match_familyname_fullfont`
  - [x] `com.google.fonts/check/name/italic_names`
  - [x] `com.google.fonts/check/family/single_directory` (ignore)
- [x] [PANOSE generation](https://github.com/googlefonts/googlesans-flex/issues/903#issuecomment-2015273322)