### PR TITLE
Add dependabot configuration for GH Actions version update monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,11 @@ version: 2
 updates:
   # GitHub Actions dependencies
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      # Also check composite actions; we must manually give this directory until
+      # https://github.com/dependabot/dependabot-core/issues/6704 is implemented
+      - "/.github/actions/*/"
     schedule:
       interval: "daily"
       time: "00:00"


### PR DESCRIPTION
Adds a dependabot configuration to monitor and propose PR updates of our GitHub Actions dependency versions