### PR TITLE
Include `com.google.fonts/check/gsub/smallcaps_before_ligatures`

### DIFF
--- a/qa/check-sources.py
+++ b/qa/check-sources.py
@@ -26,8 +26,4 @@ PROFILE = {
             "com.google.fonts/check/googlesansflex/sources/no_open_corners",
         ]
     },
-    "exclude_checks": [
-        # https://github.com/googlefonts/googlesans-flex/issues/972
-        "com.google.fonts/check/gsub/smallcaps_before_ligatures",
-    ],
 }


### PR DESCRIPTION
Closes #976 - a new Fontbakery release has been cut, addressing the original concerns that resulting in this check being excluded