### PR TITLE
GitHub workflow: diffenator2 all masters option

### DIFF
--- a/.github/workflows/diffenator.yaml
+++ b/.github/workflows/diffenator.yaml
@@ -9,6 +9,9 @@ on:
       after:
         description: The 'after' git reference (tag, branch, or commit)
         required: true
+      all-masters:
+        description: Check all masters? (--styles masters)
+        type: boolean
 
 jobs:
   build-before:
@@ -59,7 +62,6 @@ jobs:
         if-no-files-found: error
   diffenate:
     runs-on: googlefonts-64cores-256GB
-    timeout-minutes: 30
     needs:
     - build-before
     - build-after
@@ -88,8 +90,15 @@ jobs:
     - name: Run diffenator2
       run: |
         mkdir -p diffenator_report
+        if [[ ${{ inputs.all-masters }} == "true" ]] ; then
+          echo "Checking all locations"
+          STYLES_ARG="--styles masters"
+        else
+          echo "Checking instances"
+          STYLES_ARG="--styles instances"
+        fi
         diffenator2 diff --fonts-before before/*.ttf --fonts-after after/*.ttf \
-          --out diffenator_report
+          $STYLES_ARG --out diffenator_report
     - name: Upload diffenator report
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/diffenator.yaml
+++ b/.github/workflows/diffenator.yaml
@@ -105,3 +105,4 @@ jobs:
         name: Diffenator2 report (${{ inputs.before }} vs ${{ inputs.after }})
         path: diffenator_report
         if-no-files-found: error
+        compression-level: 9


### PR DESCRIPTION
Fixes #1056

![image](https://github.com/user-attachments/assets/7c0ec3a5-cc90-4b99-8dbd-188c02a6da74)

I have removed the GitHub workflow timeout for diffenator2 as I have no idea how long an all-masters report will take on the Google fast runner, but I daresay it'll be significantly longer just instances. The default timeout will apply, which is 6 hours

For reference, on a free runner the default instance checking takes ~30 minutes, but all masters did hit GitHub's 6 hour default timeout 😄 