### PR TITLE
Disable `gvar` optimisation to avoid #1034, at the cost of file size

### DIFF
--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -151,6 +151,9 @@ def cut_instance(
             "--quiet",
             "--remove-overlaps",
             "--update-name-table",
+            # NOTE: Temporarily disable IUP optimisation when subsetting until
+            # fonttools/fonttools#3634 is resolved.
+            # See googlefonts/googlesans-flex#1034
             "--no-optimize",
             "-o",
             str(output_file),

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -151,6 +151,7 @@ def cut_instance(
             "--quiet",
             "--remove-overlaps",
             "--update-name-table",
+            "--no-optimize",
             "-o",
             str(output_file),
             str(variable_font),


### PR DESCRIPTION
This PR tries disabling IUP `gvar` optimisation for the workspace fonts only as a temporary workaround for #1034, at the cost of file size.

As the workspace fonts only have one axis, their `gvar` tables are not very large, and so this workaround only costs 2-3KB per file.

File | Before | After | Difference | % Difference
:-- | --: | --: | --: | --:
GoogleSansFlexExtraExpanded-Italic[wght].ttf | 274,700 | 277,096 | 2,396 | 0.9%
GoogleSansFlexExtraExpanded[wght].ttf | 268,940 | 272,724 | 3,784 | 1.4%
GoogleSansFlexNormal-Italic[wght].ttf | 271,052 | 273,316 | 2,264 | 0.8%
GoogleSansFlexNormal[wght].ttf | 264,448 | 268,344 | 3,896 | 1.5%
GoogleSansFlexRounded-Italic[wght].ttf | 275,816 | 277,436 | 1,620 | 0.6%
GoogleSansFlexRounded[wght].ttf | 270,900 | 272,596 | 1,696 | 0.6%
GoogleSansFlexSuperCondensed-Italic[wght].ttf | 264,492 | 266,772 | 2,280 | 0.9%
GoogleSansFlexSuperCondensed[wght].ttf | 259,372 | 263,100 | 3,728 | 1.4%
GoogleSansFlexText-Italic[wght].ttf | 266,948 | 268,828 | 1,880 | 0.7%
GoogleSansFlexText[wght].ttf | 259,232 | 262,444 | 3,212 | 1.2%
GoogleSansFlexUltraCondensed-Italic[wght].ttf | 275,740 | 277,984 | 2,244 | 0.8%
GoogleSansFlexUltraCondensed[wght].ttf | 269,396 | 273,296 | 3,900 | 1.4%