### PR TITLE
Increase timeout for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   tests:
     runs-on: googlefonts-8cores-32GB
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
     - name: Checkout ${{ inputs.branch }}
       if: ${{ inputs.artifact-as-branch == '' }}


### PR DESCRIPTION
Follow up to #1072

Octavio was experience Fontbakery checks timing out, so I'm increasing the amount of time they get to run

e.g. https://github.com/googlefonts/googlesans-flex/actions/runs/11999267766/job/33447167821