### PR TITLE
Make Google TV fonts releaseable.

### DIFF
--- a/.github/actions/cut-workspace-fonts/action.yml
+++ b/.github/actions/cut-workspace-fonts/action.yml
@@ -36,10 +36,12 @@ runs:
     uses: alpha-tango-kilo/gha-artifact-name@v1
     with:
       repo-name: Google Sans Flex workspace
-  - name: Upload workspace fonts
+  - name: Upload workspace and tv fonts
     uses: actions/upload-artifact@v4
     with:
       name: ${{ steps.artifact-name.outputs.artifact-name }}
-      path: fonts/workspace
+      path: |
+        fonts/workspace
+        fonts/tv
       compression-level: 9
       if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
 
         tv_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} tv.zip"
         echo "tv-zip-name=$tv_zip_name" >> "$GITHUB_OUTPUT"
-        cd "$GITHUB_tv/${{ needs.cut-instances.outputs.workspace-artifact-name }}/tv" \
+        cd "$GITHUB_WORKSPACE/${{ needs.cut-instances.outputs.workspace-artifact-name }}/tv" \
           && zip -9 "../../$tv_zip_name" *.ttf *.md
         
         android_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} Android.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,3 +186,7 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         file: ${{ steps.release-archives.outputs.android-zip-name }}
+    - name: Upload tv font archive to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        file: ${{ steps.release-archives.outputs.tv-zip-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,15 +83,19 @@ jobs:
       with:
         python-version-file: ./.github/workflows/python-version.txt
         cache: pip
-    - name: Download workspace fonts
+    - name: Download workspace and tv fonts
       uses: actions/download-artifact@v4
       with:
         name: ${{ needs.cut-instances.outputs.workspace-artifact-name }}
-        path: fonts/workspace
+        path: fonts/
     - name: Check workspace fonts with OT Sanitizer
       uses: f-actions/opentype-sanitizer@v3
       with:
         path: fonts/workspace/*.ttf
+    - name: Check tv fonts with OT Sanitizer
+      uses: f-actions/opentype-sanitizer@v3
+      with:
+        path: fonts/tv/*.ttf
     - name: Download Android font
       uses: actions/download-artifact@v4
       with:
@@ -132,7 +136,7 @@ jobs:
       with:
         name: ${{ needs.build-variable.outputs.artifact-name }}
         path: ${{ needs.build-variable.outputs.artifact-name }}
-    - name: Download workspace fonts
+    - name: Download workspace and tv fonts
       uses: actions/download-artifact@v4
       with:
         name: ${{ needs.cut-instances.outputs.workspace-artifact-name }}
@@ -154,8 +158,13 @@ jobs:
 
         workspace_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} workspace.zip"
         echo "workspace-zip-name=$workspace_zip_name" >> "$GITHUB_OUTPUT"
-        cd "$GITHUB_WORKSPACE/${{ needs.cut-instances.outputs.workspace-artifact-name }}" \
+        cd "$GITHUB_WORKSPACE/${{ needs.cut-instances.outputs.workspace-artifact-name }}/workspace" \
           && zip -9 "../$workspace_zip_name" *.ttf *.md
+
+        tv_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} tv.zip"
+        echo "tv-zip-name=$tv_zip_name" >> "$GITHUB_OUTPUT"
+        cd "$GITHUB_tv/${{ needs.cut-instances.outputs.workspace-artifact-name }}/tv" \
+          && zip -9 "../$tv_zip_name" *.ttf *.md
         
         android_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} Android.zip"
         echo "android-zip-name=$android_zip_name" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,12 +159,12 @@ jobs:
         workspace_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} workspace.zip"
         echo "workspace-zip-name=$workspace_zip_name" >> "$GITHUB_OUTPUT"
         cd "$GITHUB_WORKSPACE/${{ needs.cut-instances.outputs.workspace-artifact-name }}/workspace" \
-          && zip -9 "../$workspace_zip_name" *.ttf *.md
+          && zip -9 "../../$workspace_zip_name" *.ttf *.md
 
         tv_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} tv.zip"
         echo "tv-zip-name=$tv_zip_name" >> "$GITHUB_OUTPUT"
         cd "$GITHUB_tv/${{ needs.cut-instances.outputs.workspace-artifact-name }}/tv" \
-          && zip -9 "../$tv_zip_name" *.ttf *.md
+          && zip -9 "../../$tv_zip_name" *.ttf *.md
         
         android_zip_name="GoogleSansFlex-${GITHUB_REF#refs/*/} Android.zip"
         echo "android-zip-name=$android_zip_name" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -58,11 +58,11 @@ jobs:
       with:
         python-version-file: ./.github/workflows/python-version.txt
         cache: pip
-    - name: Download workspace fonts
+    - name: Download workspace and tv fonts
       uses: actions/download-artifact@v4
       with:
         name: ${{ needs.cut-instances.outputs.artifact-name }}
-        path: fonts/workspace
+        path: fonts/
     - name: Run Fontbakery
       id: fontbakery-workspace
       env:

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,13 @@ android: build.stamp
 
 workspace: build.stamp
 	-@rm fonts/workspace/*.ttf
+	-@rm fonts/tv/*.ttf
 	. venv/bin/activate && python scripts/cut_instances.py \
 		fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf \
 		fonts/workspace
-	. venv/bin/activate && pyftsubset fonts/workspace/GoogleSansFlexTV[wght].ttf --output-file=fonts/workspace/GoogleSansFlexTV[wght].ttf --unicodes="U+D-25CC,U+FB00-1D61E" --layout-features="tnum,numr,subs,sups,frac,ordn,dnom,zero,kern,locl,mark,mkmk,ccmp,liga" --recalc-average-width --notdef-outline
+	mkdir -p fonts/tv
+	mv fonts/workspace/GoogleSansFlexTV[wght].ttf fonts/tv
+	. venv/bin/activate && pyftsubset fonts/tv/GoogleSansFlexTV[wght].ttf --output-file=fonts/tv/GoogleSansFlexTV[wght].ttf --unicodes="U+D-25CC,U+FB00-1D61E" --layout-features="tnum,numr,subs,sups,frac,ordn,dnom,zero,kern,locl,mark,mkmk,ccmp,liga" --recalc-average-width --recalc-max-context --recalc-bounds --notdef-outline
 
 release: android workspace
 

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -37,6 +37,7 @@ PROFILE = {
             "googlesansflex/opentype/global_fu_attributes",
             "googlesansflex/android_ymin_ymax",
             "googlesansflex/android_hvar",
+            "googlesansflex/varfont/has_HVAR",
         ]
     },
     "exclude_checks": [
@@ -61,6 +62,7 @@ PROFILE = {
         "opentype/family/consistent_family_name",  # intended with our statics
         "name/family_and_style_max_length",  # we know our statics exceed this limit and it's okay
         "opentype/varfont/family_axis_ranges",  # our workspace fonts intentionally change axes ranges
+        "googlefonts/varfont/has_HVAR",  # The Android font has no HVAR, so we had to modify this check into `googlesansflex/varfont/has_HVAR`
     ],
     "overrides": {
         "varfont/consistent_axes": [

--- a/qa/checks/charset.py
+++ b/qa/checks/charset.py
@@ -15,7 +15,7 @@
 from difflib import unified_diff
 from pathlib import Path
 
-from fontbakery.prelude import check, FAIL, PASS
+from fontbakery.prelude import check, FAIL, PASS, SKIP
 
 # ================================================
 # Glyph set checks
@@ -42,6 +42,10 @@ def com_google_fonts_check_googlesans_glyphs_glyphset_contents(font, ttFont):
     non-Unicode encoded glyph definitions. This test does not require the
     glyph order to match.
     """
+
+    if "Google Sans Flex TV" in ttFont["name"].getDebugName(1):
+        yield SKIP, "Font is not interesting to check."
+        return
 
     glyph_defs_dir = Path("qa", "definitions")
 

--- a/qa/checks/fea.py
+++ b/qa/checks/fea.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from fontbakery.prelude import FAIL, PASS, check, condition
+from fontbakery.prelude import FAIL, PASS, SKIP, check, condition
 from fontbakery.testable import Font
 
 GOOGLESANS_PROFILE_CHECKS = [
@@ -88,6 +88,11 @@ def is_variable_font(font: Font):
 )
 def com_google_fonts_check_googlesans_features_variable_uprights(ttFont):
     """Confirms that the upright builds contain expected feature tags."""
+
+    if "Google Sans Flex TV" in ttFont["name"].getDebugName(1):
+        yield SKIP, "Font is not interesting to check."
+        return
+
     tt = ttFont
     gpos = tt.get("GPOS")
     gsub = tt.get("GSUB")

--- a/qa/checks/googlesans.py
+++ b/qa/checks/googlesans.py
@@ -362,6 +362,46 @@ def com_google_fonts_check_android_ymin_ymax(font: Font, ttFont: TTFont):
         yield FAIL, f"yMax was {head.yMax} instead of 2007"
 
 
+# Copy of the check from fontbakery 1.0.1 to ignore our Android font without a
+# HVAR table.
+@check(
+    id="googlesansflex/varfont/has_HVAR",
+    rationale="""
+        Not having a HVAR table can lead to costly text-layout operations on some
+        platforms, which we want to avoid.
+
+        So, all variable fonts on the Google Fonts collection should have an HVAR
+        with valid values.
+
+        More info on the HVAR table can be found at:
+        https://docs.microsoft.com/en-us/typography/opentype/spec/otvaroverview#variation-data-tables-and-miscellaneous-requirements
+    """,
+    # FIX-ME: We should clarify which are these platforms in which there can be issues
+    #         with costly text-layout operations when an HVAR table is missing!
+    conditions=["is_variable_font"],
+    proposal="https://github.com/fonttools/fontbakery/issues/2119",
+)
+def check_varfont_has_HVAR(ttFont):
+    """Check that variable fonts have an HVAR table."""
+
+    font_path = Path(ttFont.reader.file.name)
+    if font_path.parent.name == "android":
+        yield SKIP, "Android flavour Flex has no HVAR"
+        return
+
+    if "HVAR" not in ttFont.keys():
+        yield (
+            FAIL,
+            Message(
+                "lacks-HVAR",
+                "All variable fonts on the Google Fonts collection"
+                " must have a properly set HVAR table in order"
+                " to avoid costly text-layout operations on"
+                " certain platforms.",
+            ),
+        )
+
+
 @check(
     id="googlesansflex/android_hvar",
     rationale="""

--- a/qa/checks/shaping.py
+++ b/qa/checks/shaping.py
@@ -38,6 +38,11 @@ def hb_font(font: Font):
 @check(id="googlesans/features/regression")
 def com_google_fonts_check_googlesans_features_regression(font: Font, ttFont, hb_font):
     """But does it shape?"""
+
+    if "Google Sans Flex TV" in ttFont["name"].getDebugName(1):
+        yield SKIP, "Font is not interesting to check."
+        return
+
     filename = Path(font.file)
 
     shaping_file_found = False

--- a/sources/config.yaml
+++ b/sources/config.yaml
@@ -17,6 +17,9 @@ buildStatic: false
 reverseOutlineDirection: true
 removeOutlineOverlaps: false
 
+# Work around https://github.com/fonttools/fonttools/issues/3905.
+extraVariableFontmakeArgs: "--no-auto-use-my-metrics"
+
 stat:
   "GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf":
     - name: Optical Size


### PR DESCRIPTION
As requested in the chat.

* Fix TV checks by subsetting better
* Ignore some checks for TV fonts
* Update the GitHub Actions to release TV fonts in the workspace package.
* Work around a bug in the font compiler that resulted in variable fonts without an `HVAR` table shaping differently than with.