### PR TITLE
Build from Glyphs package: make tests opt-in instead of always enabled

### DIFF
--- a/.github/workflows/build-glyphs.yml
+++ b/.github/workflows/build-glyphs.yml
@@ -6,6 +6,10 @@ on:
       git-ref:
         description: The branch to build from
         required: true
+      run-tests:
+        description: Run tests on built fonts?
+        default: false
+        type: boolean
 
 jobs:
   convert:
@@ -90,6 +94,7 @@ jobs:
     needs:
     - convert
     - build
+    if: ${{ inputs.run-tests }}
     uses: googlefonts/googlesans-flex/.github/workflows/tests.yml@main
     with:
       artifact-as-branch: ${{ needs.convert.outputs.sources-artifact }}.tar


### PR DESCRIPTION
Does what it says on the tin, won't show up until merged to main

Doesn't require any updates to Octavio's branches

![image](https://github.com/user-attachments/assets/c4051069-ccb8-4e83-be3f-83871f024dff)
