### PR TITLE
Bump workspace/Android QA to 30 minute timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
     needs:
     - cut-instances
     runs-on: googlefonts-8cores-32GB
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
     - name: Checkout ${{ github.ref_name }}
       uses: actions/checkout@v4


### PR DESCRIPTION
Fixes #1133

There has not been a sudden increase, but instead we have been edging closer to 20 minutes for a while now, and gaining a few checks from the latest Font Bakery release may have nudged us over.