### PR TITLE
Add explicit permission required for import commit to be created

### DIFF
--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -14,6 +14,9 @@ jobs:
   import-branch:
     runs-on: googlefonts-8cores-32GB
     timeout-minutes: 15
+    permissions:
+      # Explicit permission is required to push the import commit.
+      contents: write
     steps:
       - name: Log & validate inputs
         run: |


### PR DESCRIPTION
Fixes #1161 

This will fix the import job, as erroring here: https://github.com/googlefonts/googlesans-flex/actions/runs/16284450363

In addition, I investigated all of the workflows and shared actions to see if there is anywhere else requiring an explicit permission. All actions that push to the repository or upload to a release are equipped, and so I am satisfied that the permissions are now complete, as that is the most notable behaviour we perform beyond typical artefact uploads and downloads.

We'll still want to keep an eye on this as it is tricky to be exhaustive, but I am confident we've got them all this time :)