### PR TITLE
Only build PRs that target main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,14 +8,11 @@ on:
         required: true
   push:
     branches:
-      - main
+    - main
   pull_request:
     types: [opened, synchronize, reopened]
-    # Do not build on PRs that only change the design sources; these do not
-    # affect the UFO sources or pipeline until manually imported, and so should
-    # have no effect on the final TTFs.
-    paths-ignore:
-      - 'sources/design-source/**'
+    branches:
+    - main
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,11 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+    # Do not build on PRs that only change the design sources; these do not
+    # affect the UFO sources or pipeline until manually imported, and so should
+    # have no effect on the final TTFs.
+    paths-ignore:
+      - 'sources/design-source/**'
 
 jobs:
   build:


### PR DESCRIPTION
Update(Ricky): changed approach to check if a PR is targetting `main`

---

This PR stops our automatic build workflow from running for PRs that only change the sources within `sources/design-source/`.

Changes in this folder do not affect the UFO sources or pipeline until manually imported, and so have no effect on the final TTFs.

## Workflows

This would avoid booting the CI for these recent builds (highlighted):

![List of recent build workflows, with those that would no longer be issued highlighted](https://github.com/googlefonts/googlesans-flex/assets/2150762/62caaf2e-a73e-40b9-a627-4dc789a57e4c)

## Future

If we find that CI feedback for Glyphs PRs would be helpful, we could reinstate automated builds but with the "Build from Glyphs package" workflow instead, depending on CI minutes available 🚀 