### PR TITLE
Check that creation date in `head` is maintained across releases

### DIFF
--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -30,6 +30,7 @@ PROFILE = {
     "sections": {
         "Google Sans Flex Custom Checks": [
             "com.google.fonts/check/googlesansflex/opentype/os2/unicode_range_bits",
+            "com.google.fonts/check/googlesansflex/opentype/head/created",
             "com.google.fonts/check/googlesansflex/vf/fvaraxes",
             "com.google.fonts/check/googlesansflex/vf/axis_names",
             "com.google.fonts/check/googlesansflex/vf/fvardefault",

--- a/qa/checks/googlesans.py
+++ b/qa/checks/googlesans.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from fontbakery.callable import check
@@ -94,6 +95,11 @@ GS_FONTUNIT_ATTRIBUTES_ITALIC = {
     "OS/2.ySubscriptXOffset": -13,
     "OS/2.ySuperscriptXOffset": 62,
 }
+
+# Taken from 2.003 release TTF
+GS_CREATION_DATE = datetime(
+    year=2017, month=7, day=6, hour=9, minute=41, second=44, tzinfo=UTC
+)
 
 # ================================================
 #
@@ -188,6 +194,35 @@ def com_google_fonts_check_googlesansflex_unicode_range_bits(ttFont, unicoderang
                             f"in this range.",
                         ),
                     )
+
+
+@check(
+    id="com.google.fonts/check/googlesansflex/opentype/head/created",
+    rationale="""
+        The `created` date in the OpenType `head` table should be maintained
+        across releases.
+    """,
+)
+def com_google_fonts_check_googlesansflex_head_created(ttFont):
+    """
+    The `created` date in the OpenType `head` table should be maintained across
+    releases.
+    """
+
+    # Serialised creation date is the number of seconds since this epoch
+    # See: https://learn.microsoft.com/en-us/typography/opentype/spec/head
+    opentype_epoch = datetime(
+        year=1904, month=1, day=1, hour=0, minute=0, second=0, tzinfo=UTC
+    )
+    actual = opentype_epoch + timedelta(seconds=ttFont["head"].created)
+
+    if actual == GS_CREATION_DATE:
+        yield PASS, "Creation date in `head` is unchanged since initial release."
+    else:
+        yield (
+            FAIL,
+            f"Creation date in `head` has been modified since initial release: expected '{GS_CREATION_DATE}' but saw '{actual}'.",
+        )
 
 
 # ================================================


### PR DESCRIPTION
Implements #1070

Ocassionally we have had to reset this field manually:

- 03e557a4eea3dfa6564a8b97a9d90cc509a19655
- 9806e34acb8c881c2aa94dade1b72f0373ffdb85

and while the root issue should now be addressed (corrected in Glyphs sources on main), automated tests can lend full confidence that this metadata will stay the same forever.