### PR TITLE
Fix `fvar` instances in workspace build

### DIFF
--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -30,6 +30,7 @@ from fontTools.ttLib import TTFont
 from fontTools.ttLib.tables import otTables as ot
 from fontTools.ttLib.tables.O_S_2f_2 import Panose
 from fontv.libfv import FontVersion
+from gftools.fix import fix_fvar_instances
 from prune_font_binary import main as prune_font_binary_main
 from ufo2ft.fontInfoData import (
     getAttrWithFallback,
@@ -55,7 +56,7 @@ class WorkspaceInstance(TypedDict):
 
 # These are then produced in upright & italic flavours, retaining only the
 # weight variable axis
-TARGET_INSTANCES: list[tuple[str, WorkspaceInstance, dict[Any, Any]]] = [
+TARGET_INSTANCES: list[tuple[str, WorkspaceInstance]] = [
     (
         "Google Sans Flex Normal",
         {
@@ -63,7 +64,6 @@ TARGET_INSTANCES: list[tuple[str, WorkspaceInstance, dict[Any, Any]]] = [
             "wdth": 100,
             "ROND": 0,
         },
-        {"should_add_fvar_instances": False},
     ),
     (
         "Google Sans Flex Text",
@@ -72,8 +72,7 @@ TARGET_INSTANCES: list[tuple[str, WorkspaceInstance, dict[Any, Any]]] = [
             "wdth": 100,
             "ROND": 0,
         },
-        {"should_add_fvar_instances": True},   
-    ), 
+    ),
     (
         "Google Sans Flex Rounded",
         {
@@ -81,7 +80,6 @@ TARGET_INSTANCES: list[tuple[str, WorkspaceInstance, dict[Any, Any]]] = [
             "wdth": 100,
             "ROND": 100,
         },
-        {"should_add_fvar_instances": True},
     ),
     (
         "Google Sans Flex SemiRounded",
@@ -90,7 +88,6 @@ TARGET_INSTANCES: list[tuple[str, WorkspaceInstance, dict[Any, Any]]] = [
             "wdth": 100,
             "ROND": 40,
         },
-        {"should_add_fvar_instances": True},   
     ),
     (
         "Google Sans Flex UltraCondensed",
@@ -99,7 +96,6 @@ TARGET_INSTANCES: list[tuple[str, WorkspaceInstance, dict[Any, Any]]] = [
             "wdth": 50,
             "ROND": 0,
         },
-        {"should_add_fvar_instances": True},   
     ),
     (
         "Google Sans Flex SuperCondensed",
@@ -108,8 +104,7 @@ TARGET_INSTANCES: list[tuple[str, WorkspaceInstance, dict[Any, Any]]] = [
             "wdth": 25,
             "ROND": 0,
         },
-        {"should_add_fvar_instances": True},   
-    ),    
+    ),
     (
         "Google Sans Flex ExtraExpanded",
         {
@@ -117,11 +112,8 @@ TARGET_INSTANCES: list[tuple[str, WorkspaceInstance, dict[Any, Any]]] = [
             "wdth": 150,
             "ROND": 0,
         },
-        {"should_add_fvar_instances": True},   
     ),
 ]
-
-
 
 
 # Global Google Sans attributes, in 1000 upM font units.
@@ -148,30 +140,6 @@ GS_OS2_ATTRIBUTES_ITALIC = {
     "ySuperscriptXOffset": 62,
 }
 
-# From https://github.com/googlefonts/axisregistry/blob/main/Lib/axisregistry/__init__.py#L32
-GF_STATIC_STYLES_UPRIGHT = [
-    ("Thin", 100),
-    ("ExtraLight", 200),
-    ("Light", 300),
-    ("Regular", 400),
-    ("Medium", 500),
-    ("SemiBold", 600),
-    ("Bold", 700),
-    ("ExtraBold", 800),
-    ("Black", 900),
-]
-GF_STATIC_STYLES_ITALIC = [
-    ("Thin Italic", 100),
-    ("ExtraLight Italic", 200),
-    ("Light Italic", 300),
-    ("Italic", 400),
-    ("Medium Italic", 500),
-    ("SemiBold Italic", 600),
-    ("Bold Italic", 700),
-    ("ExtraBold Italic", 800),
-    ("Black Italic", 900),
-]
-
 
 def cut_instance(
     variable_font: Path,
@@ -179,7 +147,6 @@ def cut_instance(
     family_name: str | None,
     style_name: str | None,
     output_file: Path,
-    should_add_fvar_instances: bool,
 ) -> None:
     user_location_args = [f"{k}={v}" for k, v in user_location.items()]
 
@@ -279,8 +246,9 @@ def cut_instance(
     #     if before_val != after_val:
     #         print(f"{attr}: {before_val} -> {after_val}")
 
-    if should_add_fvar_instances:
-        add_fvar_instances(font, is_italic)
+    # Restore weight instances if they were pruned in slicing.
+    fix_fvar_instances(font)
+
     add_STAT_ital(font, is_italic)
     remove_STAT_useless_axes(font, is_italic)
 
@@ -365,21 +333,6 @@ def generate_panose_entries(location: GoogleSansFlexInstance) -> Panose:
     return panose
 
 
-def add_fvar_instances(font: TTFont, is_italic: bool) -> None:
-    """Add instances from 100 to 900 along the Weight axis."""
-    from fontTools.ttLib.tables._f_v_a_r import NamedInstance
-
-    fvar = font["fvar"]
-    name = font["name"]
-    for style, weight in (
-        GF_STATIC_STYLES_ITALIC if is_italic else GF_STATIC_STYLES_UPRIGHT
-    ):
-        inst = NamedInstance()
-        inst.subfamilyNameID = name.addName(style)
-        inst.coordinates = {"wght": weight}  # No avar mapping in this font
-        fvar.instances.append(inst)
-
-
 def add_STAT_ital(font: TTFont, is_italic: bool) -> None:
     """Add an ital axis to STAT to link the separate files for uprights and italics.
 
@@ -459,13 +412,11 @@ def otlib_optimise_gpos(ttf_path: Path) -> None:
     fontTools.otlLib.optimize.gpos.compact(ttf, 5)
 
 
-def cut_then_post_process(
-    cut_instance_args: list[Any], cut_instance_kwargs: dict[Any, Any]
-) -> None:
+def cut_then_post_process(cut_instance_args: list[Any]) -> None:
     ttf_path: Path = cut_instance_args[-1]
 
     print(f"Cutting {ttf_path.name}")
-    cut_instance(*cut_instance_args, **cut_instance_kwargs)
+    cut_instance(*cut_instance_args)
 
     print(f"Pruning {ttf_path.name}")
     prune_font_binary_main([str(ttf_path)])
@@ -492,7 +443,7 @@ def main(args: list[str] | None = None) -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     with multiprocessing.Pool() as pool:
-        for (family_name, workspace_instance, kwargs), italic in itertools.product(
+        for (family_name, workspace_instance), italic in itertools.product(
             TARGET_INSTANCES, (False, True)
         ):
             coordinates: GoogleSansFlexInstance = {
@@ -521,7 +472,6 @@ def main(args: list[str] | None = None) -> int:
                         "Italic" if italic else None,  # style_name: str | None
                         ttf_path,  # output_file: Path
                     ],
-                    kwargs,
                 ),
                 error_callback=lambda err: print(f"cut_then_post_process error: {err}"),
             )

--- a/scripts/cut_instances.py
+++ b/scripts/cut_instances.py
@@ -63,7 +63,7 @@ TARGET_INSTANCES: list[tuple[str, WorkspaceInstance, dict[Any, Any]]] = [
             "wdth": 100,
             "ROND": 0,
         },
-        {"should_add_fvar_instances": True},
+        {"should_add_fvar_instances": False},
     ),
     (
         "Google Sans Flex Text",


### PR DESCRIPTION
It looks like #1140 snuck back in after the old workspace locations were re-introduced; I've made a slightly different fix this time and reused gftool's `fvar` instance logic, which means we do not have to update this manually in the future.

<details>
 <summary>Full fvar instances after fix</summary>
 
- GoogleSansFlexExtraExpanded-Italic[wght].ttf
    - Thin Italic (GoogleSansFlexExtraExpanded-ThinItalic): {'wght': 100.0}
    - ExtraLight Italic (GoogleSansFlexExtraExpanded-ExtraLightItalic): {'wght': 200.0}
    - Light Italic (GoogleSansFlexExtraExpanded-LightItalic): {'wght': 300.0}
    - Italic (GoogleSansFlexExtraExpanded-Italic): {'wght': 400.0}
    - Medium Italic (GoogleSansFlexExtraExpanded-MediumItalic): {'wght': 500.0}
    - SemiBold Italic (GoogleSansFlexExtraExpanded-SemiBoldItalic): {'wght': 600.0}
    - Bold Italic (GoogleSansFlexExtraExpanded-BoldItalic): {'wght': 700.0}
    - ExtraBold Italic (GoogleSansFlexExtraExpanded-ExtraBoldItalic): {'wght': 800.0}
    - Black Italic (GoogleSansFlexExtraExpanded-BlackItalic): {'wght': 900.0}

- GoogleSansFlexExtraExpanded[wght].ttf
    - Thin (GoogleSansFlexExtraExpanded-Thin): {'wght': 100.0}
    - ExtraLight (GoogleSansFlexExtraExpanded-ExtraLight): {'wght': 200.0}
    - Light (GoogleSansFlexExtraExpanded-Light): {'wght': 300.0}
    - Regular (GoogleSansFlexExtraExpanded-Regular): {'wght': 400.0}
    - Medium (GoogleSansFlexExtraExpanded-Medium): {'wght': 500.0}
    - SemiBold (GoogleSansFlexExtraExpanded-SemiBold): {'wght': 600.0}
    - Bold (GoogleSansFlexExtraExpanded-Bold): {'wght': 700.0}
    - ExtraBold (GoogleSansFlexExtraExpanded-ExtraBold): {'wght': 800.0}
    - Black (GoogleSansFlexExtraExpanded-Black): {'wght': 900.0}

- GoogleSansFlexNormal-Italic[wght].ttf
    - Thin Italic (GoogleSansFlexNormal-ThinItalic): {'wght': 100.0}
    - ExtraLight Italic (GoogleSansFlexNormal-ExtraLightItalic): {'wght': 200.0}
    - Light Italic (GoogleSansFlexNormal-LightItalic): {'wght': 300.0}
    - Italic (GoogleSansFlexNormal-Italic): {'wght': 400.0}
    - Medium Italic (GoogleSansFlexNormal-MediumItalic): {'wght': 500.0}
    - SemiBold Italic (GoogleSansFlexNormal-SemiBoldItalic): {'wght': 600.0}
    - Bold Italic (GoogleSansFlexNormal-BoldItalic): {'wght': 700.0}
    - ExtraBold Italic (GoogleSansFlexNormal-ExtraBoldItalic): {'wght': 800.0}
    - Black Italic (GoogleSansFlexNormal-BlackItalic): {'wght': 900.0}

- GoogleSansFlexNormal[wght].ttf
    - Thin (GoogleSansFlexNormal-Thin): {'wght': 100.0}
    - ExtraLight (GoogleSansFlexNormal-ExtraLight): {'wght': 200.0}
    - Light (GoogleSansFlexNormal-Light): {'wght': 300.0}
    - Regular (GoogleSansFlexNormal-Regular): {'wght': 400.0}
    - Medium (GoogleSansFlexNormal-Medium): {'wght': 500.0}
    - SemiBold (GoogleSansFlexNormal-SemiBold): {'wght': 600.0}
    - Bold (GoogleSansFlexNormal-Bold): {'wght': 700.0}
    - ExtraBold (GoogleSansFlexNormal-ExtraBold): {'wght': 800.0}
    - Black (GoogleSansFlexNormal-Black): {'wght': 900.0}

- GoogleSansFlexRounded-Italic[wght].ttf
    - Thin Italic (GoogleSansFlexRounded-ThinItalic): {'wght': 100.0}
    - ExtraLight Italic (GoogleSansFlexRounded-ExtraLightItalic): {'wght': 200.0}
    - Light Italic (GoogleSansFlexRounded-LightItalic): {'wght': 300.0}
    - Italic (GoogleSansFlexRounded-Italic): {'wght': 400.0}
    - Medium Italic (GoogleSansFlexRounded-MediumItalic): {'wght': 500.0}
    - SemiBold Italic (GoogleSansFlexRounded-SemiBoldItalic): {'wght': 600.0}
    - Bold Italic (GoogleSansFlexRounded-BoldItalic): {'wght': 700.0}
    - ExtraBold Italic (GoogleSansFlexRounded-ExtraBoldItalic): {'wght': 800.0}
    - Black Italic (GoogleSansFlexRounded-BlackItalic): {'wght': 900.0}

- GoogleSansFlexRounded[wght].ttf
    - Thin (GoogleSansFlexRounded-Thin): {'wght': 100.0}
    - ExtraLight (GoogleSansFlexRounded-ExtraLight): {'wght': 200.0}
    - Light (GoogleSansFlexRounded-Light): {'wght': 300.0}
    - Regular (GoogleSansFlexRounded-Regular): {'wght': 400.0}
    - Medium (GoogleSansFlexRounded-Medium): {'wght': 500.0}
    - SemiBold (GoogleSansFlexRounded-SemiBold): {'wght': 600.0}
    - Bold (GoogleSansFlexRounded-Bold): {'wght': 700.0}
    - ExtraBold (GoogleSansFlexRounded-ExtraBold): {'wght': 800.0}
    - Black (GoogleSansFlexRounded-Black): {'wght': 900.0}

- GoogleSansFlexSemiRounded-Italic[wght].ttf
    - Thin Italic (GoogleSansFlexSemiRounded-ThinItalic): {'wght': 100.0}
    - ExtraLight Italic (GoogleSansFlexSemiRounded-ExtraLightItalic): {'wght': 200.0}
    - Light Italic (GoogleSansFlexSemiRounded-LightItalic): {'wght': 300.0}
    - Italic (GoogleSansFlexSemiRounded-Italic): {'wght': 400.0}
    - Medium Italic (GoogleSansFlexSemiRounded-MediumItalic): {'wght': 500.0}
    - SemiBold Italic (GoogleSansFlexSemiRounded-SemiBoldItalic): {'wght': 600.0}
    - Bold Italic (GoogleSansFlexSemiRounded-BoldItalic): {'wght': 700.0}
    - ExtraBold Italic (GoogleSansFlexSemiRounded-ExtraBoldItalic): {'wght': 800.0}
    - Black Italic (GoogleSansFlexSemiRounded-BlackItalic): {'wght': 900.0}

- GoogleSansFlexSemiRounded[wght].ttf
    - Thin (GoogleSansFlexSemiRounded-Thin): {'wght': 100.0}
    - ExtraLight (GoogleSansFlexSemiRounded-ExtraLight): {'wght': 200.0}
    - Light (GoogleSansFlexSemiRounded-Light): {'wght': 300.0}
    - Regular (GoogleSansFlexSemiRounded-Regular): {'wght': 400.0}
    - Medium (GoogleSansFlexSemiRounded-Medium): {'wght': 500.0}
    - SemiBold (GoogleSansFlexSemiRounded-SemiBold): {'wght': 600.0}
    - Bold (GoogleSansFlexSemiRounded-Bold): {'wght': 700.0}
    - ExtraBold (GoogleSansFlexSemiRounded-ExtraBold): {'wght': 800.0}
    - Black (GoogleSansFlexSemiRounded-Black): {'wght': 900.0}

- GoogleSansFlexSuperCondensed-Italic[wght].ttf
    - Thin Italic (GoogleSansFlexSuperCondensed-ThinItalic): {'wght': 100.0}
    - ExtraLight Italic (GoogleSansFlexSuperCondensed-ExtraLightItalic): {'wght': 200.0}
    - Light Italic (GoogleSansFlexSuperCondensed-LightItalic): {'wght': 300.0}
    - Italic (GoogleSansFlexSuperCondensed-Italic): {'wght': 400.0}
    - Medium Italic (GoogleSansFlexSuperCondensed-MediumItalic): {'wght': 500.0}
    - SemiBold Italic (GoogleSansFlexSuperCondensed-SemiBoldItalic): {'wght': 600.0}
    - Bold Italic (GoogleSansFlexSuperCondensed-BoldItalic): {'wght': 700.0}
    - ExtraBold Italic (GoogleSansFlexSuperCondensed-ExtraBoldItalic): {'wght': 800.0}
    - Black Italic (GoogleSansFlexSuperCondensed-BlackItalic): {'wght': 900.0}

- GoogleSansFlexSuperCondensed[wght].ttf
    - Thin (GoogleSansFlexSuperCondensed-Thin): {'wght': 100.0}
    - ExtraLight (GoogleSansFlexSuperCondensed-ExtraLight): {'wght': 200.0}
    - Light (GoogleSansFlexSuperCondensed-Light): {'wght': 300.0}
    - Regular (GoogleSansFlexSuperCondensed-Regular): {'wght': 400.0}
    - Medium (GoogleSansFlexSuperCondensed-Medium): {'wght': 500.0}
    - SemiBold (GoogleSansFlexSuperCondensed-SemiBold): {'wght': 600.0}
    - Bold (GoogleSansFlexSuperCondensed-Bold): {'wght': 700.0}
    - ExtraBold (GoogleSansFlexSuperCondensed-ExtraBold): {'wght': 800.0}
    - Black (GoogleSansFlexSuperCondensed-Black): {'wght': 900.0}

- GoogleSansFlexText-Italic[wght].ttf
    - Thin Italic (GoogleSansFlexText-ThinItalic): {'wght': 100.0}
    - ExtraLight Italic (GoogleSansFlexText-ExtraLightItalic): {'wght': 200.0}
    - Light Italic (GoogleSansFlexText-LightItalic): {'wght': 300.0}
    - Italic (GoogleSansFlexText-Italic): {'wght': 400.0}
    - Medium Italic (GoogleSansFlexText-MediumItalic): {'wght': 500.0}
    - SemiBold Italic (GoogleSansFlexText-SemiBoldItalic): {'wght': 600.0}
    - Bold Italic (GoogleSansFlexText-BoldItalic): {'wght': 700.0}
    - ExtraBold Italic (GoogleSansFlexText-ExtraBoldItalic): {'wght': 800.0}
    - Black Italic (GoogleSansFlexText-BlackItalic): {'wght': 900.0}

- GoogleSansFlexText[wght].ttf
    - Thin (GoogleSansFlexText-Thin): {'wght': 100.0}
    - ExtraLight (GoogleSansFlexText-ExtraLight): {'wght': 200.0}
    - Light (GoogleSansFlexText-Light): {'wght': 300.0}
    - Regular (GoogleSansFlexText-Regular): {'wght': 400.0}
    - Medium (GoogleSansFlexText-Medium): {'wght': 500.0}
    - SemiBold (GoogleSansFlexText-SemiBold): {'wght': 600.0}
    - Bold (GoogleSansFlexText-Bold): {'wght': 700.0}
    - ExtraBold (GoogleSansFlexText-ExtraBold): {'wght': 800.0}
    - Black (GoogleSansFlexText-Black): {'wght': 900.0}

- GoogleSansFlexUltraCondensed-Italic[wght].ttf
    - Thin Italic (GoogleSansFlexUltraCondensed-ThinItalic): {'wght': 100.0}
    - ExtraLight Italic (GoogleSansFlexUltraCondensed-ExtraLightItalic): {'wght': 200.0}
    - Light Italic (GoogleSansFlexUltraCondensed-LightItalic): {'wght': 300.0}
    - Italic (GoogleSansFlexUltraCondensed-Italic): {'wght': 400.0}
    - Medium Italic (GoogleSansFlexUltraCondensed-MediumItalic): {'wght': 500.0}
    - SemiBold Italic (GoogleSansFlexUltraCondensed-SemiBoldItalic): {'wght': 600.0}
    - Bold Italic (GoogleSansFlexUltraCondensed-BoldItalic): {'wght': 700.0}
    - ExtraBold Italic (GoogleSansFlexUltraCondensed-ExtraBoldItalic): {'wght': 800.0}
    - Black Italic (GoogleSansFlexUltraCondensed-BlackItalic): {'wght': 900.0}

- GoogleSansFlexUltraCondensed[wght].ttf
    - Thin (GoogleSansFlexUltraCondensed-Thin): {'wght': 100.0}
    - ExtraLight (GoogleSansFlexUltraCondensed-ExtraLight): {'wght': 200.0}
    - Light (GoogleSansFlexUltraCondensed-Light): {'wght': 300.0}
    - Regular (GoogleSansFlexUltraCondensed-Regular): {'wght': 400.0}
    - Medium (GoogleSansFlexUltraCondensed-Medium): {'wght': 500.0}
    - SemiBold (GoogleSansFlexUltraCondensed-SemiBold): {'wght': 600.0}
    - Bold (GoogleSansFlexUltraCondensed-Bold): {'wght': 700.0}
    - ExtraBold (GoogleSansFlexUltraCondensed-ExtraBold): {'wght': 800.0}
    - Black (GoogleSansFlexUltraCondensed-Black): {'wght': 900.0}
</details>