### PR TITLE
Switch to free runners and increase timeouts

### DIFF
--- a/.github/workflows/build-glyphs.yml
+++ b/.github/workflows/build-glyphs.yml
@@ -9,8 +9,8 @@ on:
 
 jobs:
   convert:
-    runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout main
       uses: actions/checkout@v4
@@ -61,8 +61,8 @@ jobs:
     outputs:
       sources-artifact: ${{ steps.zip-name.outputs.artifact-name }}
   build:
-    runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs:
     - convert
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,8 @@ on:
 
 jobs:
   build:
-    runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     # on: pull_request uses head_ref for branch name, on: push uses ref_name
     - name: Checkout ${{ inputs.git-ref || github.head_ref || github.ref_name }}

--- a/.github/workflows/burndown.yml
+++ b/.github/workflows/burndown.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   burndown:
-    runs-on: [linux, googlefonts-64cores-256GB]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/diffenator.yaml
+++ b/.github/workflows/diffenator.yaml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   build-before:
-    runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout ${{ inputs.before }}
       uses: actions/checkout@v4
@@ -35,8 +35,8 @@ jobs:
         path: fonts/variable
         if-no-files-found: error
   build-after:
-    runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout ${{ inputs.after }}
       uses: actions/checkout@v4
@@ -58,8 +58,8 @@ jobs:
         path: fonts/variable
         if-no-files-found: error
   diffenate:
-    runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs:
     - build-before
     - build-after

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   import-branch:
-    runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Log & validate inputs
         run: |
@@ -49,8 +49,8 @@ jobs:
     outputs:
       import-branch: ${{ steps.create-update-import.outputs.import-branch }}
   build-variable:
-    runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: import-branch
     steps:
       - name: Checkout ${{ needs.import-branch.outputs.import-branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   build-variable:
-    runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout ${{ github.ref_name }}
       uses: actions/checkout@v4
@@ -27,8 +27,8 @@ jobs:
   cut-instances:
     needs:
     - build-variable
-    runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout ${{ github.ref_name }}
       uses: actions/checkout@v4
@@ -77,8 +77,8 @@ jobs:
   test-workspace:
     needs:
     - cut-instances
-    runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout ${{ github.ref_name }}
       uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
     - test-variable
     - test-workspace
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 60
     steps:
     - name: Download variable fonts
       uses: actions/download-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ on:
 
 jobs:
   tests:
-    runs-on: [linux, googlefonts-64cores-256GB]
-    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - name: Checkout ${{ inputs.branch }}
       if: ${{ inputs.artifact-as-branch == '' }}


### PR DESCRIPTION
For more information see #961 

Faster runners are currently unavailable

This configuration is known to work fine on the testing repo, so should work for us for now