### PR TITLE
Add script that reports each glyph's size contribution to 'gvar', to find optimisations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,13 @@ font-size: venv build
 	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::group::Install font-size"
 	venv/bin/pip install -U font-size
 	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::endgroup::"
+	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::group::TTF size report, by table"
 	find fonts -name '*.ttf' -type f | xargs venv/bin/font-size
+	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::endgroup::"
+	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::group::'gvar' size report, by glyph"
+# This script uses the version of rich installed by font-size
+	venv/bin/python scripts/gvar_by_glyph.py fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::endgroup::"
 
 progress-chart: venv
 	. venv/bin/activate && python scripts/gs-progress-burndown.py

--- a/scripts/gvar_by_glyph.py
+++ b/scripts/gvar_by_glyph.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     parser.add_argument("--output", type=Path, required=False, metavar="CSV")
     args = parser.parse_args()
 
-    # Get glyph contributions, and output sorted TSV to stdout.
+    # Get glyph contributions, and output rich report to stdout.
     contribs = get_gvar_contribs(args.ttf)
 
     force_terminal = True if "GITHUB_ACTIONS" in os.environ else None

--- a/scripts/gvar_by_glyph.py
+++ b/scripts/gvar_by_glyph.py
@@ -19,6 +19,7 @@ bytes to the 'gvar' table, for identifying where optimisation is possible.
 
 
 import math
+import os
 from argparse import ArgumentParser
 from pathlib import Path
 
@@ -63,7 +64,9 @@ def output_csv_report(contribs: dict[str, int], path: Path) -> None:
             print(size, glyph, sep="\t", file=output)
 
 
-def output_rich_report(contribs: dict[str, int]) -> None:
+def output_rich_report(
+    contribs: dict[str, int], force_terminal: bool | None = None
+) -> None:
     """Output a formatted table to stdout with rich."""
 
     table = Table(title="'gvar' size contribution by glyph")
@@ -92,7 +95,7 @@ def output_rich_report(contribs: dict[str, int]) -> None:
         ]
         table.add_row(f"[bold {goodness}]{size:_}", glyph)
 
-    console = Console()
+    console = Console(force_terminal=force_terminal)
     console.print(table)
 
 
@@ -105,7 +108,8 @@ if __name__ == "__main__":
     # Get glyph contributions, and output sorted TSV to stdout.
     contribs = get_gvar_contribs(args.ttf)
 
-    output_rich_report(contribs)
+    force_terminal = True if "GITHUB_ACTIONS" in os.environ else None
+    output_rich_report(contribs, force_terminal=force_terminal)
 
     # Optionally, write a tab-delimited CSV report too.
     if args.output:

--- a/scripts/gvar_by_glyph.py
+++ b/scripts/gvar_by_glyph.py
@@ -18,9 +18,15 @@ bytes to the 'gvar' table, for identifying where optimisation is possible.
 """
 
 
-from fontTools.ttLib import TTFont
-from fontTools.ttLib.tables._g_v_a_r import GVAR_HEADER_SIZE, table__g_v_a_r as GVAR
+import math
 from argparse import ArgumentParser
+from pathlib import Path
+
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables._g_v_a_r import GVAR_HEADER_SIZE
+from fontTools.ttLib.tables._g_v_a_r import table__g_v_a_r as GVAR
+from rich.console import Console
+from rich.table import Table
 
 
 def get_gvar_contribs(ttf: TTFont) -> dict[str, int]:
@@ -48,13 +54,59 @@ def get_gvar_contribs(ttf: TTFont) -> dict[str, int]:
     return lengths
 
 
+def output_csv_report(contribs: dict[str, int], path: Path) -> None:
+    """Output a tab-delimited report to the given path."""
+
+    with path.open("w") as output:
+        print("Bytes", "Name", sep="\t", file=output)
+        for size, glyph in sorted((size, glyph) for glyph, size in contribs.items()):
+            print(size, glyph, sep="\t", file=output)
+
+
+def output_rich_report(contribs: dict[str, int]) -> None:
+    """Output a formatted table to stdout with rich."""
+
+    table = Table(title="'gvar' size contribution by glyph")
+
+    table.add_column("Size (bytes)", justify="right")
+    table.add_column("Glyph", justify="left")
+
+    # For linear interpolation of row colour by size.
+    colours = [
+        "green",
+        "cyan",
+        "yellow",
+        "red",
+    ]
+    least = min(contribs.values())
+    most = max(contribs.values())
+
+    for size, glyph in sorted(
+        ((size, glyph) for glyph, size in contribs.items()), reverse=True
+    ):
+        goodness = colours[
+            min(
+                math.floor((size - least) / (most - least) * len(colours)),
+                len(colours) - 1,
+            )
+        ]
+        table.add_row(f"[bold {goodness}]{size:_}", glyph)
+
+    console = Console()
+    console.print(table)
+
+
 if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("ttf", type=TTFont)
+    parser.add_argument("--output", type=Path, required=False, metavar="CSV")
     args = parser.parse_args()
 
     # Get glyph contributions, and output sorted TSV to stdout.
     contribs = get_gvar_contribs(args.ttf)
-    print("Bytes", "Name", sep="\t")
-    for size, glyph in sorted(((size, glyph) for glyph, size in contribs.items())):
-        print(size, glyph, sep="\t")
+
+    output_rich_report(contribs)
+
+    # Optionally, write a tab-delimited CSV report too.
+    if args.output:
+        output_csv_report(contribs, args.output)

--- a/scripts/gvar_by_glyph.py
+++ b/scripts/gvar_by_glyph.py
@@ -1,0 +1,60 @@
+# Copyright 2024 Google Sans Flex authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Command line tool that outputs a sorted TSV giving each glyphs contribution in
+bytes to the 'gvar' table, for identifying where optimisation is possible.
+"""
+
+
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables._g_v_a_r import GVAR_HEADER_SIZE, table__g_v_a_r as GVAR
+from argparse import ArgumentParser
+
+
+def get_gvar_contribs(ttf: TTFont) -> dict[str, int]:
+    """Get the contribution in bytes of each glyph to the 'gvar' table."""
+
+    # Decompile the 'gvar' table.
+    gvar = ttf["gvar"]
+    assert isinstance(gvar, GVAR)
+
+    # Get the raw bytes that make up the table.
+    assert ttf.reader is not None
+    data = ttf.reader["gvar"]
+
+    glyphs: list[str] = ttf.getGlyphOrder()  # type: ignore
+
+    # Use internal API to derive offsets.
+    # See: https://github.com/fonttools/fonttools/blob/a1a5af2f/Lib/fontTools/ttLib/tables/_g_v_a_r.py#L119-L134
+    offsets = gvar.decompileOffsets_(
+        data[GVAR_HEADER_SIZE:],
+        tableFormat=(gvar.flags & 1),  # type: ignore
+        glyphCount=len(glyphs),  # type: ignore
+    )
+    lengths = {name: offsets[gid + 1] - offsets[gid] for gid, name in enumerate(glyphs)}
+
+    return lengths
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("ttf", type=TTFont)
+    args = parser.parse_args()
+
+    # Get glyph contributions, and output sorted TSV to stdout.
+    contribs = get_gvar_contribs(args.ttf)
+    print("Bytes", "Name", sep="\t")
+    for size, glyph in sorted(((size, glyph) for glyph, size in contribs.items())):
+        print(size, glyph, sep="\t")


### PR DESCRIPTION
This draft PR contains the raw script used to produce the raw data of the report breaking down [`gvar` size by glyph](https://docs.google.com/spreadsheets/d/1hn46LgquIAnpYQ8s-PacGnAFv0ikveBwKqAPPP0VcSQ/edit?usp=sharing).

Before merging, we should adapt this PR to run the script on our build workflows - it only takes a second or so - and output something closer to the full report above as an uploaded CSV and/or table in the build log.

---

We can also think about where it could have a nice OSS home to make it available to hand for other projects :)

e.g. fonttools, [font-size](https://github.com/source-foundry/font-size), Font Bakery?