### PR TITLE
Fix Octavio's source folder to be sources/design-source in workflow

### DIFF
--- a/.github/actions/glyphspackage2ufo/action.yml
+++ b/.github/actions/glyphspackage2ufo/action.yml
@@ -30,8 +30,8 @@ runs:
       # Note: path to create worktree is relative to Git dir (main) not current dir
       git -C main worktree add --quiet --detach "$GITHUB_WORKSPACE/octavio" "origin/$GIT_REF"
 
-      if [[ ! -d "$GITHUB_WORKSPACE/octavio/sources-v2_0" ]]; then
-        echo "::error title=No glyphspackage sources::$GIT_REF doesn't have a sources-v2_0 folder"
+      if [[ ! -d "$GITHUB_WORKSPACE/octavio/sources/design-source" ]]; then
+        echo "::error title=No glyphspackage sources::$GIT_REF doesn't have a sources/design-source folder"
         exit 1
       fi
 
@@ -52,5 +52,5 @@ runs:
       echo "::endgroup::"
       echo "Running glyphs_to_ds.py"
       venv/bin/python scripts/glyphs_to_ds.py \
-        "$GITHUB_WORKSPACE/octavio/sources-v2_0/GSF-full.glyphspackage" \
+        "$GITHUB_WORKSPACE/octavio/sources/design-source/GSF-full.glyphspackage" \
         sources/GoogleSansFlex.designspace


### PR DESCRIPTION
Fix this workflow issue: https://github.com/googlefonts/googlesans-flex/actions/runs/8920489085

![image](https://github.com/googlefonts/googlesans-flex/assets/3616772/28596c4b-f051-4cd7-921c-3fedb04650ad)

Now the design sources from Octavio have been moved to sources/design-source
