### PR TITLE
Prune `HVAR` from Android build target 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ android: build.stamp
 		--ymin -605 --ymax 2007 \
 		fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf \
 		--output fonts/android/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+	venv/bin/python scripts/prune_hvar.py \
+		fonts/android/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
 
 workspace: build.stamp
 	-@rm fonts/workspace/*.ttf

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -36,6 +36,7 @@ PROFILE = {
             "googlesansflex/vf/fvardefault",
             "googlesansflex/opentype/global_fu_attributes",
             "googlesansflex/android_ymin_ymax",
+            "googlesansflex/android_hvar",
         ]
     },
     "exclude_checks": [

--- a/qa/checks/googlesans.py
+++ b/qa/checks/googlesans.py
@@ -360,3 +360,23 @@ def com_google_fonts_check_android_ymin_ymax(font: Font, ttFont: TTFont):
         yield FAIL, f"yMin was {head.yMin} instead of -605"
     if head.yMax != 2007:
         yield FAIL, f"yMax was {head.yMax} instead of 2007"
+
+
+@check(
+    id="googlesansflex/android_hvar",
+    rationale="""
+    Confirms the Android-specific Flex build has no `HVAR` table.
+
+    See: https://github.com/googlefonts/googlesans-flex/issues/1154
+    """,
+)
+def com_google_fonts_check_android_hvar(font: Font, ttFont: TTFont):
+    """Confirms the Android-specific Flex build has no `HVAR` table"""
+
+    font_path = Path(font.file)
+    if font_path.parent.name != "android":
+        yield SKIP, "Not Android flavour Flex"
+        return
+
+    if "HVAR" in ttFont:
+        yield FAIL, f"{font_path} contains an `HVAR` table, but should not"

--- a/qa/checks/googlesans.py
+++ b/qa/checks/googlesans.py
@@ -338,7 +338,6 @@ def com_google_fonts_check_googlesansflex_variable_fvar_default(font: Font, ttFo
 
 @check(
     id="googlesansflex/android_ymin_ymax",
-    conditions=["is_variable_font"],
     rationale="""
     Confirms the Android-specific Flex build has the correct yMin/yMax
     """,
@@ -347,7 +346,8 @@ def com_google_fonts_check_android_ymin_ymax(font: Font, ttFont: TTFont):
     """Confirms the Android-specific Flex build has the correct yMin/yMax"""
     font_path = Path(font.file)
     if font_path.parent.name != "android":
-        return SKIP, "Not Android flavour Flex"
+        yield SKIP, "Not Android flavour Flex"
+        return
 
     # Reopen the font fresh because the ttFont we get as argument seems to have
     # had its head yMin and yMax recomputed to the values from the font,

--- a/scripts/prune_hvar.py
+++ b/scripts/prune_hvar.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     parser.add_argument("ttf", type=Path)
     args = parser.parse_args()
 
-    ttf = TTFont(args.ttf)
+    ttf = TTFont(args.ttf, recalcBBoxes=False)
     del ttf["HVAR"]
     ttf.save(args.ttf)
     # That's it!

--- a/scripts/prune_hvar.py
+++ b/scripts/prune_hvar.py
@@ -1,0 +1,34 @@
+# Copyright 2025 Google Sans Flex authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Remove the HVAR table from the TTF, and make no other changes.
+
+This is used for the Android build, where it results in a smaller file, and
+better performance."""
+
+from argparse import ArgumentParser
+from fontTools.ttLib import TTFont
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.description = __doc__
+    parser.add_argument("ttf", type=Path)
+    args = parser.parse_args()
+
+    ttf = TTFont(args.ttf)
+    del ttf["HVAR"]
+    ttf.save(args.ttf)
+    # That's it!


### PR DESCRIPTION
Closes https://github.com/googlefonts/googlesans-flex/issues/1154

In addition, this PR:
- Adds a Font Bakery check to confirm the removal; and
- Tidies an existing custom check.

## TODOs

- [x] Confirm before/after of `HVAR` pruning is sound