### PR TITLE
Shaperglot testing - pipeline failures & update target languages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,8 @@ shaperglot: venv build
 	venv/bin/pip install -U "shaperglot>=0.5"
 	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::endgroup::"
 	mkdir -p out
-# Report coverage of target languages
-	xargs venv/bin/shaperglot check fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf < qa/target_langs.txt
 # Report coverage of all languages
 	venv/bin/shaperglot report --group fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+	@echo "\nChecking against the target language list"
+# Report coverage of target languages (exit code reports fails/warns)
+	@venv/bin/python qa/check_shaperglot.py fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf

--- a/qa/check_shaperglot.py
+++ b/qa/check_shaperglot.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import itertools
 from argparse import ArgumentParser
 from pathlib import Path
 from sys import exit
@@ -27,10 +26,13 @@ TARGET_LANGS_PATH = Path(__file__).parent / "target_langs.txt"
 
 
 def get_worst_status(reporter: Reporter) -> Result:
+    # SKIP is lower than PASS because PASSes + SKIPs = pass overall (according
+    # to shaperglot's own logic)
     ORDERING = (Result.SKIP, Result.PASS, Result.WARN, Result.FAIL)
     return max(
         (message.result for message in reporter.results),
         key=ORDERING.index,
+        # Can't be PASS/FAIL, otherwise doesn't really matter
         default=Result.WARN,
     )
 
@@ -49,19 +51,30 @@ def main(font_paths: list[Path]) -> int:
         for target_lang_config in language_list:
             report = checker.check(target_lang_config)
             worst = get_worst_status(report)
-            if worst == Result.WARN and report.is_unknown:
-                # Override untestable to SKIP
-                worst = Result.SKIP
+            if report.is_unknown:
+                # Display unknown as SKIP
                 print(
-                    f"  {worst.value} {target_lang_config['name']} (not supported by shaperglot)"
+                    f"  {Result.SKIP.value} {target_lang_config['name']} "
+                    "(not supported by shaperglot)"
                 )
             elif worst == Result.PASS:
                 print(f"  {worst.value} {target_lang_config['name']}")
             else:
                 print(f"  {target_lang_config['name']}:")
                 exit_status = 1
-                for result in itertools.chain(report.fails, report.warns):
-                    print(f"    {result}")
+                # De-duplicate messages by their content as otherwise we get a
+                # lot of repeats (usually from SKIPs)
+                report_results = {
+                    message.message: message.result for message in report.results
+                }
+                for message, result in sorted(report_results.items()):
+                    if result == Result.PASS:
+                        continue
+                    elif result == Result.SKIP:
+                        # This seems more appropriate from having looked at when
+                        # shaperglot raises SKIPs
+                        result = Result.FAIL
+                    print(f"    {result.value}: {message}")
         print()
     return exit_status
 

--- a/qa/check_shaperglot.py
+++ b/qa/check_shaperglot.py
@@ -26,8 +26,8 @@ TARGET_LANGS_PATH = Path(__file__).parent / "target_langs.txt"
 
 
 def get_worst_status(reporter: Reporter) -> Result:
-    # SKIP is lower than PASS because PASSes + SKIPs = pass overall (according
-    # to shaperglot's own logic)
+    # SKIP means some checks were omitted because they weren't relevant to the
+    # font, which is less important than any other status
     ORDERING = (Result.SKIP, Result.PASS, Result.WARN, Result.FAIL)
     return max(
         (message.result for message in reporter.results),
@@ -62,19 +62,10 @@ def main(font_paths: list[Path]) -> int:
             else:
                 print(f"  {target_lang_config['name']}:")
                 exit_status = 1
-                # De-duplicate messages by their content as otherwise we get a
-                # lot of repeats (usually from SKIPs)
-                report_results = {
-                    message.message: message.result for message in report.results
-                }
-                for message, result in sorted(report_results.items()):
-                    if result == Result.PASS:
+                for message in report.results:
+                    if message.result == Result.PASS or message.result == Result.SKIP:
                         continue
-                    elif result == Result.SKIP:
-                        # This seems more appropriate from having looked at when
-                        # shaperglot raises SKIPs
-                        result = Result.FAIL
-                    print(f"    {result.value}: {message}")
+                    print(f"    {message}")
         print()
     return exit_status
 

--- a/qa/check_shaperglot.py
+++ b/qa/check_shaperglot.py
@@ -63,7 +63,7 @@ def main(font_paths: list[Path]) -> int:
                 print(f"  {target_lang_config['name']}:")
                 exit_status = 1
                 for message in report.results:
-                    if message.result == Result.PASS or message.result == Result.SKIP:
+                    if message.result == Result.SKIP:
                         continue
                     print(f"    {message}")
         print()

--- a/qa/check_shaperglot.py
+++ b/qa/check_shaperglot.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Google Sans Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+from argparse import ArgumentParser
+from pathlib import Path
+from sys import exit
+
+from shaperglot.checker import Checker
+from shaperglot.languages import Languages
+from shaperglot.reporter import Reporter, Result
+
+TARGET_LANGS_PATH = Path(__file__).parent / "target_langs.txt"
+
+
+def get_worst_status(reporter: Reporter) -> Result:
+    ORDERING = (Result.PASS, Result.SKIP, Result.WARN, Result.FAIL)
+    return max(
+        (message.result for message in reporter.results),
+        key=ORDERING.index,
+        default=Result.SKIP,
+    )
+
+
+def main(font_paths: list[Path]) -> int:
+    shaperglot_lang_config = Languages()
+    language_list = [
+        shaperglot_lang_config[lang]
+        for lang in TARGET_LANGS_PATH.read_text().splitlines()
+    ]
+
+    exit_status = 0
+    for font_path in font_paths:
+        print(f"{font_path}:")
+        checker = Checker(font_path)
+        for target_lang_config in language_list:
+            report = checker.check(target_lang_config)
+            worst = get_worst_status(report)
+            if worst == Result.WARN and report.is_unknown:
+                # Override untestable to SKIP
+                worst = Result.SKIP
+                print(
+                    f"  {worst.value} {target_lang_config['name']} (not supported by shaperglot)"
+                )
+            elif worst == Result.FAIL or worst == Result.WARN:
+                print(f"  {target_lang_config['name']}:")
+                exit_status = 1
+                for result in itertools.chain(report.fails, report.warns):
+                    print(f"    {result}")
+            else:
+                print(f"  {worst.value} {target_lang_config['name']}")
+        print()
+    return exit_status
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Check language coverage using shaperglot")
+    parser.add_argument(
+        "font_paths",
+        help="TTF(s) to check",
+        nargs="+",
+        type=Path,
+        metavar="ttf",
+    )
+    args = parser.parse_args()
+
+    exit(main(args.font_paths))

--- a/qa/check_shaperglot.py
+++ b/qa/check_shaperglot.py
@@ -27,11 +27,11 @@ TARGET_LANGS_PATH = Path(__file__).parent / "target_langs.txt"
 
 
 def get_worst_status(reporter: Reporter) -> Result:
-    ORDERING = (Result.PASS, Result.SKIP, Result.WARN, Result.FAIL)
+    ORDERING = (Result.SKIP, Result.PASS, Result.WARN, Result.FAIL)
     return max(
         (message.result for message in reporter.results),
         key=ORDERING.index,
-        default=Result.SKIP,
+        default=Result.WARN,
     )
 
 
@@ -55,13 +55,13 @@ def main(font_paths: list[Path]) -> int:
                 print(
                     f"  {worst.value} {target_lang_config['name']} (not supported by shaperglot)"
                 )
-            elif worst == Result.FAIL or worst == Result.WARN:
+            elif worst == Result.PASS:
+                print(f"  {worst.value} {target_lang_config['name']}")
+            else:
                 print(f"  {target_lang_config['name']}:")
                 exit_status = 1
                 for result in itertools.chain(report.fails, report.warns):
                     print(f"    {result}")
-            else:
-                print(f"  {worst.value} {target_lang_config['name']}")
         print()
     return exit_status
 

--- a/qa/target_langs.txt
+++ b/qa/target_langs.txt
@@ -11,7 +11,6 @@ fi_Latn
 fr_Latn
 gl_Latn
 gsw_Latn
-gsw_Latn
 is_Latn
 ga_Latn
 it_Latn
@@ -34,3 +33,8 @@ sma_Latn
 gsw_Latn
 tr_Latn
 cy_Latn
+az_Latn
+ig_Latn
+ha_Latn
+vi_Latn
+yo_Latn


### PR DESCRIPTION
Adds a custom script/reporter for shaperglot to serve our needs

Adds language coverage for v2.003 from #804 

Pipeline is failing because target language support isn't in yet, presumably we need an import for this