### PR TITLE
GitHub workflow for workspace fonts

### DIFF
--- a/.github/actions/cut-workspace-fonts/README.md
+++ b/.github/actions/cut-workspace-fonts/README.md
@@ -1,0 +1,11 @@
+# cut-workspace-fonts
+
+Pre-requisites:
+1. Expects Python to have been set up
+2. Expects the working branch to be checked out in the current working directory
+
+Inputs:
+1. `vf-artifact` - the artifact containing the big VF
+
+Outputs:
+1. `artifact-name` - the artifact containg the workspace fonts

--- a/.github/actions/cut-workspace-fonts/action.yml
+++ b/.github/actions/cut-workspace-fonts/action.yml
@@ -1,0 +1,45 @@
+name: Cut workspace fonts
+description: Slicing workspace fonts from the main Flex VF
+
+inputs:
+  vf-artifact:
+    description: The artifact name for the main VF
+    required: true
+
+outputs:
+  artifact-name:
+    description: The artifact name for the workspace fonts
+    value: ${{ steps.artifact-name.outputs.artifact-name }}
+
+runs:
+  using: composite
+  steps:
+  - name: Log inputs
+    shell: bash
+    run: 'echo "vf-artifact: ${{ inputs.vf-artifact }}"'
+  - name: Download main VF
+    uses: actions/download-artifact@v4
+    with:
+      name: ${{ inputs.vf-artifact }}
+      path: fonts/variable
+  - name: Setup venv
+    shell: bash
+    run: make venv
+  - name: Slice workspace fonts
+    shell: bash
+    run: |
+      # Prevent font re-building
+      touch build.stamp
+      make release
+  - name: Generate archive name
+    id: artifact-name
+    uses: alpha-tango-kilo/gha-artifact-name@v1
+    with:
+      repo-name: Google Sans Flex workspace
+  - name: Upload workspace fonts
+    uses: actions/upload-artifact@v4
+    with:
+      name: ${{ steps.artifact-name.outputs.artifact-name }}
+      path: fonts/workspace
+      compression-level: 9
+      if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
   cut-instances:
     needs:
     - build-variable
-    runs-on: googlefonts-64cores-256GB
+    runs-on: googlefonts-16cores-64GB
     timeout-minutes: 10
     steps:
     - name: Checkout ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,34 +39,13 @@ jobs:
       with:
         python-version-file: ./.github/workflows/python-version.txt
         cache: pip
-    - name: Download artifact files
-      uses: actions/download-artifact@v4
+    - name: Cut workspace fonts
+      id: cut-workspace-fonts
+      uses: ./.github/actions/cut-workspace-fonts
       with:
-        name: ${{ needs.build-variable.outputs.artifact-name }}
-        path: fonts/variable
-    - name: Set up venv
-      run: make venv
-    - name: Cut instances
-      run: |
-        touch build.stamp # don't rebuild fonts
-        . venv/bin/activate && make release
-        # Copy README_WORKSPACE.md into the target folder with the fonts
-        cp README_WORKSPACE.md fonts/workspace/
-    - name: Generate archive name
-      id: zip-name
-      uses: alpha-tango-kilo/gha-artifact-name@v1
-      with:
-        repo-name: Google Sans Flex
-        overrides: "release: workspace"
-    - name: Upload archive
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ steps.zip-name.outputs.artifact-name }}
-        path: fonts/workspace
-        compression-level: 9
-        if-no-files-found: error
+        vf-artifact: ${{ needs.build-variable.outputs.artifact-name }}
     outputs:
-      artifact-name: ${{ steps.zip-name.outputs.artifact-name }}
+      artifact-name: ${{ steps.cut-workspace-fonts.outputs.artifact-name }}
   test-variable:
     needs:
     - build-variable

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -1,0 +1,80 @@
+name: Test workspace fonts
+
+on:
+  workflow_dispatch:
+
+# Mostly copied & simplified from release.yml
+jobs:
+  build-variable:
+    runs-on: googlefonts-64cores-256GB
+    timeout-minutes: 15
+    steps:
+    - name: Checkout main
+      uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: ./.github/workflows/python-version.txt
+        cache: pip
+    - name: Build font
+      id: build-ufos
+      uses: ./.github/actions/build-ufos-py
+    outputs:
+      artifact-name: ${{ steps.build-ufos.outputs.artifact-name }}
+  cut-instances:
+    needs:
+    - build-variable
+    runs-on: googlefonts-16cores-64GB
+    timeout-minutes: 10
+    steps:
+    - name: Checkout ${{ github.ref_name }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref_name }}
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: ./.github/workflows/python-version.txt
+        cache: pip
+    - name: Cut workspace fonts
+      id: cut-workspace-fonts
+      uses: ./.github/actions/cut-workspace-fonts
+      with:
+        vf-artifact: ${{ needs.build-variable.outputs.artifact-name }}
+    outputs:
+      artifact-name: ${{ steps.cut-workspace-fonts.outputs.artifact-name }}
+  test-workspace:
+    needs:
+    - cut-instances
+    runs-on: googlefonts-64cores-256GB
+    timeout-minutes: 20
+    steps:
+    - name: Checkout ${{ github.ref_name }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref_name }}
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version-file: ./.github/workflows/python-version.txt
+        cache: pip
+    - name: Download workspace fonts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ needs.cut-instances.outputs.artifact-name }}
+        path: fonts/workspace
+    - name: Run Fontbakery
+      id: fontbakery-workspace
+      env:
+        SKIP_SOURCES: 1
+      run: scripts/fontbakery.sh
+    - name: Upload Fontbakery reports
+      uses: actions/upload-artifact@v4
+      # Always upload reports (even during a pipeline fail), so long as Fontbakery completed
+      # https://docs.github.com/en/actions/learn-github-actions/expressions#always
+      # https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
+      if: ${{ !cancelled() && (steps.fontbakery-workspace.conclusion == 'success' || steps.fontbakery-workspace.conclusion == 'failure') }}
+      with:
+        name: Fontbakery workspace reports
+        path: out/fontbakery
+        if-no-files-found: error

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -51,7 +51,8 @@ class WorkspaceInstance(TypedDict):
     ROND: int
 
 
-# These are then produced at each weight instance defined in the Designspace
+# These are then produced in upright & italic flavours, retaining only the
+# weight variable axis
 TARGET_INSTANCES: dict[str, WorkspaceInstance] = {
     "Google Sans Flex Normal": {
         "opsz": 144,

--- a/scripts/prep-for-playground.sh
+++ b/scripts/prep-for-playground.sh
@@ -21,7 +21,7 @@
 # git reset -q HEAD^ && git restore .github/workflows
 
 # Change runners to free ones
-sed -i 's|googlefonts-64cores-256GB|ubuntu-latest|g' \
+sed -i -E 's|googlefonts-[0-9]+cores-[0-9]+GB|ubuntu-latest|g' \
     .github/workflows/*.{yml,yaml}
 
 # Change timeouts to 60 minutes across the board


### PR DESCRIPTION
This allows us to build & test workspace fonts without needing to make a release. The workflow is manually triggered and always runs off main