### PR TITLE
Add BASE table to feature code (produced by `autobase`)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: googlefonts-8cores-32GB
+    runs-on: googlefonts-64cores-256GB
     timeout-minutes: 15
     steps:
     # on: pull_request uses head_ref for branch name, on: push uses ref_name

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,6 @@ shaperglot: build
 
 autobase: build
 	cargo binstall --no-confirm autobase-cli || cargo install --locked autobase-cli
-	autobase --min-max --config sources/autobase.toml --words 1000000 --fea fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+	autobase --min-max --config sources/autobase.toml --words 1000000 fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
 
 .PHONY: release autobase

--- a/Makefile
+++ b/Makefile
@@ -116,4 +116,8 @@ shaperglot: build
 # Report coverage of target languages
 	@xargs uvx shaperglot check fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf < qa/target_langs.txt
 
-.PHONY: release
+autobase: build
+	cargo binstall --no-confirm autobase-cli || cargo install --locked autobase-cli
+	autobase --min-max --config sources/autobase.toml --words 1000000 --fea fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf
+
+.PHONY: release autobase

--- a/qa/check-googlesans.py
+++ b/qa/check-googlesans.py
@@ -28,6 +28,7 @@ PROFILE = {
             "googlesansflex/android_ymin_ymax",
             "googlesansflex/android_hvar",
             "googlesansflex/varfont/has_HVAR",
+            "googlesansflex/opentype/BASE",
         ],
         "Fontbakery checks": [
             "ots",

--- a/qa/checks/googlesans.py
+++ b/qa/checks/googlesans.py
@@ -420,3 +420,12 @@ def com_google_fonts_check_android_hvar(font: Font, ttFont: TTFont):
 
     if "HVAR" in ttFont:
         yield FAIL, f"{font_path} contains an `HVAR` table, but should not"
+
+
+@check(id="googlesansflex/opentype/BASE", rationale="Checks that the font has a BASE table")
+def com_google_fonts_check_googlesansflex_has_base_table(ttFont: TTFont):
+    """BASE table is present as expected."""
+    if "BASE" in ttFont:
+        yield PASS, "BASE table present in font"
+    else:
+        yield FAIL, "Missing BASE table"

--- a/requirements.in
+++ b/requirements.in
@@ -16,4 +16,4 @@ glyphslib>=6.7.1
 # v4.57.0 adds support for BASE table feature code
 fonttools>=4.57.0
 
-fontc>=0.3.2
+fontc>=0.5.0

--- a/requirements.in
+++ b/requirements.in
@@ -10,9 +10,10 @@ font-v
 # https://github.com/googlefonts/glyphsLib/pull/985
 glyphslib>=6.7.1
 
-# Includes a bugfix that is mandatory to build the workspace fonts correctly.
+# v4.54.0 includes a bugfix that is mandatory to build the workspace fonts correctly.
 # https://github.com/googlefonts/googlesans-flex/issues/1034
 # https://github.com/fonttools/fonttools/pull/3635
-fonttools>=4.54.0
+# v4.57.0 adds support for BASE table feature code
+fonttools>=4.57.0
 
 fontc>=0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ font-v==2.1.0
     # via
     #   -r requirements.in
     #   gftools
-fontc==0.3.2
+fontc==0.5.0
     # via -r requirements.in
 fontfeatures==1.9.0
     # via gftools

--- a/scripts/prune_font_binary.py
+++ b/scripts/prune_font_binary.py
@@ -49,6 +49,8 @@ def main(args: Optional[List[str]] = None):
             "--no-prune-unicode-ranges",
             "--recalc-bounds",
             "--recalc-average-width",
+            "--drop-tables-=BASE",
+            "--no-subset-tables+=BASE",
             f"--output-file={local_filepath_subset}",
         ]
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg1000-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd100-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd151-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz144-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz18-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD0-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD0-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl-10.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,9 +71,7 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 
 

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -364,3 +364,13 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
+
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -65,6 +65,18 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 
 
+# Prefix: BASE
+table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+
+
 feature aalt {
 feature locl;
 feature dnom;
@@ -364,13 +376,3 @@ sub t f by t_f;
 sub t t by t_t;
 
 } dlig;
-
-table BASE {
-    HorizAxis.BaseTagList romn;
-    HorizAxis.BaseScriptList
-        grek romn 0,
-        latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
-    HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
-} BASE;

--- a/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
+++ b/sources/GoogleSansFlex-wg400-wd25-oz6-GD100-RD100-sl0.ufo/features.fea
@@ -71,7 +71,8 @@ table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 
 

--- a/sources/autobase.toml
+++ b/sources/autobase.toml
@@ -1,0 +1,5 @@
+languages = [
+    "vi_Latn",
+]
+
+[override]

--- a/sources/autobase.toml
+++ b/sources/autobase.toml
@@ -1,5 +1,8 @@
 languages = [
     "vi_Latn",
 ]
+exclusions = [
+    "Ǻ",
+]
 
 [override]

--- a/sources/design-source/GSF-full.glyphspackage/fontinfo.plist
+++ b/sources/design-source/GSF-full.glyphspackage/fontinfo.plist
@@ -722,9 +722,7 @@ code = "table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax grek dflt -466, 1110;
     HorizAxis.MinMax latn dflt -778, 2699;
-    HorizAxis.MinMax latn VIT  -618, 2391;
 } BASE;
 ";
 name = BASE;

--- a/sources/design-source/GSF-full.glyphspackage/fontinfo.plist
+++ b/sources/design-source/GSF-full.glyphspackage/fontinfo.plist
@@ -715,6 +715,19 @@ lookup ccmp_soft_dotted {
 } ccmp_soft_dotted;
 ";
 name = Prefix;
+},
+{
+code = "table BASE {
+    HorizAxis.BaseTagList romn;
+    HorizAxis.BaseScriptList
+        grek romn 0,
+        latn romn 0;
+    HorizAxis.MinMax grek dflt -466, 1110;
+    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn VIT  -618, 2391;
+} BASE;
+";
+name = BASE;
 }
 );
 features = (

--- a/sources/design-source/GSF-full.glyphspackage/fontinfo.plist
+++ b/sources/design-source/GSF-full.glyphspackage/fontinfo.plist
@@ -722,7 +722,8 @@ code = "table BASE {
     HorizAxis.BaseScriptList
         grek romn 0,
         latn romn 0;
-    HorizAxis.MinMax latn dflt -778, 2699;
+    HorizAxis.MinMax latn dflt -778, 2154;
+    HorizAxis.MinMax latn VIT  -778, 2391;
 } BASE;
 ";
 name = BASE;


### PR DESCRIPTION
- Update requirements.txt so `fontTools` supports the BASE table
- Add autobase config file and plumb into Makefile
- Add fea code produced by autobase (edited, as currently it's not completely valid/complete, but the important metrics are there)
- Stop the subsetter from dropping the BASE table (upstream solution also being considered: https://github.com/fonttools/fonttools/pull/1866)

TODO:
- [x] Add to Glyphs sources
- [x] CI check for presence of BASE