### PR TITLE
Promote `com.google.fonts/check/metadata/unreachable_subsetting` to FAIL

### DIFF
--- a/qa/check-googlesans.toml
+++ b/qa/check-googlesans.toml
@@ -30,3 +30,8 @@ exclude_checks = [
     "STAT_strings",                                    # we're intentionally calling slant italic https://github.com/googlefonts/googlesans-flex/issues/774#issuecomment-1921326716
     "unwanted_tables",
 ]
+
+[[overrides]]
+code = "unreachable-subsetting"
+status = "FAIL"
+reason = "https://github.com/googlefonts/googlesans-flex/issues/1092"


### PR DESCRIPTION
Harry's suggestion as part of #1092 

Note: the pipeline is failing because this check is currently failing