### PR TITLE
Try and reduce dependencies a bit

### DIFF
--- a/documentation/image1.py
+++ b/documentation/image1.py
@@ -28,7 +28,7 @@ import argparse
 
 # Constants, these are the main "settings" for the image
 WIDTH, HEIGHT, MARGIN, FRAMES = 2048, 2048, 128, 1
-FONT_PATH = "fonts/variable/GSFWDTH[wdth,wght].ttf"
+FONT_PATH = "fonts/variable/GoogleSansFlex[GRAD,ROND,opsz,slnt,wdth,wght].ttf"
 FONT_LICENSE = "OFL v1.1"
 AUXILIARY_FONT = "Helvetica"
 AUXILIARY_FONT_SIZE = 48

--- a/requirements-fb.in
+++ b/requirements-fb.in
@@ -4,5 +4,6 @@
 # To unpin, delete requirements-fb.txt and get rid of any extra constraints
 # added here
 
-fontbakery[googlefonts]>=0.13.0
-fonttools[interpolatable]
+fontbakery>=0.13.0
+ufoLib2
+glyphsLib

--- a/scripts/fontbakery.sh
+++ b/scripts/fontbakery.sh
@@ -43,9 +43,7 @@ if [ -e "requirements-fb.txt" ]; then
     FONTBAKERY="uvx --with-requirements requirements-fb.txt fontbakery"
 else
     echo "Not pinning fontbakery"
-    # fonttools[interpolatable] makes
-    # 'interpolation_issues' check around 5x faster
-    FONTBAKERY="uvx --with fontbakery[googlefonts] --with fonttools[interpolatable] fontbakery"
+    FONTBAKERY="uvx --with-requirements requirements-fb.in fontbakery"
 fi
 
 mkdir -p out/fontbakery


### PR DESCRIPTION
In light of recent npm supply chain attacks, we want to see if we can reduce our attack surface by dropping dependencies we don't strictly need. As discussed in the [weekly meeting on Sept 29](https://docs.google.com/document/d/1nC4XIB-gX6sbDW33qWpJux-qzhf_wnj-_EbeaOTW_C0/edit?tab=t.0#heading=h.wvmarwn5dtlr).

* We no longer need fontbakery's `googlefonts` extra, because the Google Fonts checks are done by fontspector. This drops 30 dependencies during testing.
* There is a dependency on `sh` that seems unused, but if we want to move closer to the official Google Fonts template, we may not want to touch it for now. It brings in no other dependency, so it's not a juicy target.
* Other depdendencies cannot just be dropped. The biggest contributor to dependencies is gftools.