### PR TITLE
Rename Android TTF in release archive to GoogleSansFlex-Regular.ttf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,8 +149,10 @@ jobs:
         
         android_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} Android.zip"
         echo "android-zip-name=$android_zip_name" >> "$GITHUB_OUTPUT"
-        cd "$GITHUB_WORKSPACE/${{ needs.cut-instances.outputs.android-artifact-name }}" \
-          && zip -9 "../$android_zip_name" *.ttf *.md
+        cd "$GITHUB_WORKSPACE/${{ needs.cut-instances.outputs.android-artifact-name }}"
+        # Rename file to match what Android's already using (regardless as to how representative the name is)
+        mv GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf GoogleSansFlex-Regular.ttf
+        zip -9 "../$android_zip_name" *.ttf *.md
     - name: Upload variable font archive to release
       uses: svenstaro/upload-release-action@v2
       with:


### PR DESCRIPTION
Closes #1051 (again)

Renames the font only in the release archive to retain a more informative/representative name for as long as possible, and to not mess up the Fontbakery checks