### PR TITLE
Exclude `com.google.fonts/check/gsub/smallcaps_before_ligatures`

### DIFF
--- a/qa/check-sources.py
+++ b/qa/check-sources.py
@@ -24,4 +24,8 @@ PROFILE = {
             "com.google.fonts/check/googlesansflex/sources/kerning_present",
         ]
     },
+    "exclude_checks": [
+        # https://github.com/googlefonts/googlesans-flex/issues/972
+        "com.google.fonts/check/gsub/smallcaps_before_ligatures",
+    ],
 }


### PR DESCRIPTION
Fixes #972 