### PR TITLE
Check vertical extremes

### DIFF
--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -34,6 +34,7 @@ PROFILE = {
             "com.google.fonts/check/googlesansflex/vf/axis_names",
             "com.google.fonts/check/googlesansflex/vf/fvardefault",
             "com.google.fonts/check/googlesansflex/opentype/global_fu_attributes",
+            "com.google.fonts/check/googlesansflex/vf/win_extremes",
         ]
     },
     "exclude_checks": [

--- a/qa/checks/googlesans.py
+++ b/qa/checks/googlesans.py
@@ -25,6 +25,8 @@ from fontbakery.utils import (
     compute_unicoderange_bits,
     unicoderange_bit_name,
 )
+from fontTools.pens.boundsPen import BoundsPen
+from fontTools.ttLib import TTFont
 
 # Each VF we build will have one of these suffixes depending on whether it
 # includes the full designspace or is restricted to upright or italic only.
@@ -298,3 +300,86 @@ def com_google_fonts_check_googlesansflex_variable_fvar_default(font: Font, ttFo
             )
         else:
             yield PASS, f"Font contains the expected fvar {tag} default."
+
+
+@check(
+    id="com.google.fonts/check/googlesansflex/vf/win_extremes",
+    conditions=["is_variable_font"],
+    rationale="""
+    Checks that the OS/2.usWinAscent and OS/2.usWinDescent values do not vary
+    across the designspace, and that they are sufficient to cover the extremes
+    on the y-axis across every glyph at every named instance.
+
+    The former is an engineering decision for Google Sans Flex, in order to have
+    consistent Win vertical metrics at every position within the VF and in any
+    instanced sub-VFs.
+
+    The latter ensures that clipping does not occur at common non-default
+    positions in the designspace. Checking only against yMin and yMax is not
+    sufficient to ensure this, as yMin and yMax are defined only for the default
+    instance, while extreme vertical coordinates are more likely to occur at
+    axis extremes.
+    """,
+)
+def com_google_fonts_check_googlesansflex_vf_win_extremes(ttFont: TTFont):
+    """
+    Checks that the OS/2.usWinAscent and OS/2.usWinDescent values do not vary
+    across the designspace, and that they are sufficient to cover the extremes
+    on the y-axis across every glyph at every named instance.
+    """
+
+    # Get the OS/2.usWin{Ascent,Descent} metrics.
+    ascent: int = ttFont["OS/2"].usWinAscent  # type: ignore
+    descent: int = ttFont["OS/2"].usWinDescent  # type: ignore
+
+    # Assert that they do not vary across the designspace.
+    mvar = ttFont.get("MVAR")
+    if mvar is not None:
+        variated_tags = {
+            tag for record in mvar.table.ValueRecord for tag in record.ValueTag
+        }
+
+        if "hcla" in variated_tags:
+            yield FAIL, "TTF varies OS/2.usWinAscent across its designspace"
+        if "hcld" in variated_tags:
+            yield FAIL, "TTF varies OS/2.usWinDescent across its designspace"
+
+    # TODO: This is only named instances; we should include everywhere we have
+    # sources.
+    interesting_locations = [
+        named_instance.coordinates for named_instance in ttFont["fvar"].instances
+    ]
+
+    # Assert that the yMin/yMax of every glyph at every position does not exceed
+    # the metrics.
+    smallest_y_min = None
+    largest_y_max = None
+    for location in interesting_locations:
+        glyph_set = ttFont.getGlyphSet(
+            preferCFF=False, location=location, normalized=False
+        )
+        for glyph_name in ttFont.getGlyphOrder():
+            glyph = glyph_set[glyph_name]
+            bounds_pen = BoundsPen(glyph_set)
+            glyph.draw(bounds_pen)
+
+            bounds = bounds_pen.bounds
+            if bounds is None:
+                # Glyph was empty.
+                continue
+
+            (_, y_min, _, y_max) = bounds_pen.bounds
+
+            smallest_y_min = (
+                y_min if smallest_y_min is None else min(y_min, smallest_y_min)
+            )
+            largest_y_max = (
+                y_max if largest_y_max is None else max(y_max, largest_y_max)
+            )
+
+    # TODO: Round floats in some direction (but consider how this will interact with the +1).
+    if smallest_y_min is not None and -smallest_y_min >= descent:
+        yield FAIL, f"OS/2.usWinDescent must be at least {-smallest_y_min + 1} to extend further than the smallest y coordinate seen in outlines, but was only {descent}"
+
+    if largest_y_max is not None and largest_y_max >= ascent:
+        yield FAIL, f"OS/2.usWinAscent must be at least {largest_y_max + 1} to extend further than the largest y coordinate seen in outlines, but was only {ascent}"

--- a/scripts/one-off/find_max_ymax.py
+++ b/scripts/one-off/find_max_ymax.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Google Sans Flex Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Output a TSV containing the largest yMax found in each source of the
+designspace.
+
+This is helpful for working out what to set the WinAscent value to; we typically
+set this to the yMax + 1."""
+
+from fontTools.designspaceLib import DesignSpaceDocument
+from ufoLib2 import Font
+
+doc = DesignSpaceDocument.fromfile(r"sources/GoogleSansFlex.designspace")
+doc.loadSourceFonts(Font.open)
+
+
+source_to_ymax: dict[str, float] = {}
+
+# Get the largest yMax seen across all glyph bounds in each designspace source.
+for source in doc.sources:
+    assert isinstance(source.font, Font)
+
+    # Get the correct layer depending on what the designspace source specifies.
+    layer = (
+        source.font.layers.defaultLayer
+        if source.layerName is None
+        else source.font.layers[source.layerName]
+    )
+
+    # Get the largest yMax across all bounds, extending beyond control points.
+    y_max = float(
+        max(
+            bounds[3]
+            for glyph in layer
+            if ((bounds := glyph.getBounds(layer)) is not None)
+        )
+    )
+
+    # Store the result for this source.
+    assert source.name is not None
+    assert source.name not in source_to_ymax
+    source_to_ymax[source.name] = y_max
+
+# Output a .tsv file with the results.
+for source_name, ymax in sorted(source_to_ymax.items()):
+    print(source_name, ymax, sep="\t")

--- a/scripts/one-off/find_vertical_extremes.py
+++ b/scripts/one-off/find_vertical_extremes.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Output a TSV containing the largest yMax found in each source of the
-designspace.
+"""Output a TSV containing the most extreme yMin and yMax found in each source
+of the designspace.
 
-This is helpful for working out what to set the WinAscent value to; we typically
-set this to the yMax + 1."""
+This is helpful for working out what to set the WinAscent and WinDescent values
+to; we typically set these to 1 more than the most extreme value in each
+vertical direction."""
 
 from fontTools.designspaceLib import DesignSpaceDocument
 from ufoLib2 import Font
@@ -25,7 +26,7 @@ doc = DesignSpaceDocument.fromfile(r"sources/GoogleSansFlex.designspace")
 doc.loadSourceFonts(Font.open)
 
 
-source_to_ymax: dict[str, float] = {}
+source_to_extremes: dict[str, tuple[float, float]] = {}
 
 # Get the largest yMax seen across all glyph bounds in each designspace source.
 for source in doc.sources:
@@ -38,20 +39,20 @@ for source in doc.sources:
         else source.font.layers[source.layerName]
     )
 
-    # Get the largest yMax across all bounds, extending beyond control points.
-    y_max = float(
-        max(
-            bounds[3]
-            for glyph in layer
-            if ((bounds := glyph.getBounds(layer)) is not None)
-        )
-    )
+    bounds = [
+        bounds for glyph in layer if ((bounds := glyph.getBounds(layer)) is not None)
+    ]
 
-    # Store the result for this source.
+    # Get the vertical extremes across every glyph, extending beyond control
+    # points.
+    y_min = float(min(bounds.yMin for bounds in bounds))
+    y_max = float(max(bounds.yMax for bounds in bounds))
+
+    # Store the results for this source.
     assert source.name is not None
-    assert source.name not in source_to_ymax
-    source_to_ymax[source.name] = y_max
+    assert source.name not in source_to_extremes
+    source_to_extremes[source.name] = (y_min, y_max)
 
 # Output a .tsv file with the results.
-for source_name, ymax in sorted(source_to_ymax.items()):
-    print(source_name, ymax, sep="\t")
+for source_name, (y_min, y_max) in sorted(source_to_extremes.items()):
+    print(source_name, y_min, y_max, sep="\t")


### PR DESCRIPTION
This branch contains:

* The script used to generate [our report on the y-axis extremes in each source](https://docs.google.com/spreadsheets/d/1ISNGNcIr-gFNhjCZUb2AmZ9N6aRNe2LQYQofAshdogw/edit?usp=sharing)
* A FontBakery check for this project's OS/2.WinAscent and OS/2.WinDescent semantics

The latter is WIP, and in general this branch is non-urgent and does not need merging until after the v2.003 release :)