### PR TITLE
Add minussuperior and multiplysuperior to calculator subsetter

### DIFF
--- a/scripts/variant/calculator.py
+++ b/scripts/variant/calculator.py
@@ -296,6 +296,8 @@ SUBSET_BY_NAME = {
     "zero.dnom.percent",
     "_dotsdivide",
     "percentbar.tab",
+    "uni207B",
+    "multiplysuperior",
 }
 
 ############


### PR DESCRIPTION
This adds the two new glyphs added in https://github.com/googlefonts/googlesans-flex/pull/1169.

<img width="2531" height="996" alt="image" src="https://github.com/user-attachments/assets/7dc52cc7-34da-4d85-9317-1d3e58cbb592" />
