### PR TITLE
Install cairo when the CI does not already include it

### DIFF
--- a/scripts/fontbakery.sh
+++ b/scripts/fontbakery.sh
@@ -27,12 +27,14 @@ all_ttfs="$(find fonts/ -name '*.ttf')"
 cd "$(dirname "${BASH_SOURCE[0]}" | xargs dirname)"
 
 # Check if we're on Ubuntu and cairo isn't installed
-. /etc/os-release
-if [[ "$ID" == "ubuntu" ]] && ! dpkg --list | grep --quiet "^ii libcairo2-dev "; then
-    [ -n "$GITHUB_RUN_ID" ] && echo "::group::Installing cairo"
-    sudo apt-get update --quiet --quiet
-    sudo apt-get install --yes --no-install-recommends --quiet libcairo2-dev
-    [ -n "$GITHUB_RUN_ID" ] && echo "::endgroup::"
+if [[ -f /etc/os-release ]]; then
+    . /etc/os-release
+    if [[ "$ID" == "ubuntu" ]] && ! dpkg --list | grep --quiet "^ii libcairo2-dev "; then
+        [ -n "$GITHUB_RUN_ID" ] && echo "::group::Installing cairo"
+        sudo apt-get update --quiet --quiet
+        sudo apt-get install --yes --no-install-recommends --quiet libcairo2-dev
+        [ -n "$GITHUB_RUN_ID" ] && echo "::endgroup::"
+    fi
 fi
 
 # Setup venv with dependencies

--- a/scripts/fontbakery.sh
+++ b/scripts/fontbakery.sh
@@ -26,14 +26,14 @@ all_ttfs="$(find fonts/ -name '*.ttf')"
 # Switch to repo path by going to the parent folder of where this script is
 cd "$(dirname "${BASH_SOURCE[0]}" | xargs dirname)"
 
-# Check if we're on Ubuntu and cairo isn't installed
-if [[ -f /etc/os-release ]]; then
+# Check if we're on an Ubuntu CI and cairo isn't installed
+if [ -n "$GITHUB_RUN_ID" ] && [[ -f /etc/os-release ]]; then
     . /etc/os-release
     if [[ "$ID" == "ubuntu" ]] && ! dpkg --list | grep --quiet "^ii libcairo2-dev "; then
-        [ -n "$GITHUB_RUN_ID" ] && echo "::group::Installing cairo"
+        echo "::group::Installing cairo"
         sudo apt-get update --quiet --quiet
         sudo apt-get install --yes --no-install-recommends --quiet libcairo2-dev
-        [ -n "$GITHUB_RUN_ID" ] && echo "::endgroup::"
+        echo "::endgroup::"
     fi
 fi
 

--- a/scripts/fontbakery.sh
+++ b/scripts/fontbakery.sh
@@ -26,6 +26,15 @@ all_ttfs="$(find fonts/ -name '*.ttf')"
 # Switch to repo path by going to the parent folder of where this script is
 cd "$(dirname "${BASH_SOURCE[0]}" | xargs dirname)"
 
+# Check if we're on Ubuntu and cairo isn't installed
+. /etc/os-release
+if [[ "$ID" == "ubuntu" ]] && ! dpkg --list | grep --quiet "^ii libcairo2-dev "; then
+    [ -n "$GITHUB_RUN_ID" ] && echo "::group::Installing cairo"
+    sudo apt-get update --quiet --quiet
+    sudo apt-get install --yes --no-install-recommends --quiet libcairo2-dev
+    [ -n "$GITHUB_RUN_ID" ] && echo "::endgroup::"
+fi
+
 # Setup venv with dependencies
 [ -n "$GITHUB_RUN_ID" ] && echo "::group::Set up venv"
 test -d venv_bakery || python3 -m venv venv_bakery


### PR DESCRIPTION
Partitioned from @RickyDaMa's PR at #1135:

We use the paid Google Fonts runners on this repository, so this is not normally an issue, but is invaluable for when we test with (or if we move in the future to) plain Ubuntu runners.