### PR TITLE
For b/422910732, we're using this commit to tag a v2.007 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,22 @@
 # Google Sans Flex Changelog
 
-## Version 3.006 (2028-08=25)
+## Version 2.007 (2025-09-30)
+## Changed
+- removed HVAR table by hotfixing the Android v2.006 TTF 
+
+## Version 3.006 (2025-08-25)
 ### Changed
 - added currency signs: ₹ ₩ ฿ (#1164)
 - added script to find where glyphs accidentally vary width across duplex axes ([#1180](https://github.com/googlefonts/googlesans-flex/pull/1180))
 
 
-## Version 3.005 (2028-08-19)
+## Version 3.005 (2025-08-19)
 ### Changed
 - added GSF TV font slice (#1176)
 - added U+207B and U+02E3 (#1165)
 - removed HVAR table from Android release
 
-## Version 3.004 (2025-04-9)
+## Version 3.004 (2025-04-09)
 ### Changed
 - updated workspace font families (upright + italic):
   - added back and changed opsz from 12 to 14:

--- a/scripts/one-off/android_hvar_hotfix.py
+++ b/scripts/one-off/android_hvar_hotfix.py
@@ -1,0 +1,73 @@
+# Copyright 2025 Google Sans Flex Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This script modifes the v2.006 Android release to produce a new v2.007
+Android release that:
+
+- Has an updated version number
+- Omits `HVAR`
+- Unsets `USE_MY_METRICS` everywhere in the `glyf` table to avoid a dormant
+  compiler bug that becomes tangible when `HVAR` is removed
+  - See https://github.com/fonttools/fonttools/issues/3905
+"""
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.tables._g_l_y_f import USE_MY_METRICS
+
+
+def hotfix(ttf: TTFont, commit: str) -> None:
+    # Preserve hardcoded Android metrics
+    ttf.recalcBBoxes = False
+
+    # Delete the `HVAR` table
+    del ttf["HVAR"]
+
+    # Unset `USE_MY_METRICS` everywhere
+    for glyph in ttf["glyf"].glyphs.values():
+        glyph.expand(ttf["glyf"])  # decompile fully
+
+        if not glyph.isComposite():
+            continue
+
+        for component in glyph.components:
+            component.flags &= ~USE_MY_METRICS  # unset
+
+    # Update the version number.
+    ttf["head"].fontRevision = 2.007
+
+    # Update the version number in the `name` records.
+    for record in ttf["name"].names:
+        if record.nameID == 5:
+            record.string = f"Version 2.007;[{commit[:9]}]"
+        else:
+            record.string = record.toStr().replace("2.006", "2.007")
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("before", type=Path)
+    parser.add_argument("after", type=Path)
+    parser.add_argument("commit")
+    args = parser.parse_args()
+
+    ttf = TTFont(args.before)
+    hotfix(ttf, args.commit)
+    ttf.save(args.after)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We will attach just the Android TTF file, made by hotfixing the v2.006 Android TTF as follows:

```bash
python scripts/one-off/android_hvar_hotfix.py \
  before/GoogleSansFlex\[GRAD\,ROND\,opsz\,slnt\,wdth\,wght\].ttf \
  after/GoogleSansFlex\[GRAD\,ROND\,opsz\,slnt\,wdth\,wght\].ttf \
  49106e8594b810461688eb1dd3b2defb2f36420e
```


---

cc @davelab6 reviving this here; we've now amended your commit to use a script to avoid ttx updating the hardcoded vertical metrics required for Android, and to unset the unwanted `USE_MY_METRICS` everywhere -- otherwise, the process is the same :)