### PR TITLE
Add checks for quadratic curves & open corners; disable `EraseOpenCorners` filter

### DIFF
--- a/qa/check-sources.py
+++ b/qa/check-sources.py
@@ -22,6 +22,7 @@ PROFILE = {
             "com.google.fonts/check/googlesansflex/sources/suspicious_kerning_values",
             "com.google.fonts/check/googlesansflex/sources/same_kerning_groups",
             "com.google.fonts/check/googlesansflex/sources/kerning_present",
+            "com.google.fonts/check/googlesansflex/sources/all_quadratics",
         ]
     },
 }

--- a/qa/check-sources.py
+++ b/qa/check-sources.py
@@ -23,6 +23,7 @@ PROFILE = {
             "com.google.fonts/check/googlesansflex/sources/same_kerning_groups",
             "com.google.fonts/check/googlesansflex/sources/kerning_present",
             "com.google.fonts/check/googlesansflex/sources/all_quadratics",
+            "com.google.fonts/check/googlesansflex/sources/no_open_corners",
         ]
     },
 }

--- a/qa/checks/sources.py
+++ b/qa/checks/sources.py
@@ -191,3 +191,33 @@ def check_kerning_present(ds: DesignSpaceDocument) -> CheckStatus:
                 WARN,
                 f"{source.filename}: Found no kerning pairs (not counting exceptions)",
             )
+
+
+@check(id="com.google.fonts/check/googlesansflex/sources/all_quadratics")
+def check_all_quadratics(config, ufo: Ufo) -> CheckStatus:
+    """Checks all curves in the font are quadratic"""
+
+    offending_glyphs = [
+        glyph.name
+        for glyph in ufo.ufo_font  # type: ignore
+        if any(
+            point.type == "curve"
+            for contour in glyph.contours
+            for point in contour.points
+        )
+    ]
+
+    if offending_glyphs:
+        yield (
+            FAIL,
+            Message(
+                "cubics-found",
+                f"{ufo.file_displayname} contains glyphs with cubic curves:\n\n"
+                f"{utils.bullet_list(config, offending_glyphs)}",
+            ),
+        )
+    else:
+        yield (
+            PASS,
+            "No cubic curves found",
+        )

--- a/qa/checks/sources.py
+++ b/qa/checks/sources.py
@@ -197,9 +197,12 @@ def check_kerning_present(ds: DesignSpaceDocument) -> CheckStatus:
 def check_all_quadratics(config, ufo: Ufo) -> CheckStatus:
     """Checks all curves in the font are quadratic"""
 
+    font = ufo.ufo_font  # type: ignore
+    assert isinstance(font, Font)
+
     offending_glyphs = [
         glyph.name
-        for layer in ufo.ufo_font.layers  # type: ignore
+        for layer in font.layers
         for glyph in layer
         if any(
             point.type == "curve"
@@ -214,7 +217,7 @@ def check_all_quadratics(config, ufo: Ufo) -> CheckStatus:
             Message(
                 "cubics-found",
                 f"{ufo.file_displayname} contains glyphs with cubic curves:\n\n"
-                f"{utils.bullet_list(config, offending_glyphs)}",
+                f"{utils.bullet_list(config, offending_glyphs)}\n",
             ),
         )
     else:
@@ -222,3 +225,40 @@ def check_all_quadratics(config, ufo: Ufo) -> CheckStatus:
             PASS,
             "No cubic curves found",
         )
+
+
+@check(id="com.google.fonts/check/googlesansflex/sources/no_open_corners")
+def check_no_open_corners(config, ufo: Ufo) -> CheckStatus:
+    """Check the sources have no corners, as Google Sans Flex's design with ROND
+    is incompatible with this approach"""
+    from glyphsLib.filters.eraseOpenCorners import EraseOpenCornersPen
+    from fontTools.pens.basePen import NullPen
+
+    font = ufo.ufo_font  # type: ignore
+    assert isinstance(font, Font)
+
+    default_layer_name = font.layers.defaultLayer.name
+    for layer in font.layers:
+        offending_glyphs = []
+        for glyph in layer:
+            the_void = NullPen()
+            erase_open_corners = EraseOpenCornersPen(the_void)
+            for contour in glyph.contours:
+                contour.draw(erase_open_corners)
+            if erase_open_corners.affected:
+                offending_glyphs.append(glyph.name)
+
+        if offending_glyphs:
+            location_str = (
+                ufo.file_displayname
+                if layer.name == default_layer_name
+                else f"{ufo.file_displayname} (layer {layer.name})"
+            )
+            yield (
+                FAIL,
+                Message(
+                    "open-corners-found",
+                    f"{location_str} contains glyphs with open corners:\n\n"
+                    f"{utils.bullet_list(config, offending_glyphs)}\n",
+                ),
+            )

--- a/qa/checks/sources.py
+++ b/qa/checks/sources.py
@@ -199,7 +199,8 @@ def check_all_quadratics(config, ufo: Ufo) -> CheckStatus:
 
     offending_glyphs = [
         glyph.name
-        for glyph in ufo.ufo_font  # type: ignore
+        for layer in ufo.ufo_font.layers  # type: ignore
+        for glyph in layer
         if any(
             point.type == "curve"
             for contour in glyph.contours

--- a/scripts/glyphs_to_ds.py
+++ b/scripts/glyphs_to_ds.py
@@ -15,6 +15,7 @@
 """Convert sources from a Glyphs 3 .glyphs or .glyphspackage file into a
 designspace + UFO that can be used for building this font project."""
 
+from typing import Any
 import glyphsLib
 from glyphsLib import GSFont
 from pathlib import Path
@@ -110,6 +111,16 @@ if __name__ == "__main__":
     for ufo in ufos:
         already_skipped = set(ufo.lib.get("public.skipExportGlyphs", []))
         ufo.lib["public.skipExportGlyphs"] = sorted(already_skipped | INCOMPATIBLE)
+        # Remove the eraseOpenCorners filter as it's buggy, and we shouldn't
+        # need it anyway, as designing for ROND means we can't have open corners
+        # https://github.com/googlefonts/fontmake/issues/897
+        filters: list[dict[str, Any]] = ufo.lib.get(
+            "com.github.googlei18n.ufo2ft.filters", []
+        )
+        for index, filter in enumerate(filters):
+            if filter.get("name") == "eraseOpenCorners":
+                del filters[index]
+                break
 
     # Rename the default UFO's style name to "Regular"; this is necessary to
     # produce a correct name table, but otherwise inconvenient to have in


### PR DESCRIPTION
Closes #942 

Note: this PR is based on #891, meaning that PR needs to be merged first

Adds two Fontbakery checks: one for checking that all curves in the sources are quadratic, and one that checks for open corners. They raise FAILs if finding something they shouldn't

This PR also updates the import process to stop the `EraseOpenCorners` filter being used (this is controlled by a master-level lib key). **This will only impact the sources on the next import**

This PR _does not_ disable `cu2qu`, as this would need further work in gftools, and having benchmarked the difference, the performance improvement is within the margin of error. More details [here](https://github.com/googlefonts/googlesans-flex/issues/942#issuecomment-2112602670)