### PR TITLE
Add GitHub workflow permissions necessary for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,8 @@ jobs:
     - test-workspace-android
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
     - name: Download variable fonts
       uses: actions/download-artifact@v4


### PR DESCRIPTION
Also adds some logic to automatically install cairo if not found (as this repo doesn't use f-actions/font-bakery)