### PR TITLE
Remove Yoruba from target languages (temporarily)

### DIFF
--- a/qa/target_langs.txt
+++ b/qa/target_langs.txt
@@ -36,5 +36,4 @@ az_Latn
 ig_Latn
 ha_Latn
 vi_Latn
-yo_Latn
 zlm_Latn


### PR DESCRIPTION
To be reverted after the next release

Finishes fixing #1127 