### PR TITLE
Migrate private Fontbakery checks to open-sourced equivalents

### DIFF
--- a/qa/check-sources.py
+++ b/qa/check-sources.py
@@ -22,11 +22,11 @@ PROFILE = {
             "googlesansflex/sources/suspicious_kerning_values",
             "googlesansflex/sources/same_kerning_groups",
             "googlesansflex/sources/kerning_present",
-            "googlesansflex/sources/all_quadratics",
             "googlesansflex/sources/no_open_corners",
             "googlesansflex/sources/decomposed_by_skip",
             "googlesansflex/sources/decomposed_by_mix",
             "googlesansflex/sources/decomposed_by_var_transform",
+            "ufo_consistent_curve_type",
         ]
     },
 }

--- a/qa/check-sources.py
+++ b/qa/check-sources.py
@@ -20,13 +20,13 @@ PROFILE = {
         "Google Sans Flex Source Checks": [
             "googlesansflex/sources/same_tabular_width",
             "googlesansflex/sources/suspicious_kerning_values",
-            "googlesansflex/sources/same_kerning_groups",
             "googlesansflex/sources/kerning_present",
-            "googlesansflex/sources/no_open_corners",
             "googlesansflex/sources/decomposed_by_skip",
             "googlesansflex/sources/decomposed_by_mix",
             "googlesansflex/sources/decomposed_by_var_transform",
             "ufo_consistent_curve_type",
+            "designspace_has_consistent_groups",
+            "ufo_no_open_corners",
         ]
     },
 }

--- a/qa/checks/sources.py
+++ b/qa/checks/sources.py
@@ -90,8 +90,15 @@ def check_same_tabular_widths(ufo_font: Font, config) -> CheckStatus:
                 Message(
                     "mismatching-tabular-widths",
                     f"layer '{layer_name}':\n\n"
-                    f"""{utils.bullet_list(config, [f"{name} ({width}) has different width than {ref_name} ({ref_width})"
-                     for (name, width, ref_name, ref_width) in warnings])}""",
+                    f"""{
+                        utils.bullet_list(
+                            config,
+                            [
+                                f"{name} ({width}) has different width than {ref_name} ({ref_width})"
+                                for (name, width, ref_name, ref_width) in warnings
+                            ],
+                        )
+                    }""",
                 ),
             )
 
@@ -139,13 +146,15 @@ def check_suspicious_kerning_values(ufo_font: Font, config) -> CheckStatus:
             Message(
                 "suspicious-kerning-values",
                 f"Kerning values outside the accepted range of [{threshold_low}, {threshold_high}]:\n\n"
-                f"""{utils.bullet_list(
-                    config,
-                    [
-                        f"Pair {pair} (e.g. {example}): {value}"
-                        for (pair, example, value) in suspicious_kerning
-                    ],
-                )}""",
+                f"""{
+                    utils.bullet_list(
+                        config,
+                        [
+                            f"Pair {pair} (e.g. {example}): {value}"
+                            for (pair, example, value) in suspicious_kerning
+                        ],
+                    )
+                }""",
             ),
         )
 
@@ -204,40 +213,6 @@ def check_kerning_present(ds: DesignSpaceDocument) -> CheckStatus:
                 WARN,
                 f"{source.filename}: Found no kerning pairs (not counting exceptions)",
             )
-
-
-@check(id="googlesansflex/sources/all_quadratics")
-def check_all_quadratics(config, ufo: Ufo) -> CheckStatus:
-    """Checks all curves in the font are quadratic"""
-
-    font = ufo.ufo_font  # type: ignore
-    assert isinstance(font, Font)
-
-    offending_glyphs = [
-        glyph.name
-        for layer in font.layers
-        for glyph in layer
-        if any(
-            point.type == "curve"
-            for contour in glyph.contours
-            for point in contour.points
-        )
-    ]
-
-    if offending_glyphs:
-        yield (
-            FAIL,
-            Message(
-                "cubics-found",
-                f"{ufo.file_displayname} contains glyphs with cubic curves:\n\n"
-                f"{utils.bullet_list(config, offending_glyphs)}\n",
-            ),
-        )
-    else:
-        yield (
-            PASS,
-            "No cubic curves found",
-        )
 
 
 @check(id="googlesansflex/sources/no_open_corners")

--- a/qa/checks/sources.py
+++ b/qa/checks/sources.py
@@ -159,24 +159,6 @@ def check_suspicious_kerning_values(ufo_font: Font, config) -> CheckStatus:
         )
 
 
-@check(id="googlesansflex/sources/same_kerning_groups")
-def check_same_kerning_groups(ds: DesignSpaceDocument) -> CheckStatus:
-    """Confirms that all sources have the same kerning groups per Designspace."""
-
-    default_source = ds.findDefault()
-    reference = default_source.font.groups
-    for source in ds.sources:
-        if source is default_source:
-            continue
-        if source.font.groups == reference:
-            yield PASS, f"{source.filename} has same kerning groups as default source"
-        else:
-            yield (
-                WARN,
-                f"{source.filename} does not have the same kerning groups as default source",
-            )
-
-
 @check(id="googlesansflex/sources/kerning_present")
 def check_kerning_present(ds: DesignSpaceDocument) -> CheckStatus:
     """Check how much kerning pairs a source has, not counting exceptions."""
@@ -212,43 +194,6 @@ def check_kerning_present(ds: DesignSpaceDocument) -> CheckStatus:
             yield (
                 WARN,
                 f"{source.filename}: Found no kerning pairs (not counting exceptions)",
-            )
-
-
-@check(id="googlesansflex/sources/no_open_corners")
-def check_no_open_corners(config, ufo: Ufo) -> CheckStatus:
-    """Check the sources have no corners, as Google Sans Flex's design with ROND
-    is incompatible with this approach"""
-    from glyphsLib.filters.eraseOpenCorners import EraseOpenCornersPen
-    from fontTools.pens.basePen import NullPen
-
-    font = ufo.ufo_font  # type: ignore
-    assert isinstance(font, Font)
-
-    default_layer_name = font.layers.defaultLayer.name
-    for layer in font.layers:
-        offending_glyphs = []
-        for glyph in layer:
-            the_void = NullPen()
-            erase_open_corners = EraseOpenCornersPen(the_void)
-            for contour in glyph.contours:
-                contour.draw(erase_open_corners)
-            if erase_open_corners.affected:
-                offending_glyphs.append(glyph.name)
-
-        if offending_glyphs:
-            location_str = (
-                ufo.file_displayname
-                if layer.name == default_layer_name
-                else f"{ufo.file_displayname} (layer {layer.name})"
-            )
-            yield (
-                FAIL,
-                Message(
-                    "open-corners-found",
-                    f"{location_str} contains glyphs with open corners:\n\n"
-                    f"{utils.bullet_list(config, offending_glyphs)}\n",
-                ),
             )
 
 


### PR DESCRIPTION
- [x] Sources: `com.google.fonts/check/googlesansflex/sources/all_quadratics`
  - Replaced with: `com.daltonmaag/check/consistent_curve_type`
  - Contribution upstream: https://github.com/fonttools/fontbakery/pull/4795
  - Released in Fontbakery v0.12.9
- [x] Sources: `com.google.fonts/check/googlesansflex/sources/no_open_corners`
  - Replaced with: `com.daltonmaag/check/no_open_corners`
  - Contribution upstream: https://github.com/fonttools/fontbakery/pull/4808
  - Released in Fontbakery v0.12.10
- [x] Sources: `com.google.fonts/check/googlesansflex/sources/same_kerning_groups`
  - Replaced with: `com.daltonmaag/check/designspace_has_consistent_groups`
  - Contribution upstream: https://github.com/fonttools/fontbakery/pull/4814
  - Released in Fontbakery v0.12.10