### PR TITLE
Switch to smaller runners for most jobs

### DIFF
--- a/.github/workflows/build-glyphs.yml
+++ b/.github/workflows/build-glyphs.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   convert:
-    runs-on: googlefonts-64cores-256GB
+    runs-on: googlefonts-8cores-32GB
     timeout-minutes: 20
     steps:
     - name: Checkout main
@@ -66,7 +66,7 @@ jobs:
     outputs:
       sources-artifact: ${{ steps.zip-name.outputs.artifact-name }}
   build:
-    runs-on: googlefonts-64cores-256GB
+    runs-on: googlefonts-8cores-32GB
     timeout-minutes: 15
     needs:
     - convert

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: googlefonts-64cores-256GB
+    runs-on: googlefonts-8cores-32GB
     timeout-minutes: 15
     steps:
     # on: pull_request uses head_ref for branch name, on: push uses ref_name

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   import-branch:
-    runs-on: googlefonts-64cores-256GB
+    runs-on: googlefonts-8cores-32GB
     timeout-minutes: 15
     steps:
       - name: Log & validate inputs
@@ -49,7 +49,7 @@ jobs:
     outputs:
       import-branch: ${{ steps.create-update-import.outputs.import-branch }}
   build-variable:
-    runs-on: googlefonts-64cores-256GB
+    runs-on: googlefonts-8cores-32GB
     timeout-minutes: 15
     needs: import-branch
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-variable:
-    runs-on: googlefonts-64cores-256GB
+    runs-on: googlefonts-8cores-32GB
     timeout-minutes: 15
     steps:
     - name: Checkout ${{ github.ref_name }}
@@ -56,7 +56,7 @@ jobs:
   test-workspace:
     needs:
     - cut-instances
-    runs-on: googlefonts-64cores-256GB
+    runs-on: googlefonts-8cores-32GB
     timeout-minutes: 20
     steps:
     - name: Checkout ${{ github.ref_name }}

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -6,7 +6,7 @@ on:
 # Mostly copied & simplified from release.yml
 jobs:
   build-variable:
-    runs-on: googlefonts-64cores-256GB
+    runs-on: googlefonts-8cores-32GB
     timeout-minutes: 15
     steps:
     - name: Checkout main
@@ -46,7 +46,7 @@ jobs:
   test-workspace:
     needs:
     - cut-instances
-    runs-on: googlefonts-64cores-256GB
+    runs-on: googlefonts-8cores-32GB
     timeout-minutes: 20
     steps:
     - name: Checkout ${{ github.ref_name }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   tests:
-    runs-on: googlefonts-64cores-256GB
+    runs-on: googlefonts-8cores-32GB
     timeout-minutes: 20
     steps:
     - name: Checkout ${{ inputs.branch }}


### PR DESCRIPTION
As requested in #963, moves almost everything to 8 core runners

I've left the diffenator workflow on the big runner as it's known that diffenator can take full advantage of the specs and it takes a fair while to run even doing that

Do not merge this PR unless CI is green - we may hit our timeouts now that we're using weaker runners