### PR TITLE
diffenator.yaml: Generate output images

### DIFF
--- a/.github/workflows/diffenator.yaml
+++ b/.github/workflows/diffenator.yaml
@@ -59,7 +59,7 @@ jobs:
         if-no-files-found: error
   diffenate:
     runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 30
+    timeout-minutes: 90
     needs:
     - build-before
     - build-after

--- a/.github/workflows/diffenator.yaml
+++ b/.github/workflows/diffenator.yaml
@@ -85,11 +85,24 @@ jobs:
         cache: pip
     - name: Install diffenator2
       run: pip install --upgrade diffenator2
+
+    - name: Setup Chrome
+      uses: browser-actions/setup-chrome@latest
+    - name: Setup Chrome Driver
+      uses: nanasess/setup-chromedriver@master
+    - name: Setup Firefox
+      uses: browser-actions/setup-firefox@latest
+    - name: Setup Firefox Driver
+      uses: browser-actions/setup-geckodriver@latest
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Run diffenator2
       run: |
         mkdir -p diffenator_report
+        chromedriver --url-base=/wd/hub &
         diffenator2 diff --fonts-before before/*.ttf --fonts-after after/*.ttf \
-          --out diffenator_report
+          --out diffenator_report --imgs
     - name: Upload diffenator report
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This PR will generate browser images for the html docs produced by diffenator2.

@RickyDaMa I may need to do some back and forth in order to get this working. Please don't judge me when you see further commits with sh*t like "testing r101" or "please work". They'll get squashed. I may have to have to hardcode some paths in order to make it testable. I'll make sure I revert it.