### PR TITLE
Reduce retention for sources on CI

### DIFF
--- a/.github/workflows/build-glyphs.yml
+++ b/.github/workflows/build-glyphs.yml
@@ -58,6 +58,7 @@ jobs:
         path: ${{ steps.glyphspackage2ufo.outputs.directory }}/UFO sources.tar
         compression-level: 9
         if-no-files-found: error
+        retention-days: 1
     outputs:
       sources-artifact: ${{ steps.zip-name.outputs.artifact-name }}
   build:


### PR DESCRIPTION
Only used by the `build-glyphs` workflow, but still should save us some storage space since people aren't going to be looking at this