### PR TITLE
Fix typo in Fontbakery check code + expand Workspace fonts README

### DIFF
--- a/README_WORKSPACE.md
+++ b/README_WORKSPACE.md
@@ -18,7 +18,26 @@ These families are:
 
 - Each family has 2 VFs, one upright and one italic.
 - All VFs include a subset of the Weight axis from 100 to 900, with fvar instances.
-- All VFs have had their Slant/slnt axis renamed to Italic/ital in the STAT.
+- All VFs have had their Slant/slnt axis renamed to Italic/ital in the STAT, and
+other STAT axes removed (anything else than Weight and Italic).
+
+### Process for slicing VFs
+
+1. Slice Workspace VF from `GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf`
+  using `fonttools varLib.instancer`
+2. Fixup a few tables:
+    - `OS/2` average char width, and various measurements that get changed
+      inadvertently by the instancer. FontBakery checks that in the end we have
+      the correct measurements that match the rest of the GS family.
+    - family and style names, style mapping
+    - name ID 25, which needs to be different for each TTF file
+    - PANOSE entries, fsSelection bits, which depend on the location of the VF
+    - fvar instances along the Weight axis, as a Workspace requirement
+    - STAT Slant -> Italic, as a FontBakery requirement
+    - remove other STAT axes to prevent issues in Adobe apps
+3. Prune TTF using the subsetter, to shake off any potential unreachable glyphs
+4. Run `font-v` to write the Git commit SHA into the name table
+5. Run the GPOS compaction to reduce the file size
 
 ## Links
 
@@ -26,3 +45,4 @@ These families are:
 - Initial issue for static fonts: [Add Static Instances #897](https://github.com/googlefonts/googlesans-flex/issues/897)
 - GitHub workflow: [.github/workflows/release.yml](https://github.com/googlefonts/googlesans-flex/blob/main/.github/workflows/release.yml)
 - VF Slicing script: [scripts/cut_instances.py](https://github.com/googlefonts/googlesans-flex/blob/main/scripts/cut_instances.py)
+- [Further issue about cleaning up the STAT table](https://github.com/googlefonts/googlesans-flex/issues/949)

--- a/qa/checks/googlesans.py
+++ b/qa/checks/googlesans.py
@@ -241,7 +241,7 @@ def com_google_fonts_check_googlesansflex_axis_names(font: Font, ttFont):
     elif SUFFIX_PARTIAL_VF in font_name:
         axis_names = AXIS_NAMES
     elif SUFFIX_WORKSPACE_WEIGHT_ONLY_VF in font_name:
-        axis_names = AXIS_DEFAULTS_WORKSPACE
+        axis_names = AXIS_NAMES_WORKSPACE
     else:
         raise Exception("Unknown variable font build")
 


### PR DESCRIPTION
There was a typo in the FontBakery check code, resulting in the following failure:

![image](https://github.com/googlefonts/googlesans-flex/assets/3616772/b287c092-8a28-4b6e-a4dd-2024424c0062)
