### PR TITLE
Use uv for venv management

### DIFF
--- a/.github/actions/build-ufos-py/README.md
+++ b/.github/actions/build-ufos-py/README.md
@@ -7,7 +7,7 @@ Inputs:
 1. `repo-path` - the location of the repository to build (default `.`, i.e. `$GITHUB_WORKSPACE`)
 
 Steps:
-1. Set up venv
+1. Set up uv
 2. Run `make bump-to-tag` if release
 3. Build
 4. Upload zip artifact

--- a/.github/actions/build-ufos-py/action.yml
+++ b/.github/actions/build-ufos-py/action.yml
@@ -15,12 +15,13 @@ outputs:
 runs:
   using: composite
   steps:
-  - name: Set up venv
-    shell: bash
-    run: |
-      echo "::group::Set up venv"
-      make --directory ${{ inputs.repo-path }} venv
-      echo "::endgroup::"
+  - name: Set up uv and enable caching
+    uses: astral-sh/setup-uv@v6
+    with:
+      enable-cache: true
+      cache-dependency-glob: |
+        requirements*.txt
+        requirements*.in
   - name: Bump sources version to release tag version
     if: github.event_name == 'release'
     shell: bash

--- a/.github/actions/cut-workspace-fonts/action.yml
+++ b/.github/actions/cut-workspace-fonts/action.yml
@@ -22,9 +22,13 @@ runs:
     with:
       name: ${{ inputs.vf-artifact }}
       path: fonts/variable
-  - name: Setup venv
-    shell: bash
-    run: make venv
+  - name: Set up uv and enable caching
+    uses: astral-sh/setup-uv@v6
+    with:
+      enable-cache: true
+      cache-dependency-glob: |
+        requirements*.txt
+        requirements*.in
   - name: Slice workspace fonts
     shell: bash
     run: |

--- a/.github/actions/glyphspackage2ufo/action.yml
+++ b/.github/actions/glyphspackage2ufo/action.yml
@@ -43,6 +43,13 @@ runs:
       normalized_target="$(readlink -f "$GITHUB_WORKSPACE/$target")"
       echo "glyphspackage2ufo.outputs.directory: $normalized_target"
       echo "target=$normalized_target" >> "$GITHUB_OUTPUT"
+  - name: Set up uv and enable caching
+    uses: astral-sh/setup-uv@v6
+    with:
+      enable-cache: true
+      cache-dependency-glob: |
+        requirements*.txt
+        requirements*.in
   - name: Run import script
     shell: bash
     run: |
@@ -51,10 +58,8 @@ runs:
       # output target=, because it's been prepared to NOT have leftover UFOs
       # which is required to be able to emit a clean DS+UFOs
       cd "${{ steps.prepare-import.outputs.target }}"
-      echo "::group::Setup venv"
-      make venv
-      echo "::endgroup::"
       echo "Running glyphs_to_ds.py"
-      venv/bin/python scripts/glyphs_to_ds.py \
+      uv run --python $(cat .github/workflows/python-version.txt) --with-requirements requirements.txt \
+        scripts/glyphs_to_ds.py \
         "$GITHUB_WORKSPACE/octavio/sources/design-source/GSF-full.glyphspackage" \
         --output sources/GoogleSansFlex.designspace

--- a/.github/workflows/build-glyphs.yml
+++ b/.github/workflows/build-glyphs.yml
@@ -33,7 +33,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ./main/.github/workflows/python-version.txt
-        cache: pip
     - name: Convert Glyphs package sources to UFO
       id: glyphspackage2ufo
       uses: ./main/.github/actions/glyphspackage2ufo
@@ -82,7 +81,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ./.github/workflows/python-version.txt
-        cache: pip
     - name: Build fonts
       id: build-ufos
       uses: ./.github/actions/build-ufos-py

--- a/.github/workflows/build-glyphs.yml
+++ b/.github/workflows/build-glyphs.yml
@@ -42,7 +42,6 @@ jobs:
       shell: bash
       run: |
         cd "${{ steps.glyphspackage2ufo.outputs.directory }}"
-        rm -r venv
         shopt -s dotglob
         tar --create --exclude-vcs --file "UFO sources.tar" *
     - name: Generate sources artifact name

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ./.github/workflows/python-version.txt
-        cache: pip
     - name: Build font
       id: build-ufos
       uses: ./.github/actions/build-ufos-py

--- a/.github/workflows/burndown.yml
+++ b/.github/workflows/burndown.yml
@@ -14,7 +14,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: pip
+      - name: Set up uv and enable caching
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            requirements*.txt
+            requirements*.in
       - name: Cache load
         uses: actions/cache/restore@v3
         with:

--- a/.github/workflows/diffenator.yaml
+++ b/.github/workflows/diffenator.yaml
@@ -27,8 +27,13 @@ jobs:
       with:
         python-version-file: .github/workflows/python-version.txt
         cache: pip
-    - name: Setup venv
-      run: make venv
+    - name: Set up uv and enable caching
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          requirements*.txt
+          requirements*.in
     - name: Build fonts
       run: make build
     - name: Upload artifact
@@ -50,8 +55,13 @@ jobs:
       with:
         python-version-file: .github/workflows/python-version.txt
         cache: pip
-    - name: Setup venv
-      run: make venv
+    - name: Set up uv and enable caching
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          requirements*.txt
+          requirements*.in
     - name: Build fonts
       run: make build
     - name: Upload artifact

--- a/.github/workflows/diffenator.yaml
+++ b/.github/workflows/diffenator.yaml
@@ -54,7 +54,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: .github/workflows/python-version.txt
-        cache: pip
     - name: Set up uv and enable caching
       uses: astral-sh/setup-uv@v6
       with:

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version-file: ./main/.github/workflows/python-version.txt
-          cache: pip
       - name: Convert Glyphs package sources to UFO
         id: glyphspackage2ufo
         uses: ./main/.github/actions/glyphspackage2ufo
@@ -64,7 +63,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version-file: ./.github/workflows/python-version.txt
-          cache: pip
       - name: Build fonts
         id: build-ufos
         uses: ./.github/actions/build-ufos-py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ./.github/workflows/python-version.txt
-        cache: pip
     - name: Build font
       id: build-ufos
       uses: ./.github/actions/build-ufos-py
@@ -88,7 +87,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ./.github/workflows/python-version.txt
-        cache: pip
     - name: Download workspace and tv fonts
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ./.github/workflows/python-version.txt
+    - name: Set up uv and enable caching
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          requirements*.txt
+          requirements*.in
     - name: Download workspace and tv fonts
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ./.github/workflows/python-version.txt
-        cache: pip
+    - name: Set up uv and enable caching
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          requirements*.txt
+          requirements*.in
     - name: Cut workspace fonts
       id: cut-workspace-fonts
       uses: ./.github/actions/cut-workspace-fonts

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -55,6 +55,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ./.github/workflows/python-version.txt
+    - name: Set up uv and enable caching
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          requirements*.txt
+          requirements*.in
     - name: Download workspace and tv fonts
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/test-workspace.yml
+++ b/.github/workflows/test-workspace.yml
@@ -15,7 +15,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ./.github/workflows/python-version.txt
-        cache: pip
     - name: Build font
       id: build-ufos
       uses: ./.github/actions/build-ufos-py
@@ -35,7 +34,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ./.github/workflows/python-version.txt
-        cache: pip
     - name: Cut workspace fonts
       id: cut-workspace-fonts
       uses: ./.github/actions/cut-workspace-fonts
@@ -57,7 +55,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: ./.github/workflows/python-version.txt
-        cache: pip
     - name: Download workspace and tv fonts
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,13 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.branch }}
+    - name: Set up uv and enable caching
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          requirements*.txt
+          requirements*.in
     - name: Download sources from artifact
       if: ${{ inputs.artifact-as-branch != '' }}
       uses: actions/download-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,13 +25,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.branch }}
-    - name: Set up uv and enable caching
-      uses: astral-sh/setup-uv@v6
-      with:
-        enable-cache: true
-        cache-dependency-glob: |
-          requirements*.txt
-          requirements*.in
     - name: Download sources from artifact
       if: ${{ inputs.artifact-as-branch != '' }}
       uses: actions/download-artifact@v4
@@ -45,7 +38,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version-file: .github/workflows/python-version.txt
-        cache: pip
+    - name: Set up uv and enable caching
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          requirements*.txt
+          requirements*.in
     - name: Download built fonts
       uses: actions/download-artifact@v4
       with:
@@ -54,8 +53,6 @@ jobs:
     - name: Avoid re-building fonts
       shell: bash
       run: |
-        python -m venv venv
-        touch venv/touchfile
         if [ -d "fonts/variable" ]; then
           # Trick make into not re-building the fonts
           touch build.stamp

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+export UV_PYTHON=$(shell cat .github/workflows/python-version.txt)
+UV_RUN=uv run --with-requirements requirements.txt
+
 SOURCES=$(shell python3 scripts/read-config.py --sources )
 FAMILY=$(shell python3 scripts/read-config.py --family )
 DRAWBOT_SCRIPTS=$(shell ls documentation/*.py)
@@ -16,27 +19,15 @@ help:
 
 build: build.stamp
 
-venv: venv/touchfile
-
-build.stamp: venv sources/config.yaml $(SOURCES)
+build.stamp: requirements.txt sources/config.yaml $(SOURCES)
 	rm -rf fonts/
-	. venv/bin/activate \
-		&& gftools builder sources/config.yaml
+	$(UV_RUN) gftools builder sources/config.yaml
 # Font-v cannot deal with worktrees, which we use for imports. See
 # https://github.com/source-foundry/font-v/issues/169. Just skip it.
-	if [ -z "${SKIP_FONTV}" ]; then venv/bin/font-v write --sha1 fonts/variable/*.ttf; fi
-	venv/bin/python scripts/prune_font_binary.py fonts/variable/*.ttf
-	venv/bin/python scripts/set-overlap-bits.py sources/glyphs-with-overlap.txt sources/GoogleSansFlex.designspace fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+	if [ -z "${SKIP_FONTV}" ]; then $(UV_RUN) font-v write --sha1 fonts/variable/*.ttf; fi
+	$(UV_RUN) scripts/prune_font_binary.py fonts/variable/*.ttf
+	$(UV_RUN) scripts/set-overlap-bits.py sources/glyphs-with-overlap.txt sources/GoogleSansFlex.designspace fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
 	touch build.stamp
-
-venv/touchfile: requirements.txt
-	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::group::Set up venv"
-	test -d venv || python3 -m venv venv
-	. venv/bin/activate \
-		&& pip install -U wheel pip \
-		&& pip install --no-deps -r requirements.txt
-	touch venv/touchfile
-	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::endgroup::"
 
 test: build.stamp
 	@scripts/fontbakery.sh
@@ -44,96 +35,85 @@ test: build.stamp
 android: build.stamp
 	mkdir -p fonts/android
 	-@rm fonts/android/*.ttf
-	venv/bin/python scripts/set_ymin_ymax.py \
+	$(UV_RUN) scripts/set_ymin_ymax.py \
 		--ymin -605 --ymax 2007 \
 		fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf \
 		--output fonts/android/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
-	venv/bin/python scripts/prune_hvar.py \
+	$(UV_RUN) scripts/prune_hvar.py \
 		fonts/android/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
 
 workspace: build.stamp
 	-@rm fonts/workspace/*.ttf
 	-@rm fonts/tv/*.ttf
-	. venv/bin/activate && python scripts/cut_instances.py \
+	$(UV_RUN) scripts/cut_instances.py \
 		fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf \
 		fonts/workspace
 	mkdir -p fonts/tv
 	mv fonts/workspace/GoogleSansFlexTV[wght].ttf fonts/tv
-	. venv/bin/activate && pyftsubset fonts/tv/GoogleSansFlexTV[wght].ttf --output-file=fonts/tv/GoogleSansFlexTV[wght].ttf --unicodes="U+D-25CC,U+FB00-1D61E" --layout-features="tnum,numr,subs,sups,frac,ordn,dnom,zero,kern,locl,mark,mkmk,ccmp,liga" --recalc-average-width --recalc-max-context --recalc-bounds --notdef-outline
+	$(UV_RUN) pyftsubset fonts/tv/GoogleSansFlexTV[wght].ttf --output-file=fonts/tv/GoogleSansFlexTV[wght].ttf --unicodes="U+D-25CC,U+FB00-1D61E" --layout-features="tnum,numr,subs,sups,frac,ordn,dnom,zero,kern,locl,mark,mkmk,ccmp,liga" --recalc-average-width --recalc-max-context --recalc-bounds --notdef-outline
 
 release: android workspace
 
+COLLIDOSCOPE_OPTS = fontbakery \
+	check-googlefonts -l WARN --auto-jobs --succinct \
+	--html out/fontbakery/fontbakery-collidoscope-report.html \
+	--configuration qa/fontbakery.config \
+	-c shaping/collides \
+	fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+
 run-collidoscope: build.stamp
-# Install latest version of fontbakery on every run, isolated from build dependencies
-	test -d venv_bakery || python3 -m venv venv_bakery
-	venv_bakery/bin/pip install -U setuptools wheel pip
-	if [ -e "requirements-fb.txt" ]; then \
-		venv_bakery/bin/pip install -r requirements-fb.txt; \
+	mkdir -p out/fontbakery
+	if [ -e requirements-fb.txt ]; then \
+		uvx --with-requirements requirements-fb.txt $(COLLIDOSCOPE_OPTS); \
 	else \
-		venv_bakery/bin/pip install -U fontbakery[googlefonts] fonttools[interpolatable]; \
+		uvx --with fontbakery[googlefonts] --with fonttools[interpolatable] $(COLLIDOSCOPE_OPTS); \
 	fi
 
-# Run collidoscope tests
-	mkdir -p out/fontbakery
-	-venv_bakery/bin/fontbakery check-shaping -l WARN --auto-jobs --succinct --html out/fontbakery/fontbakery-collidoscope-report.html \
-		--configuration qa/fontbakery.config \
-		-c collides \
-		 fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
-
-images: venv build.stamp $(DRAWBOT_OUTPUT)
+images: build.stamp $(DRAWBOT_OUTPUT)
 	git add documentation/*.png && git commit -m "Rebuild images" documentation/*.png
 
 %.png: %.py build.stamp
-	python3 $< --output $@
+	$(UV_RUN) python $< --output $@
 
 clean:
-	rm -rf venv
+	rm -rf .venv
 	find . -name "*.pyc" | xargs rm delete
 
 update-project-template:
 	npx update-template https://github.com/googlefonts/googlefonts-project-template/
 
-update-glyphset-expectations: venv
-	. venv/bin/activate && python scripts/gs-update-glyphset-qa-files.py
+update-glyphset-expectations:
+	$(UV_RUN) scripts/gs-update-glyphset-qa-files.py
 
-update-shaping-expectations: venv
-	. venv/bin/activate && bash -c "cd qa && bash update_all_shaping.sh"
+update-shaping-expectations:
+	$(UV_RUN) bash -c "cd qa && bash update_all_shaping.sh"
 
-update: venv
-	. venv/bin/activate && \
-		pip install --upgrade pip-tools && \
-		pip-compile --resolver=backtracking --upgrade --allow-unsafe requirements.in
+update:
+	uv pip compile --universal requirements.in > requirements.txt
 
-font-size: venv build
-	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::group::Install font-size"
-	venv/bin/pip install -U font-size
-	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::endgroup::"
+font-size: build
 	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::group::TTF size report, by table"
-	find fonts -name '*.ttf' -type f | xargs venv/bin/font-size
+	find fonts -name '*.ttf' -type f | xargs uvx font-size
 	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::endgroup::"
 	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::group::'gvar' size report, by glyph"
-# This script uses the version of rich installed by font-size
-	venv/bin/python scripts/gvar_by_glyph.py fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+	uv run --with fonttools --with rich scripts/gvar_by_glyph.py fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
 	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::endgroup::"
 
-progress-chart: venv
-	. venv/bin/activate && python scripts/gs-progress-burndown.py
+progress-chart:
+	$(UV_RUN) scripts/gs-progress-burndown.py
 
-bump-to-tag: venv
-	. venv/bin/activate && python3 scripts/bump-to-tag.py
+bump-to-tag:
+	$(UV_RUN) scripts/bump-to-tag.py
 
-glyph-hunt: venv
-	. venv/bin/activate && python scripts/glyph-hunt.py --glyph-list .github/actions/import/glyph-list.txt --ds sources/regular/GoogleSansFlex.designspace
+glyph-hunt:
+	$(UV_RUN) scripts/glyph-hunt.py --glyph-list .github/actions/import/glyph-list.txt --ds sources/regular/GoogleSansFlex.designspace
 
-shaperglot: venv build
-	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::group::Install shaperglot"
-	venv/bin/pip install -U "shaperglot>=0.5.1"
-	-@[ -n "${GITHUB_RUN_ID}" ] && echo "::endgroup::"
+shaperglot: build
 	mkdir -p out
 # Report coverage of all languages
-	venv/bin/shaperglot report --group fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+	uvx shaperglot report --group fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
 	@echo "\nChecking against the target language list"
 # Report coverage of target languages
-	@xargs venv/bin/shaperglot check fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf < qa/target_langs.txt
+	@xargs uvx shaperglot check fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf < qa/target_langs.txt
 
 .PHONY: release

--- a/scripts/fontbakery.sh
+++ b/scripts/fontbakery.sh
@@ -37,21 +37,17 @@ if [ -n "$GITHUB_RUN_ID" ] && [[ -f /etc/os-release ]]; then
     fi
 fi
 
-# Setup venv with dependencies
-[ -n "$GITHUB_RUN_ID" ] && echo "::group::Set up venv"
-test -d venv_bakery || python3 -m venv venv_bakery
-venv_bakery/bin/pip install -U setuptools wheel pip
 # Install fontbakery on every run, isolated from build dependencies
 if [ -e "requirements-fb.txt" ]; then
     echo "Using requirements-fb.txt"
-    venv_bakery/bin/pip install -r requirements-fb.txt
+    FONTBAKERY="uvx --with-requirements requirements-fb.txt fontbakery"
 else
     echo "Not pinning fontbakery"
     # fonttools[interpolatable] makes
     # 'interpolation_issues' check around 5x faster
-    venv_bakery/bin/pip install -U "fontbakery[googlefonts]" "fonttools[interpolatable]"
+    FONTBAKERY="uvx --with fontbakery[googlefonts] --with fonttools[interpolatable] fontbakery"
 fi
-[ -n "$GITHUB_RUN_ID" ] && echo "::endgroup::"
+
 mkdir -p out/fontbakery
 
 # All checks invocations are chained into `|| failed+=("test name")` so that:
@@ -62,7 +58,7 @@ failed=()
 
 # Source checks
 if [ -z "$SKIP_SOURCES" ]; then
-    find sources/ -name "*.ufo" -print0 | xargs -0 venv_bakery/bin/fontbakery \
+    find sources/ -name "*.ufo" -print0 | xargs -0 $FONTBAKERY \
         check-profile -l WARN --auto-jobs --succinct --no-progress \
         --html out/fontbakery/fontbakery-sources-report.html \
         qa/check-sources.py \
@@ -72,31 +68,31 @@ fi
 
 # Compiled font tests
 echo "$all_ttfs" \
-    | xargs venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
+    | xargs $FONTBAKERY check-profile -l WARN --auto-jobs --succinct --no-progress \
     --html out/fontbakery/fontbakery-outlines-report.html \
     qa/check-outlines.py {} \
     || failed+=("fontbakery.profiles.outline")
 
 echo "$all_ttfs" \
-    | xargs venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
+    | xargs $FONTBAKERY check-profile -l WARN --auto-jobs --succinct --no-progress \
     --html out/fontbakery/fontbakery-googlesans-report.html \
     qa/check-googlesans.py {} \
     || failed+=("check-googlesans")
 
 echo "$all_ttfs" \
-    | xargs venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
+    | xargs $FONTBAKERY check-profile -l WARN --auto-jobs --succinct --no-progress \
     --html out/fontbakery/fontbakery-fea-report.html \
     qa/check-fea.py {} \
     || failed+=("check-fea")
 
 echo "$all_ttfs" \
-    | xargs venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
+    | xargs $FONTBAKERY check-profile -l WARN --auto-jobs --succinct --no-progress \
     --html out/fontbakery/fontbakery-charset-report.html \
 	qa/check-charset.py {} \
     || failed+=("check-charset")
 
 echo "$all_ttfs" \
-    | xargs venv_bakery/bin/fontbakery check-profile -l WARN --auto-jobs --succinct --no-progress \
+    | xargs $FONTBAKERY check-profile -l WARN --auto-jobs --succinct --no-progress \
     --html out/fontbakery/fontbakery-shaping-report.html \
     qa/check-shaping.py {} \
     || failed+=("check-shaping")


### PR DESCRIPTION
Note that there could be one more simplification, namely using a pyproject.toml and a .python-version with a uv.lock file. This would allow us to drop various arguments to uv in the Makefile. Maybe best done when all dependencies are updated, so as to not change too much now.